### PR TITLE
Fix release packaging and Envoy bootstrap bugs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,13 +64,12 @@ jobs:
       - name: Package
         shell: bash
         run: |
-          cd target/${{ matrix.target }}/release
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            7z a ../../../flowplane-${{ matrix.target }}.zip flowplane.exe flowplane-cli.exe
-          else
-            tar czvf ../../../flowplane-${{ matrix.target }}.tar.gz flowplane flowplane-cli
-          fi
-          cd -
+          mkdir -p flowplane-${{ matrix.target }}
+          cp target/${{ matrix.target }}/release/flowplane flowplane-${{ matrix.target }}/
+          cp target/${{ matrix.target }}/release/flowplane-cli flowplane-${{ matrix.target }}/
+          cp -r migrations flowplane-${{ matrix.target }}/
+          tar czvf flowplane-${{ matrix.target }}.tar.gz flowplane-${{ matrix.target }}/
+          rm -rf flowplane-${{ matrix.target }}
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v1
         with:

--- a/src/api/handlers/api_definitions.rs
+++ b/src/api/handlers/api_definitions.rs
@@ -220,6 +220,7 @@ pub async fn get_bootstrap_handler(
     let xds_addr = state.xds_state.config.bind_address.clone();
     let xds_port = state.xds_state.config.port;
     let node_id = format!("team={}/dp-{}", def.team, uuid::Uuid::new_v4());
+    let node_cluster = format!("{}-cluster", def.team);
 
     let metadata = match scope.as_str() {
         "team" => serde_json::json!({
@@ -238,7 +239,7 @@ pub async fn get_bootstrap_handler(
             "access_log_path": "/tmp/envoy_admin.log",
             "address": { "socket_address": { "address": "127.0.0.1", "port_value": 9901 } }
         },
-        "node": { "id": node_id, "metadata": metadata },
+        "node": { "id": node_id, "cluster": node_cluster, "metadata": metadata },
         "dynamic_resources": {
             "lds_config": { "ads": {} },
             "cds_config": { "ads": {} },


### PR DESCRIPTION
## Summary

Fixes two critical bugs discovered during release testing:

1. **Missing migrations directory in release packages** (Task #18)
   - Updated  packaging step to include  directory alongside binaries
   - Previously caused "Migrations directory not found" error on startup

2. **Envoy bootstrap missing required node.cluster field** (Task #19)
   - Added `node.cluster` field to bootstrap config (format: `{team}-cluster`)
   - Previously caused Envoy startup failure: "ads: node 'id' and 'cluster' are required"

## Changes

- `src/api/handlers/api_definitions.rs`: Added node_cluster generation and included in bootstrap JSON
- `.github/workflows/release.yml`: Updated packaging to include migrations directory in structured tarball

## Testing

- ✅ Local cargo build passes
- ✅ Bootstrap config verified to include both `node.id` and `node.cluster`
- ✅ Envoy starts successfully with generated config
- ✅ Envoy connects to control plane via ADS
- ✅ cargo fmt and clippy pass

## Related Tasks

- Closes Task #18
- Closes Task #19