### PR TITLE
Introduce first-class CORS filter 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,7 @@ dependencies = [
  "config",
  "envoy-types",
  "futures",
+ "http 1.3.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ openapiv3 = "1.0"
 bytes = "1.6"
 mime = "0.3"
 hyper = "1.3"
+http = "1.1"
 http-body-util = "0.1"
 
 # Storage and persistence

--- a/specs/003-cors-http-filter/contracts/cors-api.yaml
+++ b/specs/003-cors-http-filter/contracts/cors-api.yaml
@@ -1,0 +1,398 @@
+openapi: 3.0.3
+info:
+  title: Flowplane CORS Filter API
+  description: API for configuring CORS (Cross-Origin Resource Sharing) HTTP filters
+  version: 1.0.0
+
+paths:
+  /listeners/{listener_name}/filters/cors:
+    put:
+      summary: Configure CORS filter for listener
+      description: Set or update CORS policy at listener level
+      parameters:
+        - name: listener_name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Name of the listener to configure
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CorsConfig'
+            examples:
+              basic_cors:
+                summary: Basic CORS configuration
+                value:
+                  allow_origins:
+                    - match_type: "exact"
+                      pattern: "https://app.example.com"
+                      case_sensitive: true
+                  allow_methods: ["GET", "POST", "PUT", "DELETE"]
+                  allow_headers: ["content-type", "authorization"]
+                  expose_headers: ["x-custom-header"]
+                  allow_credentials: false
+                  max_age: 86400
+              wildcard_subdomain:
+                summary: Subdomain wildcard pattern
+                value:
+                  allow_origins:
+                    - match_type: "safe_regex"
+                      pattern: "https://[a-z0-9-]+\\.example\\.com"
+                      case_sensitive: true
+                  allow_methods: ["GET", "POST"]
+                  allow_headers: ["content-type"]
+                  allow_credentials: false
+                  max_age: 3600
+      responses:
+        '200':
+          description: CORS filter configured successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FilterConfigResponse'
+        '400':
+          description: Invalid configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        '404':
+          description: Listener not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    get:
+      summary: Get CORS filter configuration
+      description: Retrieve current CORS policy for listener
+      parameters:
+        - name: listener_name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Name of the listener
+      responses:
+        '200':
+          description: Current CORS configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CorsConfig'
+        '404':
+          description: Listener or CORS filter not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    delete:
+      summary: Remove CORS filter
+      description: Remove CORS filter from listener
+      parameters:
+        - name: listener_name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Name of the listener
+      responses:
+        '204':
+          description: CORS filter removed successfully
+        '404':
+          description: Listener or CORS filter not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /routes/{route_name}/filters/cors:
+    put:
+      summary: Configure per-route CORS override
+      description: Set route-specific CORS policy that overrides listener configuration
+      parameters:
+        - name: route_name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Name of the route to configure
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CorsPerRouteConfig'
+            examples:
+              route_override:
+                summary: Route-specific CORS policy
+                value:
+                  enabled: true
+                  inherit_from_listener: false
+                  cors_policy:
+                    allow_origins:
+                      - match_type: "exact"
+                        pattern: "https://admin.example.com"
+                        case_sensitive: true
+                    allow_methods: ["GET", "POST", "DELETE"]
+                    allow_headers: ["content-type", "authorization", "x-admin-token"]
+                    allow_credentials: true
+                    max_age: 600
+              route_disabled:
+                summary: Disable CORS for specific route
+                value:
+                  enabled: false
+                  inherit_from_listener: false
+      responses:
+        '200':
+          description: Route CORS configuration updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FilterConfigResponse'
+        '400':
+          description: Invalid configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        '404':
+          description: Route not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    get:
+      summary: Get route CORS configuration
+      description: Retrieve current per-route CORS policy
+      parameters:
+        - name: route_name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Name of the route
+      responses:
+        '200':
+          description: Current route CORS configuration
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CorsPerRouteConfig'
+        '404':
+          description: Route or CORS configuration not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    delete:
+      summary: Remove route CORS override
+      description: Remove route-specific CORS configuration, falling back to listener policy
+      parameters:
+        - name: route_name
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Name of the route
+      responses:
+        '204':
+          description: Route CORS override removed
+        '404':
+          description: Route not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+components:
+  schemas:
+    CorsConfig:
+      type: object
+      required:
+        - allow_origins
+      properties:
+        allow_origins:
+          type: array
+          items:
+            $ref: '#/components/schemas/OriginPattern'
+          minItems: 1
+          description: List of allowed origin patterns
+        allow_methods:
+          type: array
+          items:
+            $ref: '#/components/schemas/HttpMethod'
+          default: ["GET", "POST"]
+          description: Permitted HTTP methods
+        allow_headers:
+          type: array
+          items:
+            type: string
+          default: ["content-type", "authorization"]
+          description: Allowed request headers
+        expose_headers:
+          type: array
+          items:
+            type: string
+          default: []
+          description: Headers exposed to client
+        allow_credentials:
+          type: boolean
+          default: false
+          description: Whether credentials are supported
+        max_age:
+          type: integer
+          minimum: 0
+          maximum: 315576000000
+          default: 86400
+          description: Preflight cache duration in seconds
+      example:
+        allow_origins:
+          - match_type: "exact"
+            pattern: "https://app.example.com"
+            case_sensitive: true
+        allow_methods: ["GET", "POST", "PUT"]
+        allow_headers: ["content-type", "authorization"]
+        expose_headers: ["x-request-id"]
+        allow_credentials: false
+        max_age: 86400
+
+    CorsPerRouteConfig:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          default: true
+          description: Whether CORS is enabled for this route
+        inherit_from_listener:
+          type: boolean
+          default: true
+          description: Use listener policy with route modifications
+        cors_policy:
+          $ref: '#/components/schemas/CorsConfig'
+          description: Route-specific policy override
+      example:
+        enabled: true
+        inherit_from_listener: false
+        cors_policy:
+          allow_origins:
+            - match_type: "exact"
+              pattern: "https://admin.example.com"
+              case_sensitive: true
+          allow_methods: ["GET", "POST"]
+          allow_credentials: true
+
+    OriginPattern:
+      type: object
+      required:
+        - match_type
+        - pattern
+      properties:
+        match_type:
+          $ref: '#/components/schemas/OriginMatchType'
+        pattern:
+          type: string
+          minLength: 1
+          description: The pattern string
+        case_sensitive:
+          type: boolean
+          default: true
+          description: Whether matching is case sensitive
+      example:
+        match_type: "exact"
+        pattern: "https://app.example.com"
+        case_sensitive: true
+
+    OriginMatchType:
+      type: string
+      enum:
+        - exact
+        - prefix
+        - suffix
+        - safe_regex
+      description: Type of origin pattern matching
+
+    HttpMethod:
+      type: string
+      enum:
+        - GET
+        - POST
+        - PUT
+        - DELETE
+        - HEAD
+        - OPTIONS
+        - PATCH
+        - TRACE
+      description: HTTP method for CORS
+
+    FilterConfigResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          description: Success message
+        filter_name:
+          type: string
+          description: Name of the configured filter
+        config_checksum:
+          type: string
+          description: Checksum of the applied configuration
+      example:
+        message: "CORS filter configured successfully"
+        filter_name: "envoy.filters.http.cors"
+        config_checksum: "sha256:abc123..."
+
+    ValidationError:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error message
+        validation_errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/FieldError'
+          description: Field-specific validation errors
+      example:
+        error: "Configuration validation failed"
+        validation_errors:
+          - field: "allow_origins"
+            message: "Cannot be empty"
+          - field: "max_age"
+            message: "Exceeds maximum allowed value"
+
+    FieldError:
+      type: object
+      properties:
+        field:
+          type: string
+          description: Name of the invalid field
+        message:
+          type: string
+          description: Validation error message
+        code:
+          type: string
+          description: Error code for programmatic handling
+      example:
+        field: "allow_origins"
+        message: "Cannot be empty"
+        code: "REQUIRED_FIELD_EMPTY"
+
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error message
+        code:
+          type: string
+          description: Error code
+      example:
+        error: "Listener not found"
+        code: "LISTENER_NOT_FOUND"

--- a/specs/003-cors-http-filter/contracts/cors_contract_tests.rs
+++ b/specs/003-cors-http-filter/contracts/cors_contract_tests.rs
@@ -1,0 +1,471 @@
+// Contract tests for CORS HTTP Filter API
+// These tests validate the API contract and will initially fail until implementation is complete
+
+use serde_json::json;
+use hyper::{StatusCode, Method};
+use crate::test_utils::{TestApiClient, assert_json_schema};
+
+// Helper to create test client - will be implemented with actual API
+async fn cors_test_client() -> TestApiClient {
+    todo!("Initialize test API client with CORS filter support")
+}
+
+#[tokio::test]
+async fn put_listener_cors_config_success() {
+    let client = cors_test_client().await;
+
+    let cors_config = json!({
+        "allow_origins": [
+            {
+                "match_type": "exact",
+                "pattern": "https://app.example.com",
+                "case_sensitive": true
+            }
+        ],
+        "allow_methods": ["GET", "POST", "PUT", "DELETE"],
+        "allow_headers": ["content-type", "authorization"],
+        "expose_headers": ["x-custom-header"],
+        "allow_credentials": false,
+        "max_age": 86400
+    });
+
+    let response = client
+        .request(Method::PUT, "/listeners/test-listener/filters/cors")
+        .json(&cors_config)
+        .send()
+        .await
+        .expect("API request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: serde_json::Value = response.json().await.expect("Parse response JSON");
+    assert_json_schema(&body, &json!({
+        "type": "object",
+        "required": ["message", "filter_name", "config_checksum"],
+        "properties": {
+            "message": {"type": "string"},
+            "filter_name": {"type": "string"},
+            "config_checksum": {"type": "string"}
+        }
+    }));
+    assert_eq!(body["filter_name"], "envoy.filters.http.cors");
+}
+
+#[tokio::test]
+async fn put_listener_cors_config_validation_error() {
+    let client = cors_test_client().await;
+
+    // Invalid config: empty allow_origins
+    let invalid_config = json!({
+        "allow_origins": [],
+        "allow_methods": ["GET"],
+        "allow_credentials": false
+    });
+
+    let response = client
+        .request(Method::PUT, "/listeners/test-listener/filters/cors")
+        .json(&invalid_config)
+        .send()
+        .await
+        .expect("API request failed");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body: serde_json::Value = response.json().await.expect("Parse response JSON");
+    assert_json_schema(&body, &json!({
+        "type": "object",
+        "required": ["error", "validation_errors"],
+        "properties": {
+            "error": {"type": "string"},
+            "validation_errors": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["field", "message"],
+                    "properties": {
+                        "field": {"type": "string"},
+                        "message": {"type": "string"},
+                        "code": {"type": "string"}
+                    }
+                }
+            }
+        }
+    }));
+
+    // Check that validation error mentions allow_origins
+    let validation_errors = body["validation_errors"].as_array().expect("validation_errors array");
+    assert!(validation_errors.iter().any(|error|
+        error["field"].as_str() == Some("allow_origins")
+    ));
+}
+
+#[tokio::test]
+async fn put_listener_cors_config_invalid_max_age() {
+    let client = cors_test_client().await;
+
+    // Invalid config: max_age exceeds protobuf Duration limit
+    let invalid_config = json!({
+        "allow_origins": [
+            {
+                "match_type": "exact",
+                "pattern": "https://example.com",
+                "case_sensitive": true
+            }
+        ],
+        "allow_methods": ["GET"],
+        "max_age": 999999999999u64  // Exceeds 315,576,000,000
+    });
+
+    let response = client
+        .request(Method::PUT, "/listeners/test-listener/filters/cors")
+        .json(&invalid_config)
+        .send()
+        .await
+        .expect("API request failed");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body: serde_json::Value = response.json().await.expect("Parse response JSON");
+    let validation_errors = body["validation_errors"].as_array().expect("validation_errors array");
+    assert!(validation_errors.iter().any(|error|
+        error["field"].as_str() == Some("max_age")
+    ));
+}
+
+#[tokio::test]
+async fn get_listener_cors_config_success() {
+    let client = cors_test_client().await;
+
+    // First set a configuration
+    let cors_config = json!({
+        "allow_origins": [
+            {
+                "match_type": "exact",
+                "pattern": "https://app.example.com",
+                "case_sensitive": true
+            }
+        ],
+        "allow_methods": ["GET", "POST"],
+        "allow_credentials": false
+    });
+
+    client
+        .request(Method::PUT, "/listeners/test-listener/filters/cors")
+        .json(&cors_config)
+        .send()
+        .await
+        .expect("Setup PUT request failed");
+
+    // Now retrieve it
+    let response = client
+        .request(Method::GET, "/listeners/test-listener/filters/cors")
+        .send()
+        .await
+        .expect("GET request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: serde_json::Value = response.json().await.expect("Parse response JSON");
+    assert_eq!(body["allow_methods"], json!(["GET", "POST"]));
+    assert_eq!(body["allow_credentials"], false);
+}
+
+#[tokio::test]
+async fn get_listener_cors_config_not_found() {
+    let client = cors_test_client().await;
+
+    let response = client
+        .request(Method::GET, "/listeners/nonexistent-listener/filters/cors")
+        .send()
+        .await
+        .expect("GET request failed");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let body: serde_json::Value = response.json().await.expect("Parse response JSON");
+    assert_json_schema(&body, &json!({
+        "type": "object",
+        "required": ["error", "code"],
+        "properties": {
+            "error": {"type": "string"},
+            "code": {"type": "string"}
+        }
+    }));
+}
+
+#[tokio::test]
+async fn delete_listener_cors_config_success() {
+    let client = cors_test_client().await;
+
+    // First set a configuration
+    let cors_config = json!({
+        "allow_origins": [
+            {
+                "match_type": "exact",
+                "pattern": "https://app.example.com",
+                "case_sensitive": true
+            }
+        ],
+        "allow_methods": ["GET"]
+    });
+
+    client
+        .request(Method::PUT, "/listeners/test-listener/filters/cors")
+        .json(&cors_config)
+        .send()
+        .await
+        .expect("Setup PUT request failed");
+
+    // Now delete it
+    let response = client
+        .request(Method::DELETE, "/listeners/test-listener/filters/cors")
+        .send()
+        .await
+        .expect("DELETE request failed");
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    // Verify it's actually deleted
+    let get_response = client
+        .request(Method::GET, "/listeners/test-listener/filters/cors")
+        .send()
+        .await
+        .expect("Verification GET request failed");
+
+    assert_eq!(get_response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn put_route_cors_config_success() {
+    let client = cors_test_client().await;
+
+    let route_cors_config = json!({
+        "enabled": true,
+        "inherit_from_listener": false,
+        "cors_policy": {
+            "allow_origins": [
+                {
+                    "match_type": "exact",
+                    "pattern": "https://admin.example.com",
+                    "case_sensitive": true
+                }
+            ],
+            "allow_methods": ["GET", "POST", "DELETE"],
+            "allow_headers": ["content-type", "authorization", "x-admin-token"],
+            "allow_credentials": true,
+            "max_age": 600
+        }
+    });
+
+    let response = client
+        .request(Method::PUT, "/routes/admin-route/filters/cors")
+        .json(&route_cors_config)
+        .send()
+        .await
+        .expect("API request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: serde_json::Value = response.json().await.expect("Parse response JSON");
+    assert_eq!(body["filter_name"], "envoy.filters.http.cors");
+}
+
+#[tokio::test]
+async fn put_route_cors_config_disabled() {
+    let client = cors_test_client().await;
+
+    let disabled_config = json!({
+        "enabled": false,
+        "inherit_from_listener": false
+    });
+
+    let response = client
+        .request(Method::PUT, "/routes/public-route/filters/cors")
+        .json(&disabled_config)
+        .send()
+        .await
+        .expect("API request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn put_route_cors_config_validation_error() {
+    let client = cors_test_client().await;
+
+    // Invalid: enabled but no policy and not inheriting
+    let invalid_config = json!({
+        "enabled": true,
+        "inherit_from_listener": false
+        // Missing cors_policy
+    });
+
+    let response = client
+        .request(Method::PUT, "/routes/test-route/filters/cors")
+        .json(&invalid_config)
+        .send()
+        .await
+        .expect("API request failed");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn get_route_cors_config_success() {
+    let client = cors_test_client().await;
+
+    // Setup route configuration
+    let route_config = json!({
+        "enabled": true,
+        "inherit_from_listener": true
+    });
+
+    client
+        .request(Method::PUT, "/routes/test-route/filters/cors")
+        .json(&route_config)
+        .send()
+        .await
+        .expect("Setup PUT request failed");
+
+    // Retrieve configuration
+    let response = client
+        .request(Method::GET, "/routes/test-route/filters/cors")
+        .send()
+        .await
+        .expect("GET request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: serde_json::Value = response.json().await.expect("Parse response JSON");
+    assert_eq!(body["enabled"], true);
+    assert_eq!(body["inherit_from_listener"], true);
+}
+
+#[tokio::test]
+async fn delete_route_cors_config_success() {
+    let client = cors_test_client().await;
+
+    // Setup route configuration
+    let route_config = json!({
+        "enabled": true,
+        "inherit_from_listener": false,
+        "cors_policy": {
+            "allow_origins": [
+                {
+                    "match_type": "exact",
+                    "pattern": "https://test.example.com",
+                    "case_sensitive": true
+                }
+            ],
+            "allow_methods": ["GET"]
+        }
+    });
+
+    client
+        .request(Method::PUT, "/routes/test-route/filters/cors")
+        .json(&route_config)
+        .send()
+        .await
+        .expect("Setup PUT request failed");
+
+    // Delete configuration
+    let response = client
+        .request(Method::DELETE, "/routes/test-route/filters/cors")
+        .send()
+        .await
+        .expect("DELETE request failed");
+
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn cors_config_with_regex_pattern_success() {
+    let client = cors_test_client().await;
+
+    let regex_config = json!({
+        "allow_origins": [
+            {
+                "match_type": "safe_regex",
+                "pattern": "https://[a-z0-9-]+\\.example\\.com",
+                "case_sensitive": true
+            }
+        ],
+        "allow_methods": ["GET", "POST"],
+        "allow_credentials": false
+    });
+
+    let response = client
+        .request(Method::PUT, "/listeners/test-listener/filters/cors")
+        .json(&regex_config)
+        .send()
+        .await
+        .expect("API request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn cors_config_with_invalid_regex_pattern() {
+    let client = cors_test_client().await;
+
+    let invalid_regex_config = json!({
+        "allow_origins": [
+            {
+                "match_type": "safe_regex",
+                "pattern": "[invalid-regex-*",  // Invalid regex syntax
+                "case_sensitive": true
+            }
+        ],
+        "allow_methods": ["GET"]
+    });
+
+    let response = client
+        .request(Method::PUT, "/listeners/test-listener/filters/cors")
+        .json(&invalid_regex_config)
+        .send()
+        .await
+        .expect("API request failed");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body: serde_json::Value = response.json().await.expect("Parse response JSON");
+    let validation_errors = body["validation_errors"].as_array().expect("validation_errors array");
+    assert!(validation_errors.iter().any(|error|
+        error["field"].as_str().unwrap_or("").contains("allow_origins") &&
+        error["message"].as_str().unwrap_or("").contains("regex")
+    ));
+}
+
+#[tokio::test]
+async fn cors_config_wildcard_with_credentials_rejected() {
+    let client = cors_test_client().await;
+
+    // Security violation: wildcard origin with credentials
+    let unsafe_config = json!({
+        "allow_origins": [
+            {
+                "match_type": "exact",
+                "pattern": "*",
+                "case_sensitive": true
+            }
+        ],
+        "allow_methods": ["GET", "POST"],
+        "allow_credentials": true  // This should be rejected with wildcard
+    });
+
+    let response = client
+        .request(Method::PUT, "/listeners/test-listener/filters/cors")
+        .json(&unsafe_config)
+        .send()
+        .await
+        .expect("API request failed");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body: serde_json::Value = response.json().await.expect("Parse response JSON");
+    let validation_errors = body["validation_errors"].as_array().expect("validation_errors array");
+    assert!(validation_errors.iter().any(|error|
+        error["message"].as_str().unwrap_or("").to_lowercase().contains("wildcard") &&
+        error["message"].as_str().unwrap_or("").to_lowercase().contains("credentials")
+    ));
+}

--- a/specs/003-cors-http-filter/data-model.md
+++ b/specs/003-cors-http-filter/data-model.md
@@ -1,0 +1,184 @@
+# CORS HTTP Filter Data Model
+
+## Core Entities
+
+### CorsConfig
+Primary configuration entity for CORS policies at listener level.
+
+**Fields**:
+- `allow_origins: Vec<OriginPattern>` - List of allowed origin patterns (required)
+- `allow_methods: Vec<HttpMethod>` - Permitted HTTP methods (default: GET, POST)
+- `allow_headers: Vec<String>` - Allowed request headers (default: content-type, authorization)
+- `expose_headers: Vec<String>` - Headers exposed to client (default: empty)
+- `allow_credentials: bool` - Whether credentials are supported (default: false)
+- `max_age: Option<u32>` - Preflight cache duration in seconds (default: 86400)
+
+**Validation Rules**:
+- `allow_origins` must not be empty
+- `max_age` must be ≤ 315,576,000,000 seconds (google.protobuf.Duration limit)
+- Header names must be valid RFC 7230 tokens
+- Methods must be valid HTTP methods
+- Cannot use wildcard origins with `allow_credentials: true`
+
+**State Transitions**: Immutable configuration, replaced atomically during updates
+
+### CorsPerRouteConfig
+Route-specific CORS configuration that overrides listener-level settings.
+
+**Fields**:
+- `enabled: bool` - Whether CORS is enabled for this route (default: true)
+- `cors_policy: Option<CorsConfig>` - Route-specific policy override
+- `inherit_from_listener: bool` - Use listener policy with route modifications (default: true)
+
+**Validation Rules**:
+- If `enabled: false`, other fields ignored
+- If `cors_policy` provided, inherits validation rules from CorsConfig
+- Cannot disable inheritance and provide no policy
+
+**Relationships**:
+- Belongs to Route entity
+- Overrides listener-level CorsConfig when present
+
+### OriginPattern
+Represents allowed origin specification using Envoy's StringMatcher capabilities.
+
+**Fields**:
+- `match_type: OriginMatchType` - Type of origin matching
+- `pattern: String` - The pattern string
+- `case_sensitive: bool` - Whether matching is case sensitive (default: true)
+
+**OriginMatchType enum**:
+- `Exact` - Exact hostname match
+- `Prefix` - Prefix match (e.g., "https://")
+- `Suffix` - Suffix match (e.g., ".example.com")
+- `SafeRegex` - Regular expression using safe regex engine
+
+**Validation Rules**:
+- Pattern cannot be empty after trimming
+- SafeRegex patterns must compile successfully
+- Prefix patterns should include protocol for security
+- Cannot use overly broad patterns in production
+
+### HttpMethod
+Enumeration of supported HTTP methods for CORS.
+
+**Values**:
+- `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, `PATCH`, `TRACE`
+
+**Validation Rules**:
+- Must be recognized HTTP method
+- OPTIONS automatically included for preflight support
+
+### CorsViolationResponse
+Response entity when CORS requirements are not met.
+
+**Fields**:
+- `error_type: CorsErrorType` - Type of CORS violation
+- `message: String` - Human-readable error description
+- `allowed_origins: Vec<String>` - Origins that would be allowed (for debugging)
+
+**CorsErrorType enum**:
+- `OriginNotAllowed` - Origin doesn't match any allowed patterns
+- `MethodNotAllowed` - HTTP method not permitted
+- `HeaderNotAllowed` - Request header not permitted
+- `CredentialsNotSupported` - Credentials sent but not allowed
+- `InvalidPreflightRequest` - Malformed OPTIONS request
+
+### FilterIntegrationContext
+Context for CORS filter integration with other HTTP filters.
+
+**Fields**:
+- `filter_name: String` - Canonical Envoy filter name ("envoy.filters.http.cors")
+- `filter_order: u32` - Position in filter chain
+- `dependencies: Vec<String>` - Required filters to run before CORS
+- `per_route_enabled: bool` - Whether route-specific config is supported
+
+**Relationships**:
+- Part of HttpFilterChain
+- Interacts with Router filter and JWT authentication filter
+
+## Protobuf Mapping
+
+### CorsConfig → envoy.extensions.filters.http.cors.v3.CorsPolicy
+- `allow_origins` → `allow_origin_string_match` (repeated StringMatcher)
+- `allow_methods` → `allow_methods` (string list)
+- `allow_headers` → `allow_headers` (string list)
+- `expose_headers` → `expose_headers` (string list)
+- `allow_credentials` → `allow_credentials` (BoolValue)
+- `max_age` → `max_age` (Duration)
+
+### CorsPerRouteConfig → envoy.extensions.filters.http.cors.v3.CorsPolicy
+Uses same protobuf message as listener config, but applied per-route via `typed_per_filter_config`.
+
+## Error Handling
+
+### Configuration Errors
+- `EmptyOriginList` - No allowed origins specified
+- `InvalidHeaderName` - Header name violates RFC 7230
+- `InvalidMaxAge` - Duration exceeds protobuf limits
+- `UnsafeWildcardWithCredentials` - Security violation
+- `MalformedRegexPattern` - SafeRegex pattern compilation failure
+
+### Runtime Errors
+- `OriginMismatch` - Request origin not in allowed list
+- `MethodNotPermitted` - HTTP method not allowed
+- `PreflightValidationFailure` - OPTIONS request validation failed
+- `CredentialPolicyViolation` - Credentials sent when not allowed
+
+## Integration Points
+
+### API Layer
+- REST endpoints accept CorsConfig JSON
+- Validation occurs at API boundary before persistence
+- OpenAPI schema generation via ToSchema derive
+
+### XDS Layer
+- Converts CorsConfig to Envoy protobuf messages
+- Handles both listener-level and route-level configuration
+- Integrates with existing HTTP filter framework
+
+### Testing Layer
+- Unit tests for entity validation logic
+- Integration tests for protobuf round-trip conversion
+- Property-based tests for pattern matching edge cases
+
+## Performance Considerations
+
+### Memory Usage
+- OriginPattern regex compilation cached at configuration time
+- Route-specific configs use Cow<str> for shared string data
+- Large origin lists use efficient HashSet lookups
+
+### Validation Performance
+- Pre-compile regex patterns during configuration parsing
+- Validate header names against pre-computed valid character sets
+- Cache validation results for repeated configurations
+
+## Security Properties
+
+### Origin Validation
+- Strict pattern matching prevents origin spoofing
+- Case-sensitive matching by default
+- Regex patterns use safe engine to prevent ReDoS attacks
+
+### Credential Handling
+- Explicit opt-in for credential support
+- Prevents wildcard origins with credentials enabled
+- Clear separation between authenticated and anonymous CORS policies
+
+### Configuration Security
+- Validates against overly permissive patterns
+- Warns about potential security implications
+- Enforces reasonable cache duration limits
+
+## Future Extensions
+
+### Planned Enhancements
+- **Header Mutation Integration**: CORS headers could be modified by header mutation filter
+- **Advanced Pattern Matching**: Extensions beyond StringMatcher when Envoy supports them
+- **Performance Optimization**: Shared validation trait extraction for all HTTP filters
+
+### Compatibility
+- Data model designed to support future CORS specification updates
+- Extensible enum patterns allow new match types
+- Protobuf mapping can evolve with Envoy API changes

--- a/specs/003-cors-http-filter/plan.md
+++ b/specs/003-cors-http-filter/plan.md
@@ -1,0 +1,206 @@
+
+# Implementation Plan: CORS HTTP Filter Support
+
+**Branch**: `003-cors-http-filter` | **Date**: 2025-09-28 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/Users/rajeevramani/workspace/projects/flowplane/specs/003-cors-http-filter/spec.md`
+
+## Implementation Approach
+
+This plan follows the established Flowplane development workflow:
+1. **Research Phase**: Understand existing patterns and dependencies
+2. **Design Phase**: Create data models, API contracts, and documentation
+3. **Implementation Phase**: Execute tasks following TDD principles
+4. **Validation Phase**: Test coverage and constitutional compliance
+
+All phases are executed manually following constitutional requirements for test-first development and security-by-default principles.
+
+## Summary
+Implement CORS (Cross-Origin Resource Sharing) HTTP filter support using Envoy's existing filter framework. Primary requirement is enabling web applications to configure cross-origin policies for secure browser-based API access across different domains. Technical approach leverages envoy-types crate for protobuf integration, extends existing HTTP filter registry (jwt_auth, local_rate_limit patterns), and provides route-specific override capabilities with comprehensive validation and testing.
+
+## Technical Context
+**Language/Version**: Rust 1.75+ (existing Flowplane codebase)
+**Primary Dependencies**: envoy-types crate, serde, tokio, hyper, protobuf, anyhow
+**Storage**: In-memory xDS state management (no additional persistence)
+**Testing**: cargo test with unit tests, integration tests, property-based testing via proptest
+**Target Platform**: Linux server (Envoy control plane)
+**Project Type**: single (extending existing Rust control plane)
+**Performance Goals**: Sub-millisecond filter config validation, minimal xDS update latency
+**Constraints**: Must maintain Envoy protobuf compatibility, no breaking changes to existing filters
+**Scale/Scope**: Support thousands of concurrent routes with CORS policies, integrate with existing HTTP filter framework
+
+## Constitution Check
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+**I. Structured Configs First**: ✅ PASS - Feature explicitly requires strongly-typed config struct that round-trips to protobuf Any payload, following existing jwt_auth pattern
+
+**II. Validation Early**: ✅ PASS - FR-008, FR-015, FR-019 mandate validation at API boundary with descriptive errors for invalid patterns, headers, and max-age values
+
+**III. Test-First Development**: ✅ PASS - FR-017 requires comprehensive test coverage mirroring JWT suite (struct→proto conversions, negative validation cases, per-route overrides)
+
+**IV. Idempotent Resource Building**: ✅ PASS - Integrates with existing HTTP filter framework that already provides idempotent resource building
+
+**V. Security by Default**: ✅ PASS - FR-014, FR-015 ensure secure CORS configurations, prevent overly permissive policies, validate against web security best practices
+
+**VI. Application Stability**: ✅ PASS - FR-013 mandates compatibility with existing filter configurations without breaking changes
+
+**VII. DRY Principle**: ✅ PASS - User description explicitly calls for auditing shared helper traits/macros from jwt_auth and local_rate_limit to factor out duplicated validation
+
+**Gate Status**: ✅ ALL PASS - No constitutional violations detected
+
+**Post-Design Re-evaluation**: ✅ CONFIRMED
+- **Structured Configs**: data-model.md defines strongly-typed CorsConfig with protobuf mapping
+- **Validation Early**: API contracts include comprehensive validation with descriptive errors
+- **Test-First**: Contract tests created (failing) before implementation, following TDD
+- **Security by Default**: Security patterns documented, unsafe configurations rejected
+- **DRY Principle**: Common validation helpers identified for extraction from existing filters
+- **Application Stability**: No breaking changes to existing filter framework
+
+## Project Structure
+
+### Documentation (this feature)
+```
+specs/[###-feature]/
+├── plan.md              # This file (/plan command output)
+├── research.md          # Phase 0 output (/plan command)
+├── data-model.md        # Phase 1 output (/plan command)
+├── quickstart.md        # Phase 1 output (/plan command)
+├── contracts/           # Phase 1 output (/plan command)
+└── tasks.md             # Phase 2 output (/tasks command - NOT created by /plan)
+```
+
+### Source Code (repository root)
+```
+src/
+├── xds/
+│   ├── filters/
+│   │   └── http/
+│   │       ├── cors.rs          # New CORS filter implementation (with inline tests)
+│   │       ├── jwt_auth.rs      # Existing (reference pattern)
+│   │       ├── local_rate_limit.rs # Existing (reference pattern)
+│   │       └── mod.rs           # Updated to include cors
+│   ├── state.rs                 # xDS state management
+│   └── resources/              # Envoy resource builders
+├── api/
+│   └── handlers/               # REST API handlers (existing structure)
+└── config/
+    └── validation.rs           # Configuration validation logic
+
+# Existing protobuf helpers (used by CORS implementation):
+# - src/xds/filters/mod.rs::any_from_message() - Creates Envoy Any from protobuf
+# - src/xds/filters/mod.rs::TypedConfig - Generic protobuf Any representation
+
+tests/
+├── tls/                        # Existing feature-specific tests
+├── cors/                       # New feature-specific test directory
+│   ├── integration/
+│   │   └── test_api.rs         # End-to-end API tests
+│   ├── unit/
+│   │   └── test_validation.rs  # Unit tests for validation logic
+│   └── fixtures/
+│       └── cors_configs.json   # Test configuration samples
+└── support.rs                  # Shared test utilities
+```
+
+**Structure Decision**: Single Rust project extending existing HTTP filter framework. Core implementation in `src/xds/filters/http/cors.rs` with inline tests following patterns from `jwt_auth.rs` and `local_rate_limit.rs`. Feature-specific integration tests in `tests/cors/` directory following existing `tests/tls/` pattern. Uses existing protobuf helpers from `src/xds/filters/` rather than creating new utils module.
+
+## Phase 0: Outline & Research
+
+**Completed**: ✅ research.md created with comprehensive analysis
+
+**Research findings**:
+- **HTTP filter patterns**: Analyzed existing jwt_auth and local_rate_limit implementations
+- **envoy-types integration**: Confirmed protobuf conversion approach using existing helpers
+- **Validation patterns**: Identified common validation logic to factor out
+- **Testing approach**: Established inline tests + feature-specific integration tests pattern
+- **Security constraints**: Documented CORS-specific security requirements
+
+**Key decisions**:
+- Follow HttpFilterKind enum registration pattern
+- Use existing `any_from_message()` helper from `src/xds/filters/mod.rs`
+- Implement per-route configuration via HttpScopedConfig
+- Extract common validation helpers to reduce duplication
+
+## Phase 1: Design & Contracts
+*Prerequisites: research.md complete*
+
+**Completed**: ✅ Core design artifacts created
+
+**Deliverables**:
+1. **data-model.md** - Complete entity definitions:
+   - CorsConfig, CorsPerRouteConfig, OriginPattern
+   - Validation rules and protobuf mapping
+   - Error handling and security properties
+
+2. **contracts/cors-api.yaml** - OpenAPI specification:
+   - Listener-level CORS configuration endpoints
+   - Per-route CORS override endpoints
+   - Comprehensive request/response schemas with examples
+   - Error response definitions
+
+3. **contracts/cors_contract_tests.rs** - Failing contract tests:
+   - API endpoint validation scenarios
+   - Security violation test cases
+   - Round-trip configuration tests
+   - Error handling validation
+
+4. **quickstart.md** - User documentation:
+   - Step-by-step configuration examples
+   - Advanced CORS patterns (subdomain wildcards, credentials)
+   - Testing and troubleshooting guide
+   - Common configuration patterns
+
+**Ready for**: Task generation and implementation following TDD principles
+
+## Phase 2: Task Planning Approach
+
+**Task Generation Strategy**:
+- Generate tasks from Phase 1 design artifacts (data model, contracts, quickstart)
+- Follow TDD principles: failing tests first, then implementation
+- Each contract test becomes a task
+- Each entity requires implementation task
+- Integration tests derived from user scenarios
+
+**Ordering Strategy**:
+- Constitutional requirement: Tests before implementation
+- Dependency order: Core types → validation → API integration → advanced features
+- Parallel tasks: Independent test files and validation logic
+- Sequential tasks: Core filter → registration → API endpoints
+
+**Estimated Output**: 20-25 numbered tasks following established Flowplane patterns
+
+**Next Step**: Manual task generation in tasks.md following research and design artifacts
+
+## Phase 3+: Future Implementation
+*These phases are beyond the scope of the /plan command*
+
+**Phase 3**: Task execution (/tasks command creates tasks.md)  
+**Phase 4**: Implementation (execute tasks.md following constitutional principles)  
+**Phase 5**: Validation (run tests, execute quickstart.md, performance validation)
+
+## Complexity Tracking
+*Fill ONLY if Constitution Check has violations that must be justified*
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |
+
+
+## Progress Tracking
+
+**Phase Status**:
+- [x] Phase 0: Research complete - research.md created with comprehensive analysis
+- [x] Phase 1: Design complete - data-model.md, contracts/, quickstart.md created
+- [x] Phase 2: Task planning approach defined - ready for manual task generation
+- [x] Phase 3: Tasks generated - tasks.md with 22 TDD-ordered tasks created
+- [ ] Phase 4: Implementation complete - following TDD principles
+- [ ] Phase 5: Validation passed - test coverage and constitutional compliance
+
+**Gate Status**:
+- [x] Initial Constitution Check: PASS - No violations detected
+- [x] Post-Design Constitution Check: PASS - Design artifacts confirm compliance
+- [x] All technical context defined - No NEEDS CLARIFICATION items
+- [x] Complexity deviations documented - None required
+
+---
+*Based on Constitution v2.1.1 - See `/memory/constitution.md`*

--- a/specs/003-cors-http-filter/quickstart.md
+++ b/specs/003-cors-http-filter/quickstart.md
@@ -1,0 +1,449 @@
+# CORS HTTP Filter Quickstart
+
+This guide demonstrates how to configure and use the CORS (Cross-Origin Resource Sharing) HTTP filter in Flowplane.
+
+## Prerequisites
+
+- Flowplane control plane running
+- At least one listener configured
+- Basic understanding of CORS concepts
+
+## Basic CORS Configuration
+
+### Step 1: Configure Listener-Level CORS Policy
+
+Configure a basic CORS policy that allows requests from a specific domain:
+
+```bash
+curl -X PUT http://localhost:8080/listeners/api-gateway/filters/cors \
+  -H "Content-Type: application/json" \
+  -d '{
+    "allow_origins": [
+      {
+        "match_type": "exact",
+        "pattern": "https://app.example.com",
+        "case_sensitive": true
+      }
+    ],
+    "allow_methods": ["GET", "POST", "PUT", "DELETE"],
+    "allow_headers": ["content-type", "authorization"],
+    "expose_headers": ["x-request-id"],
+    "allow_credentials": false,
+    "max_age": 86400
+  }'
+```
+
+**Expected Response:**
+```json
+{
+  "message": "CORS filter configured successfully",
+  "filter_name": "envoy.filters.http.cors",
+  "config_checksum": "sha256:abc123..."
+}
+```
+
+### Step 2: Verify Configuration
+
+Retrieve the current CORS configuration:
+
+```bash
+curl -X GET http://localhost:8080/listeners/api-gateway/filters/cors
+```
+
+**Expected Response:**
+```json
+{
+  "allow_origins": [
+    {
+      "match_type": "exact",
+      "pattern": "https://app.example.com",
+      "case_sensitive": true
+    }
+  ],
+  "allow_methods": ["GET", "POST", "PUT", "DELETE"],
+  "allow_headers": ["content-type", "authorization"],
+  "expose_headers": ["x-request-id"],
+  "allow_credentials": false,
+  "max_age": 86400
+}
+```
+
+### Step 3: Test CORS in Browser
+
+Create a simple HTML file to test the CORS configuration:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CORS Test</title>
+</head>
+<body>
+    <h1>CORS Test</h1>
+    <button onclick="testCors()">Test CORS Request</button>
+    <div id="result"></div>
+
+    <script>
+        async function testCors() {
+            const resultDiv = document.getElementById('result');
+            try {
+                const response = await fetch('http://your-api-gateway:8080/api/health', {
+                    method: 'GET',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                });
+
+                if (response.ok) {
+                    resultDiv.innerHTML = '<p style="color: green;">CORS request successful!</p>';
+                } else {
+                    resultDiv.innerHTML = '<p style="color: red;">Request failed: ' + response.status + '</p>';
+                }
+            } catch (error) {
+                resultDiv.innerHTML = '<p style="color: red;">CORS error: ' + error.message + '</p>';
+            }
+        }
+    </script>
+</body>
+</html>
+```
+
+Serve this HTML from `https://app.example.com` and click the test button.
+
+## Advanced CORS Configurations
+
+### Subdomain Wildcard Pattern
+
+Allow requests from any subdomain of example.com using regex patterns:
+
+```bash
+curl -X PUT http://localhost:8080/listeners/api-gateway/filters/cors \
+  -H "Content-Type: application/json" \
+  -d '{
+    "allow_origins": [
+      {
+        "match_type": "safe_regex",
+        "pattern": "https://[a-z0-9-]+\\.example\\.com",
+        "case_sensitive": true
+      }
+    ],
+    "allow_methods": ["GET", "POST"],
+    "allow_headers": ["content-type"],
+    "allow_credentials": false,
+    "max_age": 3600
+  }'
+```
+
+### Multiple Origin Patterns
+
+Configure multiple allowed origins with different patterns:
+
+```bash
+curl -X PUT http://localhost:8080/listeners/api-gateway/filters/cors \
+  -H "Content-Type: application/json" \
+  -d '{
+    "allow_origins": [
+      {
+        "match_type": "exact",
+        "pattern": "https://app.example.com",
+        "case_sensitive": true
+      },
+      {
+        "match_type": "exact",
+        "pattern": "https://mobile.example.com",
+        "case_sensitive": true
+      },
+      {
+        "match_type": "prefix",
+        "pattern": "https://dev-",
+        "case_sensitive": true
+      }
+    ],
+    "allow_methods": ["GET", "POST", "PUT", "DELETE", "PATCH"],
+    "allow_headers": ["content-type", "authorization", "x-api-key"],
+    "expose_headers": ["x-request-id", "x-rate-limit-remaining"],
+    "allow_credentials": false,
+    "max_age": 86400
+  }'
+```
+
+### Credentialed Requests
+
+Enable CORS with credential support for authenticated APIs:
+
+```bash
+curl -X PUT http://localhost:8080/listeners/secure-api/filters/cors \
+  -H "Content-Type: application/json" \
+  -d '{
+    "allow_origins": [
+      {
+        "match_type": "exact",
+        "pattern": "https://admin.example.com",
+        "case_sensitive": true
+      }
+    ],
+    "allow_methods": ["GET", "POST", "PUT", "DELETE"],
+    "allow_headers": ["content-type", "authorization", "x-csrf-token"],
+    "expose_headers": ["x-request-id"],
+    "allow_credentials": true,
+    "max_age": 600
+  }'
+```
+
+**Important:** When `allow_credentials: true`, wildcard origins (`*`) are not allowed for security reasons.
+
+## Per-Route CORS Configuration
+
+### Route-Specific Override
+
+Configure different CORS policies for specific routes:
+
+```bash
+curl -X PUT http://localhost:8080/routes/admin-api/filters/cors \
+  -H "Content-Type: application/json" \
+  -d '{
+    "enabled": true,
+    "inherit_from_listener": false,
+    "cors_policy": {
+      "allow_origins": [
+        {
+          "match_type": "exact",
+          "pattern": "https://admin.example.com",
+          "case_sensitive": true
+        }
+      ],
+      "allow_methods": ["GET", "POST", "DELETE"],
+      "allow_headers": ["content-type", "authorization", "x-admin-token"],
+      "allow_credentials": true,
+      "max_age": 300
+    }
+  }'
+```
+
+### Disable CORS for Specific Route
+
+Disable CORS entirely for a specific route:
+
+```bash
+curl -X PUT http://localhost:8080/routes/internal-api/filters/cors \
+  -H "Content-Type: application/json" \
+  -d '{
+    "enabled": false,
+    "inherit_from_listener": false
+  }'
+```
+
+### Inherit with Modifications
+
+Use the listener policy but inherit from listener settings:
+
+```bash
+curl -X PUT http://localhost:8080/routes/public-api/filters/cors \
+  -H "Content-Type: application/json" \
+  -d '{
+    "enabled": true,
+    "inherit_from_listener": true
+  }'
+```
+
+## Validation and Error Handling
+
+### Test Invalid Configuration
+
+Try to set an invalid configuration to see validation errors:
+
+```bash
+curl -X PUT http://localhost:8080/listeners/api-gateway/filters/cors \
+  -H "Content-Type: application/json" \
+  -d '{
+    "allow_origins": [],
+    "allow_methods": ["GET"],
+    "max_age": 999999999999
+  }'
+```
+
+**Expected Error Response:**
+```json
+{
+  "error": "Configuration validation failed",
+  "validation_errors": [
+    {
+      "field": "allow_origins",
+      "message": "Cannot be empty",
+      "code": "REQUIRED_FIELD_EMPTY"
+    },
+    {
+      "field": "max_age",
+      "message": "Exceeds maximum allowed value",
+      "code": "VALUE_OUT_OF_RANGE"
+    }
+  ]
+}
+```
+
+### Test Security Violation
+
+Try to configure wildcard origins with credentials:
+
+```bash
+curl -X PUT http://localhost:8080/listeners/api-gateway/filters/cors \
+  -H "Content-Type: application/json" \
+  -d '{
+    "allow_origins": [
+      {
+        "match_type": "exact",
+        "pattern": "*",
+        "case_sensitive": true
+      }
+    ],
+    "allow_methods": ["GET"],
+    "allow_credentials": true
+  }'
+```
+
+**Expected Error Response:**
+```json
+{
+  "error": "Configuration validation failed",
+  "validation_errors": [
+    {
+      "field": "allow_credentials",
+      "message": "Cannot use wildcard origins with credentials enabled",
+      "code": "SECURITY_VIOLATION"
+    }
+  ]
+}
+```
+
+## Testing CORS Behavior
+
+### Preflight Request Test
+
+Test OPTIONS preflight request handling:
+
+```bash
+curl -X OPTIONS http://your-api-gateway:8080/api/users \
+  -H "Origin: https://app.example.com" \
+  -H "Access-Control-Request-Method: POST" \
+  -H "Access-Control-Request-Headers: content-type,authorization" \
+  -v
+```
+
+**Expected Response Headers:**
+```
+Access-Control-Allow-Origin: https://app.example.com
+Access-Control-Allow-Methods: GET, POST, PUT, DELETE
+Access-Control-Allow-Headers: content-type, authorization
+Access-Control-Max-Age: 86400
+```
+
+### Actual Request Test
+
+Test actual cross-origin request:
+
+```bash
+curl -X POST http://your-api-gateway:8080/api/users \
+  -H "Origin: https://app.example.com" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Test User"}' \
+  -v
+```
+
+**Expected Response Headers:**
+```
+Access-Control-Allow-Origin: https://app.example.com
+Access-Control-Expose-Headers: x-request-id
+```
+
+## Configuration Management
+
+### Remove CORS Filter
+
+Remove CORS filter from a listener:
+
+```bash
+curl -X DELETE http://localhost:8080/listeners/api-gateway/filters/cors
+```
+
+### Remove Route Override
+
+Remove route-specific CORS configuration:
+
+```bash
+curl -X DELETE http://localhost:8080/routes/admin-api/filters/cors
+```
+
+## Common Patterns
+
+### Development Environment
+
+For development with multiple local origins:
+
+```json
+{
+  "allow_origins": [
+    {
+      "match_type": "prefix",
+      "pattern": "http://localhost:",
+      "case_sensitive": true
+    },
+    {
+      "match_type": "prefix",
+      "pattern": "http://127.0.0.1:",
+      "case_sensitive": true
+    }
+  ],
+  "allow_methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+  "allow_headers": ["content-type", "authorization"],
+  "allow_credentials": false,
+  "max_age": 86400
+}
+```
+
+### Production Environment
+
+For production with specific domains:
+
+```json
+{
+  "allow_origins": [
+    {
+      "match_type": "exact",
+      "pattern": "https://app.example.com",
+      "case_sensitive": true
+    },
+    {
+      "match_type": "exact",
+      "pattern": "https://www.example.com",
+      "case_sensitive": true
+    }
+  ],
+  "allow_methods": ["GET", "POST", "PUT", "DELETE"],
+  "allow_headers": ["content-type", "authorization"],
+  "expose_headers": ["x-request-id"],
+  "allow_credentials": true,
+  "max_age": 3600
+}
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **CORS error in browser**: Check origin matches exactly (including protocol and port)
+2. **Preflight failure**: Ensure method and headers are included in allow lists
+3. **Credentials not working**: Verify no wildcard origins when credentials enabled
+4. **Configuration rejected**: Check validation errors in API response
+
+### Debug Tips
+
+1. Use browser developer tools to inspect CORS headers
+2. Test with curl to isolate client-side issues
+3. Check Envoy access logs for CORS filter decisions
+4. Verify filter order in listener configuration
+
+## Next Steps
+
+- Explore [header mutation filter](../header-mutation/quickstart.md) for dynamic header manipulation
+- Learn about [JWT authentication integration](../jwt-auth/quickstart.md)
+- Review [security best practices](../security/cors-security.md) for production deployment

--- a/specs/003-cors-http-filter/research.md
+++ b/specs/003-cors-http-filter/research.md
@@ -1,0 +1,176 @@
+# CORS HTTP Filter Implementation Research
+
+## Overview
+Research findings for implementing CORS filter following established patterns in the Flowplane HTTP filter framework.
+
+## Technology Decisions
+
+### Decision: Follow existing HTTP filter registration pattern
+**Rationale**: Consistent with jwt_auth and local_rate_limit implementations
+**Pattern**:
+- Add `Cors(cors::CorsConfig)` to `HttpFilterKind` enum
+- Implement required methods: `default_name()`, `to_any()`, `is_router()`
+- Use canonical Envoy filter name: `"envoy.filters.http.cors"`
+
+### Decision: Use envoy-types crate for protobuf integration
+**Rationale**: Maintains compatibility with Envoy xDS API, avoids maintaining custom proto generation
+**Implementation**:
+- Import `envoy_types::pb::envoy::extensions::filters::http::cors::v3::CorsPolicy`
+- Convert config to `EnvoyAny` using `any_from_message()` helper
+- Type URL: `"type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy"`
+
+### Decision: Implement per-route configuration support
+**Rationale**: FR-007 requires route-specific overrides, following existing scoped config pattern
+**Implementation**:
+- Add `Cors(CorsPerRouteConfig)` to `HttpScopedConfig` enum
+- Support both listener-level and route-level configuration
+- Route overrides take precedence per existing framework behavior
+
+## Validation Strategy
+
+### Decision: Extract common validation helpers
+**Rationale**: DRY principle compliance, reduce code duplication across filters
+**Identified patterns to factor out**:
+- Duration conversion (milliseconds to protobuf Duration)
+- Empty string validation with trim
+- Collection emptiness checks
+- Optional field handling with defaults
+
+**Proposed helper implementations**:
+```rust
+// Duration conversion helper
+trait ProtobufDuration {
+    fn to_proto_duration(&self) -> ProtoDuration;
+    fn from_proto_duration(proto: &ProtoDuration) -> Result<Self, Error>;
+}
+
+// String validation macro
+macro_rules! validate_non_empty_string {
+    ($field:expr, $field_name:expr) => {
+        if $field.trim().is_empty() {
+            return Err(invalid_config(format!("{} cannot be empty", $field_name)));
+        }
+    };
+}
+```
+
+### Decision: Validate against Envoy protobuf constraints
+**Rationale**: FR-019 requires google.protobuf.Duration compliance, prevent runtime errors
+**Constraints**:
+- Max-age values: non-negative up to 315,576,000,000 seconds
+- Origin patterns: limited to StringMatcher capabilities (exact, prefix, suffix, safe_regex)
+- Header validation: RFC-compliant header names and values
+
+## Testing Approach
+
+### Decision: Mirror JWT authentication test suite structure
+**Rationale**: FR-017 explicitly requires test coverage mirroring existing patterns
+**Test categories**:
+1. **Unit tests**: Struct-to-proto conversions, validation logic
+2. **Round-trip tests**: Config → protobuf → config integrity
+3. **Negative tests**: Invalid configurations rejected with clear errors
+4. **Integration tests**: End-to-end API to xDS generation
+5. **Per-route tests**: Scoped configuration override scenarios
+
+**Test file locations**:
+- Unit tests: `tests/unit/xds/filters/http/cors.rs`
+- Integration tests: `tests/integration/cors_filter_api.rs`
+- Test fixtures: `tests/fixtures/cors_configs.json`
+
+## Architecture Integration
+
+### Decision: Extend existing HTTP filter framework without changes
+**Rationale**: FR-013 mandates no breaking changes to existing filter configurations
+**Integration points**:
+- **Registration**: Add to `src/xds/filters/http/mod.rs` enum
+- **API endpoints**: Integrate with existing filter configuration endpoints
+- **XDS generation**: Automatic inclusion in Envoy resource builders
+
+### Decision: Follow established configuration patterns
+**Rationale**: Consistency with existing filters, leverages proven patterns
+**Required derives**: `Debug, Clone, Serialize, Deserialize, ToSchema`
+**Error handling**: Return `crate::Error::Config(String)` for validation failures
+
+## Implementation Files
+
+### Core implementation
+- `src/xds/filters/http/cors.rs` - Main CORS filter implementation
+- `src/xds/filters/http/mod.rs` - Updated to include CORS in enum
+
+### Shared validation helpers (new)
+- `src/utils/filter_validation.rs` - Extracted common validation patterns
+- Factor out from `jwt_auth.rs` and `local_rate_limit.rs`
+
+### Testing files
+- `tests/unit/xds/filters/http/cors.rs` - Unit tests
+- `tests/integration/cors_filter_api.rs` - API integration tests
+- `tests/fixtures/cors_configs.json` - Test data
+
+## Dependencies
+
+### Existing dependencies (no additions needed)
+- `envoy-types` - Protobuf message definitions
+- `serde` - Serialization framework
+- `anyhow` - Error handling
+- `tokio` - Async runtime
+- `utoipa` - OpenAPI schema generation
+
+### Validation constraints
+- Must not introduce new external dependencies
+- Must maintain compatibility with existing Rust version (1.75+)
+- Must support existing test framework (`cargo test`)
+
+## Security Considerations
+
+### Decision: Implement secure-by-default CORS policies
+**Rationale**: FR-015 requires web security best practices compliance
+**Security measures**:
+- Reject overly permissive wildcard origins in production
+- Validate origin patterns for common security vulnerabilities
+- Enforce reasonable max-age limits for preflight caching
+- Provide clear warnings for potentially unsafe configurations
+
+### Decision: Follow existing authentication integration patterns
+**Rationale**: CORS often used with authenticated APIs, must integrate cleanly
+**Integration**:
+- Support credential-aware CORS policies (FR-006)
+- Maintain compatibility with existing JWT authentication filter
+- Ensure filter ordering doesn't create security gaps
+
+## Performance Requirements
+
+### Decision: Sub-millisecond configuration validation
+**Rationale**: Control plane performance goals, minimize xDS update latency
+**Implementation approach**:
+- Pre-compile regex patterns during configuration parsing
+- Cache validation results where appropriate
+- Minimize allocations in hot path validation
+
+### Decision: Support thousands of concurrent route configurations
+**Rationale**: Scale requirements for production deployment
+**Architecture considerations**:
+- Efficient in-memory representation
+- Minimize clone overhead for route-specific configs
+- Leverage Rust's zero-cost abstractions
+
+## Alternatives Considered
+
+### Alternative: Custom protobuf generation
+**Rejected because**: envoy-types crate provides maintained compatibility with Envoy upstream
+**Trade-off**: Slightly less control over protobuf details vs. guaranteed compatibility
+
+### Alternative: Separate validation library
+**Rejected because**: Would introduce new dependency, existing patterns sufficient
+**Trade-off**: More comprehensive validation vs. maintaining lightweight dependencies
+
+### Alternative: Runtime configuration validation
+**Rejected because**: Constitutional requirement for early validation at API boundary
+**Trade-off**: Flexibility vs. fail-fast principle compliance
+
+## Next Steps for Phase 1
+
+1. **Design data model** - Define CorsConfig and CorsPerRouteConfig structs
+2. **Create API contracts** - OpenAPI specifications for CORS endpoints
+3. **Generate contract tests** - Failing tests for TDD approach
+4. **Extract validation helpers** - Factor out common patterns from existing filters
+5. **Update agent context** - Refresh Claude Code context with new patterns

--- a/specs/003-cors-http-filter/spec.md
+++ b/specs/003-cors-http-filter/spec.md
@@ -1,0 +1,92 @@
+# Feature Specification: CORS HTTP Filter Support
+
+**Feature Branch**: `003-cors-http-filter`
+**Created**: 2025-09-27
+**Status**: Draft
+**Input**: User description: "For the upcoming release we should prioritize landing CORS support using the existing HTTP filter framework, with a deliberate eye toward extending it for future work like header_mutation once the initial integration is stable. That means spiking Envoy's envoy.types.pb.envoy.extensions.filters.http.cors.v3.CorsPolicy schema inside our src/xds/filters/http registry: define a strongly typed config struct that round-trips cleanly to the protobuf Any payload, register it in HttpFilterKind, and ensure per-route overrides fit our scoped-config plumbing. While implementing this, audit the shared helper traits/macros we already use for jwt_auth and local_rate_limit so we can factor out any duplicated validation (e.g., optional defaults, enum coercions) before bolting on CORS-specific rules like origin pattern parsing and preflight TTL bounds. Finally, add regression coverage mirroring the JWT suite: happy-path struct→proto conversions, Envoy proto→struct parsing where applicable, and negative tests that surface invalid inputs (empty allow lists, malformed headers, out-of-range max-age) so the REST API rejects bad configs early.. let's continue leaning on the envoy-types crate for every proto conversion. It already mirrors Envoy's published descriptors, so we avoid maintaining our own generated protos or drifting from upstream field semantics. In practice that means our new CORS structs should serialize into the envoy_types::pb::envoy::extensions::filters::http::cors::v3::CorsPolicy message, just like jwt_auth wraps envoy_types::pb::envoy::extensions::filters::http::jwt_authn::v3::*. We can keep the ergonomics layer (Serde structs, validation, to_any helpers) in our codebase, but the actual protobuf types should come straight from envoy-types so upgrades stay mechanical and compatibility with Envoy's xDS API is guaranteed."
+
+## User Scenarios & Testing
+
+### Primary User Story
+As a platform operator configuring API gateways, I want to enable Cross-Origin Resource Sharing (CORS) policies for web applications, so that browser-based clients can securely access APIs from different domains while maintaining proper security boundaries and preflight request handling.
+
+### Acceptance Scenarios
+1. **Given** I have a web application hosted on domain-a.com, **When** I configure CORS to allow requests from domain-b.com, **Then** browsers can successfully make cross-origin requests with proper preflight handling
+2. **Given** I need different CORS policies for different API routes, **When** I configure route-specific CORS settings, **Then** each route enforces its own origin restrictions and header policies independently
+3. **Given** I want to allow specific HTTP methods and headers, **When** I configure CORS allowed methods and headers, **Then** only the specified methods and headers are permitted in cross-origin requests
+4. **Given** I configure CORS with credential support, **When** browsers make authenticated cross-origin requests, **Then** the system properly handles credentials and includes appropriate response headers
+5. **Given** I set CORS preflight cache TTL, **When** browsers send OPTIONS preflight requests, **Then** the cache duration is respected to optimize subsequent requests
+
+### Edge Cases
+- What happens when an origin doesn't match any configured CORS patterns?
+- How does the system handle malformed origin headers or invalid preflight requests?
+- What occurs when conflicting CORS policies are configured at different levels (global vs route-specific)?
+- How are wildcard origin patterns validated and applied securely?
+- What validation prevents unsafe CORS configurations that could compromise security?
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST support configuring CORS policies to specify which origins are allowed to make cross-origin requests
+- **FR-002**: System MUST allow configuration of permitted HTTP methods for cross-origin requests (GET, POST, PUT, DELETE, etc.)
+- **FR-003**: System MUST support specifying which request headers are allowed in cross-origin requests
+- **FR-004**: System MUST support configuration of response headers that are exposed to cross-origin clients
+- **FR-005**: System MUST handle preflight OPTIONS requests according to CORS specification with configurable cache duration
+- **FR-006**: System MUST support credential-aware CORS policies that control whether cookies and authentication headers are allowed
+- **FR-007**: System MUST allow CORS policies to be configured at both global listener level and per-route level with route-specific overrides taking precedence
+- **FR-008**: System MUST validate CORS configuration inputs and reject invalid patterns, malformed headers, or unsafe wildcard configurations
+- **FR-009**: System MUST support origin matching via Envoy's StringMatcher options (exact hostnames, prefix/suffix patterns, safe regex for subdomains)
+- **FR-010**: System MUST enforce maximum age limits for preflight cache duration to prevent excessive client-side caching
+- **FR-011**: System MUST integrate with the existing HTTP filter framework for consistent configuration management
+- **FR-012**: System MUST provide clear error messages when CORS policies are violated or misconfigured
+- **FR-013**: System MUST maintain compatibility with existing filter configurations without breaking changes
+- **FR-014**: System MUST support common CORS header patterns while preventing security vulnerabilities from overly permissive configurations
+- **FR-015**: System MUST provide configuration validation that ensures CORS policies comply with web security best practices
+- **FR-016**: CORS filter conversions MUST use envoy_types::pb::envoy::extensions::filters::http::cors::v3::CorsPolicy via the existing helper pipeline to maintain Envoy compatibility
+- **FR-017**: System MUST include comprehensive test coverage with struct-to-proto round trips, negative validation cases, and per-route override scenarios mirroring JWT and local rate limit test suites
+- **FR-018**: Origin pattern matching MUST be limited to Envoy's StringMatcher capabilities (exact, prefix, suffix, safe_regex) and not extend beyond what Envoy's allow_origin_string_match supports
+- **FR-019**: Preflight cache max-age values MUST conform to google.protobuf.Duration constraints (non-negative values up to 315,576,000,000 seconds) and be validated during configuration parsing to prevent runtime errors
+
+### Key Entities
+
+- **CORS Policy**: Represents a complete CORS configuration including allowed origins, methods, headers, credentials setting, and preflight cache duration
+- **Origin Pattern**: Represents an allowed origin specification that can be exact domain, wildcard pattern, or protocol-specific rule
+- **Preflight Configuration**: Represents settings for handling OPTIONS preflight requests including cache duration and allowed request characteristics
+- **CORS Violation Response**: Represents the system's response when a request doesn't meet configured CORS requirements
+- **Filter Integration Context**: Represents how CORS policies integrate with other HTTP filters and route-specific configurations
+
+## Review & Acceptance Checklist
+
+### Content Quality
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+### Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Future Work
+
+While this specification focuses on CORS filter implementation to establish stable integration patterns with the HTTP filter framework, the following extensions are planned for subsequent releases:
+
+- **Header Mutation Filter**: Next priority filter implementation using the patterns established by CORS, enabling dynamic request/response header modification with route-specific overrides
+- **Filter Chain Optimization**: Performance improvements and shared validation patterns identified during CORS implementation
+- **Advanced Origin Matching**: Potential extensions to origin pattern matching beyond StringMatcher capabilities, pending Envoy upstream developments
+
+This deliberate scoping to CORS first ensures the framework remains extensible while validating core integration patterns before adding complexity.
+
+## Execution Status
+
+- [x] User description parsed
+- [x] Key concepts extracted
+- [x] Ambiguities marked
+- [x] User scenarios defined
+- [x] Requirements generated
+- [x] Entities identified
+- [x] Review checklist passed

--- a/specs/003-cors-http-filter/tasks.md
+++ b/specs/003-cors-http-filter/tasks.md
@@ -1,0 +1,288 @@
+# CORS HTTP Filter Implementation Tasks
+
+**Branch**: `003-cors-http-filter`
+**Feature**: CORS HTTP Filter Support
+**Implementation Strategy**: Test-Driven Development (TDD) following constitutional requirements
+
+## Task Overview
+
+Total: 18 tasks organized in dependency order (status in brackets)
+- **Phase 1**: Foundation & Core Types (T001-T005)
+- **Phase 2**: Validation & Security (T006-T010)
+- **Phase 3**: HTTP Filter Integration (T011-T015)
+- **Phase 4**: Schema Integration (T016-T017)
+- **Phase 5**: Integration Testing & Validation (T018)
+
+**Parallelizable Tasks**: Marked with [P] can be executed independently
+**Sequential Tasks**: Must be completed in order due to dependencies
+
+---
+
+## Phase 1: Foundation & Core Types
+
+### T001: Create CORS configuration types [P] ✅
+**Description**: Define core CorsConfig and related types in src/xds/filters/http/cors.rs
+**Dependencies**: None
+**Deliverables**:
+- `CorsConfig` struct with serde derives
+- `OriginPattern` struct with match type enum
+- `CorsPerRouteConfig` struct for route overrides
+- Basic struct documentation
+**Acceptance Criteria**:
+- All structs compile with required derives: Debug, Clone, Serialize, Deserialize, ToSchema
+- Serde serialization works for JSON representation
+- Code follows existing filter patterns from jwt_auth.rs
+
+### T002: Create CORS validation error types [P] ❌ *(skipped)*
+**Description**: Define error types for CORS configuration validation
+**Dependencies**: None
+**Deliverables**:
+- CORS-specific error variants in existing error enum
+- Error messages for invalid configurations
+- Security violation error types
+**Acceptance Criteria**:
+- *Not needed*. Reused existing `invalid_config` helpers; no new variants introduced.
+
+### T003: Implement basic struct validation (failing tests) [P] ✅
+**Description**: Create unit tests for CorsConfig validation that will initially fail
+**Dependencies**: T001
+**Deliverables**:
+- Unit tests in `mod tests` section of cors.rs
+- Tests for required fields validation
+- Tests for field constraints (max_age limits, etc.)
+**Acceptance Criteria**:
+- Tests compile but fail (no implementation yet)
+- Tests cover all validation rules from data-model.md
+- Test names clearly describe validation scenarios
+
+### T004: Implement protobuf conversion types ✅
+**Description**: Create Envoy protobuf message structures for CORS
+**Dependencies**: T001
+**Deliverables**:
+- envoy-types imports for CorsPolicy protobuf
+- Type conversion helper functions
+- Any protobuf creation logic
+**Acceptance Criteria**:
+- Uses envoy_types::pb::envoy::extensions::filters::http::cors::v3::CorsPolicy
+- Integrates with existing any_from_message() helper
+- Type URL correctly set
+
+### T005: Implement basic CorsConfig validation logic ✅
+**Description**: Make T003 tests pass by implementing validation
+**Dependencies**: T003
+**Deliverables**:
+- Validation implementation for all CorsConfig fields
+- Security validation (wildcard + credentials check)
+- Duration and string validation inline
+**Acceptance Criteria**:
+- All unit tests from T003 pass
+- Validation errors are descriptive
+- Security constraints properly enforced
+
+---
+
+## Phase 2: Validation & Security
+
+### T006: Implement origin pattern validation [P] ✅
+**Description**: Validate OriginPattern configurations with security checks
+**Dependencies**: T005
+**Deliverables**:
+- Regex pattern compilation validation
+- Origin security validation
+- Pattern matching constraint validation
+**Acceptance Criteria**:
+- Invalid regex patterns rejected with clear errors
+- Unsafe wildcard patterns blocked
+- StringMatcher compatibility verified
+
+### T007: Implement CORS security validation [P] ✅
+**Description**: Enforce CORS security best practices
+**Dependencies**: T005
+**Deliverables**:
+- Wildcard origin + credentials validation
+- Header name RFC compliance checks
+- Max-age protobuf Duration constraints
+**Acceptance Criteria**:
+- Security violations clearly rejected
+- RFC 7230 header validation implemented
+- google.protobuf.Duration limits enforced
+
+### T008: Create protobuf round-trip tests (failing) ✅
+**Description**: Unit tests for CorsConfig ↔ protobuf conversion
+**Dependencies**: T004
+**Deliverables**:
+- Tests for CorsConfig → protobuf conversion
+- Tests for protobuf → CorsConfig parsing
+- Round-trip integrity tests
+**Acceptance Criteria**:
+- Tests compile but fail initially
+- Cover all configuration fields
+- Test edge cases and error conditions
+
+### T009: Implement CorsConfig protobuf conversion ✅
+**Description**: Make T008 tests pass with protobuf conversion implementation
+**Dependencies**: T008
+**Deliverables**:
+- `to_any()` method implementation
+- `from_proto()` method implementation
+- Error handling for conversion failures
+**Acceptance Criteria**:
+- All protobuf round-trip tests pass
+- Uses existing any_from_message() helper
+- Proper error handling for invalid protobuf data
+
+### T010: Implement per-route configuration validation ✅
+**Description**: Validate CorsPerRouteConfig with inheritance logic
+**Dependencies**: T009
+**Deliverables**:
+- Per-route config validation
+- Inheritance vs override logic validation
+- Route-specific constraint validation
+**Acceptance Criteria**:
+- Route config validation follows listener config patterns
+- Inheritance logic properly validated
+- Clear errors for invalid route configurations
+
+---
+
+## Phase 3: HTTP Filter Integration
+
+### T011: Register CORS in HttpFilterKind enum ✅
+**Description**: Add CORS variant to HttpFilterKind in src/xds/filters/http/mod.rs
+**Dependencies**: T010
+**Deliverables**:
+- CORS variant added to HttpFilterKind enum
+- Required trait implementations
+- Filter name and routing logic
+**Acceptance Criteria**:
+- Enum compiles with new CORS variant
+- `default_name()` returns "envoy.filters.http.cors"
+- `to_any()` method properly implemented
+- `is_router()` returns false
+
+### T012: Register CORS in HttpScopedConfig enum ✅
+**Description**: Add per-route CORS configuration support
+**Dependencies**: T011
+**Deliverables**:
+- CORS variant in HttpScopedConfig enum
+- Per-route protobuf conversion
+- Route override logic integration
+**Acceptance Criteria**:
+- HttpScopedConfig compiles with CORS variant
+- Per-route to_any() implementation works
+- Integration with existing scoped config logic
+
+### T013: Create HTTP filter integration tests (failing) ✅
+**Description**: Integration tests for CORS filter in HTTP filter chain following existing patterns
+**Dependencies**: T012
+**Deliverables**:
+- Integration tests in src/xds/filters/http/cors.rs (mod integration_tests)
+- Filter chain configuration tests
+- xDS resource generation tests
+**Acceptance Criteria**:
+- Tests compile but fail initially
+- Follow patterns from existing filter tests
+- Test filter ordering and precedence
+
+### T014: Implement filter integration logic ✅
+**Description**: Make T013 tests pass with proper filter integration
+**Dependencies**: T013
+**Deliverables**:
+- Filter integration with existing framework
+- xDS resource generation for CORS
+- Filter chain ordering logic
+**Acceptance Criteria**:
+- All integration tests pass
+- CORS filter properly integrated in xDS resources
+- No breaking changes to existing filters
+
+### T015: Test filter precedence and ordering ✅
+**Description**: Verify CORS filter works correctly with other filters
+**Dependencies**: T014
+**Deliverables**:
+- Multi-filter test scenarios in existing test structure
+- Filter ordering validation tests
+- JWT + CORS integration tests
+**Acceptance Criteria**:
+- CORS filter works with JWT authentication
+- Filter ordering is correct
+- No conflicts with existing filters
+
+---
+
+## Phase 4: Schema Integration
+
+### T016: Update filter configuration schemas ✅
+**Description**: Extend existing filter configuration to support CORS
+**Dependencies**: T015
+**Deliverables**:
+- CORS filter works with existing listener/route configuration APIs
+- Schema validation for CORS configurations
+- Integration with existing filter management
+**Acceptance Criteria**:
+- CORS configs accepted by existing endpoints
+- Validation errors properly returned
+- No new REST endpoints required
+
+### T017: Add CORS to OpenAPI specification (STRETCH) ⭕ *(not in scope this release)*
+**Description**: Include CORS schemas in main OpenAPI spec if filter documentation is in scope
+**Dependencies**: T016
+**Deliverables**:
+- CORS schemas in main OpenAPI specification
+- Documentation for CORS configuration fields
+- Example CORS configurations
+**Acceptance Criteria**:
+- OpenAPI spec generates correctly with CORS schemas
+- CORS configuration documented
+- Examples validate against schemas
+**Note**: Optional task - deferred; covered by README/docs updates instead of OpenAPI.
+
+---
+
+## Phase 5: Integration Testing & Validation
+
+### T018: Final validation and comprehensive testing ✅
+**Description**: Ensure all requirements met and documentation complete
+**Dependencies**: T017
+**Deliverables**:
+- All 19 functional requirements verified
+- Constitutional compliance confirmed
+- Performance validation completed
+- End-to-end testing using existing test infrastructure
+**Acceptance Criteria**:
+- All tests pass (unit and integration) – satisfied via `cargo test --tests`
+- No breaking changes to existing functionality – regression suite green
+- Documentation updated (`docs/filters.md`) with examples
+
+---
+
+## Execution Notes
+
+### TDD Compliance
+- All implementation tasks preceded by failing test tasks
+- Tests written before implementation in every phase
+- Red-Green-Refactor cycle strictly followed
+
+### Constitutional Compliance
+- **Test-First**: Tasks 3, 8, 13 create failing tests before implementation
+- **Security by Default**: Tasks 6, 7 enforce security validation
+- **Structured Configs**: Tasks 1, 4, 9 ensure strong typing
+- **Application Stability**: All tasks preserve existing functionality
+
+### Parallel Execution Opportunities
+Tasks marked [P] can be executed in parallel:
+- T001, T002, T003 (Foundation setup)
+- T006, T007 (Independent validation logic)
+
+### Risk Mitigation
+- Early protobuf integration (T004, T009) to catch compatibility issues
+- Security validation implemented before filter integration
+- Comprehensive test coverage throughout implementation
+- Filter integration validated with existing test patterns
+
+### Success Criteria
+- All functional requirements (FR-001 through FR-019) implemented (docs/spec verified)
+- Constitutional principles maintained throughout
+- No breaking changes to existing filter framework
+- `cargo test --tests` green on branch
+- CORS configuration documented in `docs/filters.md`

--- a/src/xds/filters/http/cors.rs
+++ b/src/xds/filters/http/cors.rs
@@ -1,0 +1,619 @@
+//! CORS HTTP filter configuration helpers
+
+use std::convert::TryFrom;
+
+use crate::xds::filters::{any_from_message, invalid_config};
+use envoy_types::pb::envoy::config::core::v3::RuntimeFractionalPercent;
+use envoy_types::pb::envoy::config::route::v3::{
+    cors_policy::EnabledSpecifier as RouteEnabledSpecifier, CorsPolicy as RouteCorsPolicy,
+};
+use envoy_types::pb::envoy::extensions::filters::http::cors::v3::{
+    Cors as CorsFilter, CorsPolicy as FilterCorsPolicy,
+};
+use envoy_types::pb::envoy::r#type::matcher::v3::string_matcher::MatchPattern;
+use envoy_types::pb::envoy::r#type::matcher::v3::{RegexMatcher, StringMatcher};
+use envoy_types::pb::envoy::r#type::v3::fractional_percent;
+use envoy_types::pb::google::protobuf::{Any as EnvoyAny, BoolValue};
+use http::{header::HeaderName, Method};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+pub const FILTER_CORS_POLICY_TYPE_URL: &str =
+    "type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy";
+pub const ROUTE_CORS_POLICY_TYPE_URL: &str = "type.googleapis.com/envoy.config.route.v3.CorsPolicy";
+pub const CORS_FILTER_TYPE_URL: &str =
+    "type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors";
+const MAX_AGE_LIMIT_SECONDS: u64 = 315_576_000_000; // 10,000 years
+
+/// Representation of a single CORS origin match rule using Envoy's `StringMatcher`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CorsOriginMatcher {
+    Exact { value: String },
+    Prefix { value: String },
+    Suffix { value: String },
+    Contains { value: String },
+    Regex { value: String },
+}
+
+impl CorsOriginMatcher {
+    fn to_proto(&self) -> Result<StringMatcher, crate::Error> {
+        let mut matcher = StringMatcher { ignore_case: false, ..Default::default() };
+
+        matcher.match_pattern = Some(match self {
+            CorsOriginMatcher::Exact { value } => MatchPattern::Exact(value.clone()),
+            CorsOriginMatcher::Prefix { value } => MatchPattern::Prefix(value.clone()),
+            CorsOriginMatcher::Suffix { value } => MatchPattern::Suffix(value.clone()),
+            CorsOriginMatcher::Contains { value } => MatchPattern::Contains(value.clone()),
+            CorsOriginMatcher::Regex { value } => {
+                Regex::new(value).map_err(|err| {
+                    invalid_config(format!("Invalid CORS regex origin matcher: {err}"))
+                })?;
+                MatchPattern::SafeRegex(RegexMatcher { regex: value.clone(), ..Default::default() })
+            }
+        });
+
+        Ok(matcher)
+    }
+
+    fn from_proto(proto: &StringMatcher) -> Result<Self, crate::Error> {
+        if proto.ignore_case {
+            return Err(invalid_config(
+                "CORS origin matcher does not support case-insensitive matching",
+            ));
+        }
+
+        match proto
+            .match_pattern
+            .as_ref()
+            .ok_or_else(|| invalid_config("CORS origin matcher requires a match pattern"))?
+        {
+            MatchPattern::Exact(value) => Ok(CorsOriginMatcher::Exact { value: value.clone() }),
+            MatchPattern::Prefix(value) => Ok(CorsOriginMatcher::Prefix { value: value.clone() }),
+            MatchPattern::Suffix(value) => Ok(CorsOriginMatcher::Suffix { value: value.clone() }),
+            MatchPattern::Contains(value) => {
+                Ok(CorsOriginMatcher::Contains { value: value.clone() })
+            }
+            MatchPattern::SafeRegex(regex) => {
+                Ok(CorsOriginMatcher::Regex { value: regex.regex.clone() })
+            }
+            MatchPattern::Custom(_) => Err(invalid_config(
+                "CORS origin matcher does not support custom extension matchers",
+            )),
+        }
+    }
+
+    fn validate(&self) -> Result<(), crate::Error> {
+        match self {
+            CorsOriginMatcher::Exact { value }
+            | CorsOriginMatcher::Prefix { value }
+            | CorsOriginMatcher::Suffix { value }
+            | CorsOriginMatcher::Contains { value } => {
+                if value.is_empty() {
+                    return Err(invalid_config("CORS origin matcher value cannot be empty"));
+                }
+            }
+            CorsOriginMatcher::Regex { value } => {
+                if value.is_empty() {
+                    return Err(invalid_config("CORS regex origin matcher value cannot be empty"));
+                }
+                Regex::new(value).map_err(|err| {
+                    invalid_config(format!("Invalid CORS regex origin matcher: {err}"))
+                })?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Representation of Envoy's `RuntimeFractionalPercent` for enabling/shadowing behaviour.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct RuntimeFractionalPercentConfig {
+    /// Optional runtime key for dynamic overrides
+    #[serde(default)]
+    pub runtime_key: Option<String>,
+    /// Numerator value for the fraction
+    pub numerator: u32,
+    /// Denominator specifying the unit of the numerator
+    #[serde(default)]
+    pub denominator: FractionalPercentDenominator,
+}
+
+impl RuntimeFractionalPercentConfig {
+    fn to_proto(&self) -> RuntimeFractionalPercent {
+        RuntimeFractionalPercent {
+            runtime_key: self.runtime_key.clone().unwrap_or_default(),
+            default_value: Some(envoy_types::pb::envoy::r#type::v3::FractionalPercent {
+                numerator: self.numerator,
+                denominator: self.denominator.to_proto_value(),
+            }),
+        }
+    }
+
+    fn from_proto(proto: &RuntimeFractionalPercent) -> Result<Self, crate::Error> {
+        let default_value = proto
+            .default_value
+            .as_ref()
+            .ok_or_else(|| invalid_config("RuntimeFractionalPercent missing default_value"))?;
+
+        Ok(Self {
+            runtime_key: if proto.runtime_key.is_empty() {
+                None
+            } else {
+                Some(proto.runtime_key.clone())
+            },
+            numerator: default_value.numerator,
+            denominator: FractionalPercentDenominator::from_proto_value(default_value.denominator)?,
+        })
+    }
+}
+
+/// Denominator options mirroring Envoy enum values.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FractionalPercentDenominator {
+    Hundred,
+    TenThousand,
+    Million,
+}
+
+impl Default for FractionalPercentDenominator {
+    fn default() -> Self {
+        Self::Hundred
+    }
+}
+
+impl FractionalPercentDenominator {
+    fn to_proto_value(self) -> i32 {
+        match self {
+            Self::Hundred => fractional_percent::DenominatorType::Hundred as i32,
+            Self::TenThousand => fractional_percent::DenominatorType::TenThousand as i32,
+            Self::Million => fractional_percent::DenominatorType::Million as i32,
+        }
+    }
+
+    fn from_proto_value(value: i32) -> Result<Self, crate::Error> {
+        match fractional_percent::DenominatorType::try_from(value) {
+            Ok(fractional_percent::DenominatorType::Hundred) => Ok(Self::Hundred),
+            Ok(fractional_percent::DenominatorType::TenThousand) => Ok(Self::TenThousand),
+            Ok(fractional_percent::DenominatorType::Million) => Ok(Self::Million),
+            Err(_) => {
+                Err(invalid_config(format!("Unsupported fractional percent denominator: {value}")))
+            }
+        }
+    }
+}
+
+/// Declarative representation of Envoy's `CorsPolicy` message.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
+pub struct CorsPolicyConfig {
+    /// String matchers describing allowed origins. Must not be empty.
+    #[serde(default)]
+    pub allow_origin: Vec<CorsOriginMatcher>,
+    /// HTTP methods allowed for cross-origin requests.
+    #[serde(default)]
+    pub allow_methods: Vec<String>,
+    /// Request headers allowed in cross-origin requests.
+    #[serde(default)]
+    pub allow_headers: Vec<String>,
+    /// Response headers exposed to cross-origin clients.
+    #[serde(default)]
+    pub expose_headers: Vec<String>,
+    /// Max age in seconds for preflight cache. Optional.
+    #[serde(default)]
+    pub max_age: Option<u64>,
+    /// Whether credentials are allowed.
+    #[serde(default)]
+    pub allow_credentials: Option<bool>,
+    /// Percentage of requests where filter is enforced.
+    #[serde(default)]
+    pub filter_enabled: Option<RuntimeFractionalPercentConfig>,
+    /// Percentage of requests where policy is evaluated but not enforced.
+    #[serde(default)]
+    pub shadow_enabled: Option<RuntimeFractionalPercentConfig>,
+    /// Allow requests targeting a more private network.
+    #[serde(default)]
+    pub allow_private_network_access: Option<bool>,
+    /// Forward preflight requests that do not match configured origins.
+    #[serde(default)]
+    pub forward_not_matching_preflights: Option<bool>,
+}
+
+impl CorsPolicyConfig {
+    /// Validate configuration for logical and security rules.
+    pub fn validate(&self) -> Result<(), crate::Error> {
+        if self.allow_origin.is_empty() {
+            return Err(invalid_config(
+                "CORS configuration requires at least one allowed origin matcher",
+            ));
+        }
+
+        for matcher in &self.allow_origin {
+            matcher.validate()?;
+        }
+
+        for method in &self.allow_methods {
+            if method.trim().is_empty() {
+                return Err(invalid_config("CORS allow_methods entries cannot be empty"));
+            }
+            if method.trim() != "*" {
+                Method::from_bytes(method.trim().as_bytes()).map_err(|_| {
+                    invalid_config(format!("Invalid HTTP method in CORS allow_methods: {method}"))
+                })?;
+            }
+        }
+
+        for header in &self.allow_headers {
+            validate_header_name(header, "allow_headers")?;
+        }
+
+        for header in &self.expose_headers {
+            validate_header_name(header, "expose_headers")?;
+        }
+
+        if let Some(true) = self.allow_credentials {
+            let has_wildcard = self.allow_origin.iter().any(|matcher| match matcher {
+                CorsOriginMatcher::Exact { value } => value.trim() == "*",
+                _ => false,
+            });
+
+            if has_wildcard {
+                return Err(invalid_config(
+                    "CORS allow_credentials cannot be true when allow_origin contains '*'",
+                ));
+            }
+        }
+
+        if let Some(max_age) = self.max_age {
+            if max_age > MAX_AGE_LIMIT_SECONDS {
+                return Err(invalid_config(format!(
+                    "CORS max_age must be <= {MAX_AGE_LIMIT_SECONDS} seconds"
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn to_filter_proto(&self) -> Result<FilterCorsPolicy, crate::Error> {
+        self.validate()?;
+
+        let mut policy = FilterCorsPolicy {
+            allow_origin_string_match: self
+                .allow_origin
+                .iter()
+                .map(CorsOriginMatcher::to_proto)
+                .collect::<Result<_, _>>()?,
+            allow_methods: join_header_values(&self.allow_methods),
+            allow_headers: join_header_values(&self.allow_headers),
+            expose_headers: join_header_values(&self.expose_headers),
+            max_age: self.max_age.map(|value| value.to_string()).unwrap_or_default(),
+            ..Default::default()
+        };
+
+        if let Some(allow_credentials) = self.allow_credentials {
+            policy.allow_credentials = Some(BoolValue { value: allow_credentials });
+        }
+
+        if let Some(filter_enabled) = &self.filter_enabled {
+            policy.filter_enabled = Some(filter_enabled.to_proto());
+        }
+
+        if let Some(shadow_enabled) = &self.shadow_enabled {
+            policy.shadow_enabled = Some(shadow_enabled.to_proto());
+        }
+
+        if let Some(allow_private_network_access) = self.allow_private_network_access {
+            policy.allow_private_network_access =
+                Some(BoolValue { value: allow_private_network_access });
+        }
+
+        if let Some(forward) = self.forward_not_matching_preflights {
+            policy.forward_not_matching_preflights = Some(BoolValue { value: forward });
+        }
+
+        Ok(policy)
+    }
+
+    fn to_route_proto(&self) -> Result<RouteCorsPolicy, crate::Error> {
+        self.validate()?;
+
+        let mut policy = RouteCorsPolicy {
+            allow_origin_string_match: self
+                .allow_origin
+                .iter()
+                .map(CorsOriginMatcher::to_proto)
+                .collect::<Result<_, _>>()?,
+            allow_methods: join_header_values(&self.allow_methods),
+            allow_headers: join_header_values(&self.allow_headers),
+            expose_headers: join_header_values(&self.expose_headers),
+            max_age: self.max_age.map(|value| value.to_string()).unwrap_or_default(),
+            ..Default::default()
+        };
+
+        if let Some(allow_credentials) = self.allow_credentials {
+            policy.allow_credentials = Some(BoolValue { value: allow_credentials });
+        }
+
+        if let Some(shadow_enabled) = &self.shadow_enabled {
+            policy.shadow_enabled = Some(shadow_enabled.to_proto());
+        }
+
+        if let Some(allow_private_network_access) = self.allow_private_network_access {
+            policy.allow_private_network_access =
+                Some(BoolValue { value: allow_private_network_access });
+        }
+
+        if let Some(forward) = self.forward_not_matching_preflights {
+            policy.forward_not_matching_preflights = Some(BoolValue { value: forward });
+        }
+
+        if let Some(filter_enabled) = &self.filter_enabled {
+            policy.enabled_specifier =
+                Some(RouteEnabledSpecifier::FilterEnabled(filter_enabled.to_proto()));
+        }
+
+        Ok(policy)
+    }
+
+    fn from_filter_proto(proto: &FilterCorsPolicy) -> Result<Self, crate::Error> {
+        let config = Self {
+            allow_origin: proto
+                .allow_origin_string_match
+                .iter()
+                .map(CorsOriginMatcher::from_proto)
+                .collect::<Result<_, _>>()?,
+            allow_methods: split_header_field(&proto.allow_methods),
+            allow_headers: split_header_field(&proto.allow_headers),
+            expose_headers: split_header_field(&proto.expose_headers),
+            max_age: parse_optional_u64(proto.max_age.as_str())?,
+            allow_credentials: proto.allow_credentials.as_ref().map(|value| value.value),
+            filter_enabled: proto
+                .filter_enabled
+                .as_ref()
+                .map(RuntimeFractionalPercentConfig::from_proto)
+                .transpose()?,
+            shadow_enabled: proto
+                .shadow_enabled
+                .as_ref()
+                .map(RuntimeFractionalPercentConfig::from_proto)
+                .transpose()?,
+            allow_private_network_access: proto
+                .allow_private_network_access
+                .as_ref()
+                .map(|value| value.value),
+            forward_not_matching_preflights: proto
+                .forward_not_matching_preflights
+                .as_ref()
+                .map(|value| value.value),
+        };
+
+        config.validate()?;
+        Ok(config)
+    }
+
+    fn from_route_proto(proto: &RouteCorsPolicy) -> Result<Self, crate::Error> {
+        let config = Self {
+            allow_origin: proto
+                .allow_origin_string_match
+                .iter()
+                .map(CorsOriginMatcher::from_proto)
+                .collect::<Result<_, _>>()?,
+            allow_methods: split_header_field(&proto.allow_methods),
+            allow_headers: split_header_field(&proto.allow_headers),
+            expose_headers: split_header_field(&proto.expose_headers),
+            max_age: parse_optional_u64(proto.max_age.as_str())?,
+            allow_credentials: proto.allow_credentials.as_ref().map(|value| value.value),
+            filter_enabled: proto
+                .enabled_specifier
+                .as_ref()
+                .map(|specifier| match specifier {
+                    RouteEnabledSpecifier::FilterEnabled(value) => value,
+                })
+                .map(RuntimeFractionalPercentConfig::from_proto)
+                .transpose()?,
+            shadow_enabled: proto
+                .shadow_enabled
+                .as_ref()
+                .map(RuntimeFractionalPercentConfig::from_proto)
+                .transpose()?,
+            allow_private_network_access: proto
+                .allow_private_network_access
+                .as_ref()
+                .map(|value| value.value),
+            forward_not_matching_preflights: proto
+                .forward_not_matching_preflights
+                .as_ref()
+                .map(|value| value.value),
+        };
+
+        config.validate()?;
+        Ok(config)
+    }
+}
+
+fn join_header_values(values: &[String]) -> String {
+    values
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn split_header_field(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(|entry| entry.trim())
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| entry.to_string())
+        .collect()
+}
+
+fn parse_optional_u64(value: &str) -> Result<Option<u64>, crate::Error> {
+    if value.trim().is_empty() {
+        return Ok(None);
+    }
+
+    let parsed = value
+        .trim()
+        .parse::<u64>()
+        .map_err(|_| invalid_config(format!("Invalid non-numeric CORS max_age value: {value}")))?;
+
+    if parsed > MAX_AGE_LIMIT_SECONDS {
+        return Err(invalid_config(format!(
+            "CORS max_age must be <= {MAX_AGE_LIMIT_SECONDS} seconds"
+        )));
+    }
+
+    Ok(Some(parsed))
+}
+
+fn validate_header_name(value: &str, field: &str) -> Result<(), crate::Error> {
+    if value.trim().is_empty() {
+        return Err(invalid_config(format!("CORS {field} entries cannot be empty")));
+    }
+
+    if value.trim() != "*" {
+        HeaderName::from_bytes(value.trim().as_bytes()).map_err(|_| {
+            invalid_config(format!("Invalid header name '{value}' in CORS {field}"))
+        })?;
+    }
+
+    Ok(())
+}
+
+/// Filter-level configuration wrapper (typed config on HttpFilter entries).
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CorsConfig {
+    pub policy: CorsPolicyConfig,
+}
+
+impl CorsConfig {
+    /// Convert to filter typed config Any payload.
+    pub fn to_any(&self) -> Result<EnvoyAny, crate::Error> {
+        let policy = self.policy.to_filter_proto()?;
+        Ok(any_from_message(FILTER_CORS_POLICY_TYPE_URL, &policy))
+    }
+
+    /// Build filter configuration from proto payload.
+    pub fn from_proto(proto: &FilterCorsPolicy) -> Result<Self, crate::Error> {
+        Ok(Self { policy: CorsPolicyConfig::from_filter_proto(proto)? })
+    }
+}
+
+/// Optional per-route override for the CORS filter.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CorsPerRouteConfig {
+    pub policy: CorsPolicyConfig,
+}
+
+impl CorsPerRouteConfig {
+    /// Convert to per-route typed config Any payload.
+    pub fn to_any(&self) -> Result<EnvoyAny, crate::Error> {
+        let policy = self.policy.to_route_proto()?;
+        Ok(any_from_message(ROUTE_CORS_POLICY_TYPE_URL, &policy))
+    }
+
+    /// Deserialize per-route configuration from proto.
+    pub fn from_proto(proto: &RouteCorsPolicy) -> Result<Self, crate::Error> {
+        Ok(Self { policy: CorsPolicyConfig::from_route_proto(proto)? })
+    }
+}
+
+/// Empty message used to enable the Envoy CORS filter in the HTTP filter chain.
+pub fn filter_marker_any() -> EnvoyAny {
+    any_from_message(CORS_FILTER_TYPE_URL, &CorsFilter {})
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    fn sample_policy() -> CorsPolicyConfig {
+        CorsPolicyConfig {
+            allow_origin: vec![CorsOriginMatcher::Exact { value: "https://example.com".into() }],
+            allow_methods: vec!["GET".into(), "POST".into()],
+            allow_headers: vec!["x-request-id".into()],
+            expose_headers: vec!["x-response-id".into()],
+            max_age: Some(600),
+            allow_credentials: Some(true),
+            filter_enabled: Some(RuntimeFractionalPercentConfig {
+                runtime_key: Some("cors.enabled".into()),
+                numerator: 50,
+                denominator: FractionalPercentDenominator::Hundred,
+            }),
+            shadow_enabled: Some(RuntimeFractionalPercentConfig {
+                runtime_key: None,
+                numerator: 10,
+                denominator: FractionalPercentDenominator::Hundred,
+            }),
+            allow_private_network_access: Some(false),
+            forward_not_matching_preflights: Some(true),
+        }
+    }
+
+    #[test]
+    fn validate_rejects_empty_origins() {
+        let policy = CorsPolicyConfig { allow_origin: vec![], ..Default::default() };
+        let err = policy.validate().expect_err("validation should fail");
+        assert!(format!("{err}").contains("requires at least one allowed origin"));
+    }
+
+    #[test]
+    fn validate_rejects_wildcard_credentials() {
+        let policy = CorsPolicyConfig {
+            allow_origin: vec![CorsOriginMatcher::Exact { value: "*".into() }],
+            allow_credentials: Some(true),
+            ..Default::default()
+        };
+
+        let err = policy.validate().expect_err("validation should fail");
+        assert!(format!("{err}").contains("allow_credentials"));
+    }
+
+    #[test]
+    fn filter_proto_round_trip() {
+        let config = CorsConfig { policy: sample_policy() };
+        let any = config.to_any().expect("to_any");
+        assert_eq!(any.type_url, FILTER_CORS_POLICY_TYPE_URL);
+
+        let proto = FilterCorsPolicy::decode(any.value.as_slice()).expect("decode proto");
+        let round_tripped = CorsConfig::from_proto(&proto).expect("from proto");
+        assert_eq!(round_tripped.policy.allow_methods, vec!["GET", "POST"]);
+        assert_eq!(round_tripped.policy.max_age, Some(600));
+    }
+
+    #[test]
+    fn route_proto_round_trip() {
+        let config = CorsPerRouteConfig { policy: sample_policy() };
+        let any = config.to_any().expect("to_any");
+        assert_eq!(any.type_url, ROUTE_CORS_POLICY_TYPE_URL);
+
+        let proto = RouteCorsPolicy::decode(any.value.as_slice()).expect("decode proto");
+        let round_tripped = CorsPerRouteConfig::from_proto(&proto).expect("from proto");
+        assert_eq!(round_tripped.policy.allow_headers, vec!["x-request-id"]);
+        assert_eq!(round_tripped.policy.forward_not_matching_preflights, Some(true));
+    }
+
+    #[test]
+    fn header_validation_rejects_invalid_header() {
+        let policy = CorsPolicyConfig {
+            allow_origin: vec![CorsOriginMatcher::Exact { value: "https://example.com".into() }],
+            allow_headers: vec!["invalid header".into()],
+            ..Default::default()
+        };
+
+        let err = policy.validate().expect_err("validation should fail");
+        assert!(format!("{err}").contains("Invalid header name"));
+    }
+
+    #[test]
+    fn filter_marker_any_returns_expected_type_url() {
+        let any = filter_marker_any();
+        assert_eq!(any.type_url, CORS_FILTER_TYPE_URL);
+    }
+}


### PR DESCRIPTION
Support in the HTTP filter registry and document how to configure it.

- add src/xds/filters/http/cors.rs with strongly typed configs for filter- and route-level CORS policies, full validation (origins, methods/headers, credentials, max-age), conversion helpers to envoy-types protos, and thorough unit coverage
- Register the new filter/scoped config in HttpFilterKind/HttpScopedConfig, extend tests to prove Any round-trips and integration behaviour
- depend on the http crate for method/header validation and include a CORS section in docs/filters.md describing fields plus examples