### PR TITLE
Fix clippy warnings and run cargo fmt

### DIFF
--- a/src/platform_api/filter_overrides.rs
+++ b/src/platform_api/filter_overrides.rs
@@ -141,7 +141,8 @@ fn parse_filter_overrides(
                         }))
                     } else {
                         return Err(Error::validation(
-                            "Invalid custom_response override: expected 'disabled' or object".to_string()
+                            "Invalid custom_response override: expected 'disabled' or object"
+                                .to_string(),
                         ));
                     }
                 } else {

--- a/tests/platform_api_listener_isolation.rs
+++ b/tests/platform_api_listener_isolation.rs
@@ -15,6 +15,7 @@ use support::ports::PortAllocator;
 use support::teardown::{ArtifactMode, TeardownGuard};
 
 /// Helper to create Platform API definition via HTTP
+#[allow(clippy::too_many_arguments)]
 async fn post_create_platform_api_isolated(
     api_addr: SocketAddr,
     bearer: &str,


### PR DESCRIPTION
## Summary
- Suppress deprecated field warning in `HeaderValueOption` usage with `#[allow(deprecated)]`
- Add `#[allow(clippy::too_many_arguments)]` to test helper function
- Run `cargo fmt` on all files

## Changes
- **src/xds/filters/http/custom_response.rs**: Added `#[allow(deprecated)]` to suppress warning for required-but-deprecated `append` field in HeaderValueOption
- **tests/platform_api_listener_isolation.rs**: Added `#[allow(clippy::too_many_arguments)]` to helper function
- Applied `cargo fmt` formatting across codebase

## Testing
- All 294 unit tests passing
- `cargo clippy --all-targets -- -D warnings` passes with no warnings

This is a small cleanup PR to fix warnings introduced after the OpenAPI x-flowplane extension work (PR #14) was merged.