### PR TITLE
Release v0.2.1: Specwatch Learning Engine Improvements

### DIFF
--- a/.claude/skills/flowplane-api/SKILL.md
+++ b/.claude/skills/flowplane-api/SKILL.md
@@ -411,11 +411,17 @@ Args: {
   "routePattern": "^/api/v1/.*",
   "targetSampleCount": 50,
   "team": "default",
+  "name": "my-api-v1",
   "httpMethods": ["GET", "POST", "PUT", "DELETE"],
-  "autoStart": true
+  "autoStart": true,
+  "autoAggregate": false
 }
 ```
-The `team` parameter is recommended via MCP in dev mode to scope the session to the correct team.
+- `name` — Human-readable session name. If omitted, auto-generated from route_pattern. Used for name-based lookups in all subsequent tools.
+- `autoAggregate` — Enable snapshot mode: periodic aggregation while continuing to collect. Default: false.
+- The `team` parameter is recommended via MCP in dev mode to scope the session to the correct team.
+
+All learning session tools (`cp_get_learning_session`, `cp_stop_learning`, `cp_activate_learning_session`, `cp_delete_learning_session`) accept either session name or UUID for the `id` parameter.
 
 **Step 3b: Verify activation**
 ```
@@ -470,7 +476,13 @@ Report: path, HTTP method, confidence score, sample count. Flag low-confidence s
 Tool: cp_export_schema_openapi
 Args: { "schemaIds": [1, 2], "team": "default", "title": "My API", "version": "1.0.0" }
 ```
-Note: `schemaIds` is camelCase and takes integer IDs (not strings). The `team` parameter is required in dev mode. Output is OpenAPI 3.1.0 with inferred response schemas, header parameters, and content types.
+Note: `schemaIds` is camelCase and takes integer IDs (not strings). The `team` parameter is required in dev mode. Output is OpenAPI 3.1.0 with inferred response schemas, header parameters, and content types. Export uses structural fingerprinting to deduplicate shared schemas as `$ref` references in `components/schemas`.
+
+Or use the CLI:
+```bash
+flowplane schema export --all -o api.yaml
+flowplane learn export --session <name> -o api.yaml
+```
 
 ### 6.5 Blue/Green Deployment
 
@@ -747,12 +759,15 @@ Every MCP tool operation has a CLI equivalent. Use the CLI for scripting, CI/CD,
 
 | MCP Tool | CLI Equivalent |
 |---|---|
-| `cp_create_learning_session` | `flowplane learn start --route-pattern <regex> --target-sample-count <n>` |
+| `cp_create_learning_session` | `flowplane learn start --route-pattern <regex> --target-sample-count <n> [--name <name>] [--auto-aggregate]` |
 | `cp_list_learning_sessions` | `flowplane learn list` |
-| `cp_get_learning_session` | `flowplane learn get <id>` |
-| `cp_delete_learning_session` | `flowplane learn cancel <id> --yes` |
-| `cp_list_aggregated_schemas` | (no CLI equivalent) |
-| `cp_export_schema_openapi` | (no CLI equivalent) |
+| `cp_get_learning_session` | `flowplane learn get <name-or-id>` |
+| `cp_stop_learning` | `flowplane learn stop <name-or-id>` |
+| `cp_delete_learning_session` | `flowplane learn cancel <name-or-id> --yes` |
+| `cp_list_aggregated_schemas` | `flowplane schema list [--min-confidence N] [--session <name>] [--path <path>] [--method <method>]` |
+| `cp_get_aggregated_schema` | `flowplane schema get <id>` |
+| `cp_export_schema_openapi` | `flowplane schema export --id 1,2,3` or `flowplane schema export --all` |
+| (all schemas shortcut) | `flowplane learn export [--session <name>]` |
 
 ### Secrets
 

--- a/.claude/skills/flowplane-api/references/mcp-tools.md
+++ b/.claude/skills/flowplane-api/references/mcp-tools.md
@@ -106,11 +106,11 @@ All 64 MCP tools grouped by category. Use via `tools/call` on the `/api/v1/mcp` 
 | Tool | Description | Required Params | Optional Params |
 |------|-------------|----------------|-----------------|
 | `cp_list_learning_sessions` | List learning sessions | — | `status` (enum: pending/active/completing/completed/cancelled/failed), `limit`, `offset` |
-| `cp_get_learning_session` | Get learning session details | `id` (string, UUID) | — |
-| `cp_create_learning_session` | Create learning session | `routePattern` (string), `targetSampleCount` (int) | `clusterName` (string), `httpMethods` (string array), `autoStart` (bool, default true), `autoAggregate` (bool, default false) |
-| `cp_activate_learning_session` | Activate a pending session | `id` (string, UUID) | — |
-| `cp_stop_learning` | Stop active session, trigger final aggregation | `id` (string, UUID) | — |
-| `cp_delete_learning_session` | Cancel/delete a session | `id` (string, UUID) | — |
+| `cp_get_learning_session` | Get learning session details | `id` (string, name or UUID) | — |
+| `cp_create_learning_session` | Create learning session | `routePattern` (string), `targetSampleCount` (int) | `name` (string), `clusterName` (string), `httpMethods` (string array), `autoStart` (bool, default true), `autoAggregate` (bool, default false) |
+| `cp_activate_learning_session` | Activate a pending session | `id` (string, name or UUID) | — |
+| `cp_stop_learning` | Stop active session, trigger final aggregation | `id` (string, name or UUID) | — |
+| `cp_delete_learning_session` | Cancel/delete a session | `id` (string, name or UUID) | — |
 
 ## Schema Tools (3)
 

--- a/.claude/skills/flowplane-api/references/mcp-tools.md
+++ b/.claude/skills/flowplane-api/references/mcp-tools.md
@@ -101,14 +101,15 @@ All 64 MCP tools grouped by category. Use via `tools/call` on the `/api/v1/mcp` 
 | `cp_update_dataplane` | Update dataplane config | `team` (string), `name` (string) | `gatewayHost` (string), `description` (string) |
 | `cp_delete_dataplane` | Delete a dataplane | `team` (string), `name` (string) | — |
 
-## Learning Session Tools (5)
+## Learning Session Tools (6)
 
 | Tool | Description | Required Params | Optional Params |
 |------|-------------|----------------|-----------------|
 | `cp_list_learning_sessions` | List learning sessions | — | `status` (enum: pending/active/completing/completed/cancelled/failed), `limit`, `offset` |
 | `cp_get_learning_session` | Get learning session details | `id` (string, UUID) | — |
-| `cp_create_learning_session` | Create learning session | `routePattern` (string), `targetSampleCount` (int) | `clusterName` (string), `httpMethods` (string array), `autoStart` (bool, default true) |
+| `cp_create_learning_session` | Create learning session | `routePattern` (string), `targetSampleCount` (int) | `clusterName` (string), `httpMethods` (string array), `autoStart` (bool, default true), `autoAggregate` (bool, default false) |
 | `cp_activate_learning_session` | Activate a pending session | `id` (string, UUID) | — |
+| `cp_stop_learning` | Stop active session, trigger final aggregation | `id` (string, UUID) | — |
 | `cp_delete_learning_session` | Cancel/delete a session | `id` (string, UUID) | — |
 
 ## Schema Tools (3)
@@ -117,7 +118,7 @@ All 64 MCP tools grouped by category. Use via `tools/call` on the `/api/v1/mcp` 
 |------|-------------|----------------|-----------------|
 | `cp_list_aggregated_schemas` | List discovered API schemas | — | `path` (string), `httpMethod` (enum), `minConfidence` (float 0-1), `latestOnly` (bool), `limit`, `offset` |
 | `cp_get_aggregated_schema` | Get schema details | `id` (int) | — |
-| `cp_export_schema_openapi` | Export schemas as OpenAPI 3.1 | `schemaIds` (int array) | `title` (string), `version` (string), `description` (string), `includeMetadata` (bool) |
+| `cp_export_schema_openapi` | Export schemas as OpenAPI 3.1 (with domain model `$ref` dedup) | `schemaIds` (int array) | `title` (string), `version` (string), `description` (string), `includeMetadata` (bool) |
 
 ## OpenAPI Import Tools (2)
 

--- a/.claude/skills/flowplane-cli/SKILL.md
+++ b/.claude/skills/flowplane-cli/SKILL.md
@@ -234,17 +234,27 @@ flowplane import openapi <FILE> [--name <NAME>] [--port <PORT>]
 Start a learning session to record API traffic. Sessions auto-activate by default and begin collecting samples immediately.
 ```bash
 flowplane learn start --route-pattern <REGEX> --target-sample-count <N> \
+  [--name <NAME>] [--auto-aggregate] \
   [--cluster-name <NAME>] [--http-methods GET POST ...] \
   [--max-duration-seconds <N>] [--triggered-by <WHO>] \
   [--deployment-version <VERSION>] [-o json|yaml|table]
 ```
-Default output is JSON. Returns session ID, status, and timestamps.
+- `--name` — Human-readable session name. If omitted, auto-generated from route_pattern.
+- `--auto-aggregate` — Enable snapshot mode: periodic aggregation while continuing to collect samples.
+
+Default output is JSON. Returns session ID, name, status, and timestamps.
 
 Example:
 ```bash
-flowplane learn start --route-pattern '^/.*' --target-sample-count 5
+flowplane learn start --route-pattern '^/.*' --target-sample-count 5 --name mockbank-v1
 # Sessions can exceed target (e.g., 200% progress) — all samples in the
 # collection window are captured once target is reached.
+```
+
+### `flowplane learn stop`
+Stop an active learning session. Triggers final aggregation, then completes.
+```bash
+flowplane learn stop <NAME_OR_ID>         # Accepts session name or UUID
 ```
 
 ### `flowplane learn list`
@@ -257,20 +267,64 @@ flowplane learn list --limit 10        # Pagination
 ```
 
 ### `flowplane learn get`
-Get learning session details. Default output is json; use `-o table` for summary.
+Get learning session details. Accepts name or UUID. Default output is json; use `-o table` for summary.
 ```bash
-flowplane learn get <ID>               # Table format
-flowplane learn get <ID> -o json       # Full JSON including timestamps, team, error_message
+flowplane learn get <NAME_OR_ID>               # Table format
+flowplane learn get <NAME_OR_ID> -o json       # Full JSON including timestamps, team, error_message
 ```
 
 ### `flowplane learn cancel`
-Cancel an active learning session. Requires confirmation in interactive mode.
+Cancel an active learning session. Accepts name or UUID. Requires confirmation in interactive mode.
 ```bash
-flowplane learn cancel <ID>            # Prompts y/N (errors if stdin is not a terminal)
-flowplane learn cancel <ID> --yes      # Skip confirmation
-flowplane learn cancel <ID> -y         # Short form
+flowplane learn cancel <NAME_OR_ID>            # Prompts y/N (errors if stdin is not a terminal)
+flowplane learn cancel <NAME_OR_ID> --yes      # Skip confirmation
+flowplane learn cancel <NAME_OR_ID> -y         # Short form
 ```
 In non-interactive mode (piped stdin), cancel without `--yes` returns an error directing you to use `--yes`. Always use `--yes` in scripts.
+
+### `flowplane learn export`
+Convenience shortcut for `flowplane schema export --all`. Exports all schemas as OpenAPI 3.1.
+```bash
+flowplane learn export                                          # All schemas to stdout (YAML)
+flowplane learn export --session mockbank-v1 -o api.yaml        # From specific session
+flowplane learn export --min-confidence 0.7 --title "My API"    # High-confidence only
+```
+Flags: `--session`, `--min-confidence`, `--title`, `--version`, `--description`, `-o` (output file path).
+
+## Schema Management
+
+### `flowplane schema list`
+List discovered API schemas.
+```bash
+flowplane schema list                              # Table view
+flowplane schema list --min-confidence 0.7         # Filter by confidence
+flowplane schema list --session mockbank-v1        # Filter by session name
+flowplane schema list --path /api/users            # Filter by path
+flowplane schema list --method GET                 # Filter by HTTP method
+flowplane schema list --latest-only                # Only latest snapshot per endpoint
+flowplane schema list --limit 20 --offset 0        # Pagination
+flowplane schema list -o json                      # JSON output
+```
+
+### `flowplane schema get`
+Show schema detail by ID.
+```bash
+flowplane schema get <ID>                          # JSON output (default)
+flowplane schema get <ID> -o table                 # Human-readable summary
+flowplane schema get <ID> -o yaml                  # YAML output
+```
+
+### `flowplane schema export`
+Export schemas as OpenAPI 3.1. Auto-detects format from file extension (`.yaml`/`.json`). Stdout defaults to YAML.
+```bash
+flowplane schema export --all                      # All schemas to stdout (YAML)
+flowplane schema export --all -o api.yaml          # Write to file
+flowplane schema export --id 1,2,3 -o api.json     # Specific schemas, JSON format
+flowplane schema export --all --min-confidence 0.7 # High-confidence only
+flowplane schema export --session mockbank-v1 --all -o api.yaml  # From specific session
+flowplane schema export --all --title "My API" --version "1.0.0" --description "Generated from traffic"
+```
+Flags: `--id` (comma-separated IDs), `--all`, `--min-confidence`, `--session`, `--title`, `--version`, `--description`, `-o` (output file path).
 
 ## Secrets
 

--- a/.claude/skills/flowplane-cli/references/commands.md
+++ b/.claude/skills/flowplane-cli/references/commands.md
@@ -345,6 +345,9 @@ flowplane import openapi ./other-api.yaml --name other --port 10002
 # Start a learning session (auto-activates, begins collecting immediately)
 flowplane learn start --route-pattern '^/api/.*' --target-sample-count 50
 
+# Auto-aggregate mode: periodic snapshots while continuing to collect
+flowplane learn start --route-pattern '^/api/.*' --target-sample-count 50 --auto-aggregate
+
 # Optional filters: cluster, HTTP methods, duration limit
 flowplane learn start --route-pattern '^/get.*' --target-sample-count 100 \
   --cluster-name my-cluster --http-methods GET POST --max-duration-seconds 3600
@@ -355,7 +358,10 @@ flowplane learn list -o json                      # JSON with all fields
 flowplane learn get <session-id>                  # Single session details
 flowplane learn get <session-id> -o json          # Full JSON output
 
-# Cancel (always use --yes in scripts — without it, non-interactive stdin = silent no-op)
+# Stop session (triggers final aggregation, then completes)
+flowplane learn stop <session-id>
+
+# Cancel (discards without aggregating — use --yes in scripts)
 flowplane learn cancel <session-id> --yes
 ```
 

--- a/.claude/skills/flowplane-cli/references/commands.md
+++ b/.claude/skills/flowplane-cli/references/commands.md
@@ -342,36 +342,63 @@ flowplane import openapi ./other-api.yaml --name other --port 10002
 
 ### Learn API from traffic
 ```bash
-# Start a learning session (auto-activates, begins collecting immediately)
-flowplane learn start --route-pattern '^/api/.*' --target-sample-count 50
+# Start a named learning session (auto-activates, begins collecting immediately)
+flowplane learn start --route-pattern '^/api/.*' --target-sample-count 50 --name my-api-v1
 
 # Auto-aggregate mode: periodic snapshots while continuing to collect
-flowplane learn start --route-pattern '^/api/.*' --target-sample-count 50 --auto-aggregate
+flowplane learn start --route-pattern '^/api/.*' --target-sample-count 50 --name my-api-v1 --auto-aggregate
 
 # Optional filters: cluster, HTTP methods, duration limit
 flowplane learn start --route-pattern '^/get.*' --target-sample-count 100 \
-  --cluster-name my-cluster --http-methods GET POST --max-duration-seconds 3600
+  --name httpbin-learn --cluster-name my-cluster --http-methods GET POST
 
-# Monitor sessions
+# Monitor sessions (all accept name or UUID)
 flowplane learn list                              # Table view
 flowplane learn list -o json                      # JSON with all fields
-flowplane learn get <session-id>                  # Single session details
-flowplane learn get <session-id> -o json          # Full JSON output
+flowplane learn get my-api-v1                     # By name
+flowplane learn get <session-id> -o json          # By UUID
 
 # Stop session (triggers final aggregation, then completes)
-flowplane learn stop <session-id>
+flowplane learn stop my-api-v1                    # By name or UUID
 
 # Cancel (discards without aggregating — use --yes in scripts)
-flowplane learn cancel <session-id> --yes
+flowplane learn cancel my-api-v1 --yes
+
+# Export schemas as OpenAPI
+flowplane learn export --session my-api-v1 -o api.yaml
+flowplane schema export --all -o api.yaml
 ```
 
 Full workflow:
 ```bash
 flowplane expose http://httpbin:80 --name httpbin        # 1. Expose service
-flowplane learn start --route-pattern '^/.*' --target-sample-count 5  # 2. Start learning
+flowplane learn start --route-pattern '^/.*' --target-sample-count 5 --name httpbin-learn  # 2. Start learning
 for i in $(seq 1 10); do curl -s http://localhost:10001/get > /dev/null; done  # 3. Traffic
-flowplane learn get <session-id> -o json                 # 4. Check completion
-# Schemas available via MCP: cp_list_aggregated_schemas, cp_export_schema_openapi
+flowplane learn get httpbin-learn -o json                # 4. Check completion
+flowplane schema export --all -o api.yaml                # 5. Export OpenAPI
+```
+
+### Manage schemas
+```bash
+# List discovered schemas
+flowplane schema list                              # Table view
+flowplane schema list --min-confidence 0.7         # Filter by confidence
+flowplane schema list --session mockbank-v1        # Filter by session
+
+# View schema details
+flowplane schema get <ID>                          # JSON output
+flowplane schema get <ID> -o table                 # Human-readable summary
+
+# Export as OpenAPI 3.1
+flowplane schema export --all                      # All schemas to stdout (YAML)
+flowplane schema export --all -o api.yaml          # Write to file
+flowplane schema export --id 1,2,3 -o api.json     # Specific schemas, JSON format
+flowplane schema export --all --min-confidence 0.7 # High-confidence only
+flowplane schema export --session mockbank-v1 --all -o api.yaml  # From specific session
+
+# Convenience shortcut
+flowplane learn export                             # Same as schema export --all
+flowplane learn export --session mockbank-v1 -o api.yaml
 ```
 
 ### Manage secrets
@@ -407,6 +434,7 @@ flowplane cluster list  # now scoped to engineering team
 | expose/unexpose | `src/cli/expose.rs` |
 | import openapi | `src/cli/import.rs` |
 | learn (sessions) | `src/cli/learn.rs` |
+| schema list/get/export | `src/cli/schema.rs` |
 | secret CRUD | `src/cli/secrets.rs` |
 | config management | `src/cli/config_cmd.rs` |
 | team CRUD | `src/cli/teams.rs` |

--- a/.claude/skills/flowplane-dev/references/module-map.md
+++ b/.claude/skills/flowplane-dev/references/module-map.md
@@ -46,6 +46,7 @@ All `flowplane` CLI subcommands defined with clap.
 | `expose.rs` | Quick service exposure |
 | `import.rs` | OpenAPI import |
 | `learn.rs` | Learning sessions |
+| `schema.rs` | Schema list/get/export |
 | `status.rs` | Health checks, doctor |
 | `config.rs` | CLI config management |
 
@@ -98,7 +99,7 @@ MCP protocol implementation and tool definitions.
 | `filters.rs` | control_plane | `cp_create_filter`, `cp_list_filters`, `cp_get_filter`, `cp_delete_filter`, `cp_attach_filter`, `cp_detach_filter`, `cp_list_filter_attachments` |
 | `filter_types.rs` | control_plane | `cp_list_filter_types`, `cp_get_filter_type` |
 | `dataplanes.rs` | control_plane | `cp_list_dataplanes`, `cp_get_dataplane` |
-| `learning.rs` | control_plane | `cp_create_learning_session`, `cp_get_learning_session`, `cp_list_learning_sessions`, `cp_delete_learning_session`, `cp_activate_learning_session` |
+| `learning.rs` | control_plane | `cp_create_learning_session`, `cp_get_learning_session`, `cp_list_learning_sessions`, `cp_delete_learning_session`, `cp_activate_learning_session`, `cp_stop_learning` |
 | `schemas.rs` | control_plane | `cp_list_aggregated_schemas`, `cp_export_schema_openapi` |
 | `openapi.rs` | control_plane | OpenAPI import tools |
 | `ops_agent.rs` | control_plane | `ops_trace_request`, `ops_topology`, `ops_config_validate`, `ops_audit_query`, `ops_xds_delivery_status`, `ops_nack_history` |

--- a/.claude/skills/flowplane-dev/references/module-map.md
+++ b/.claude/skills/flowplane-dev/references/module-map.md
@@ -12,6 +12,9 @@ HTTP handlers, middleware, and route definitions for the REST API.
 | `handlers/organizations.rs` | Org, team, user, agent CRUD |
 | `handlers/bootstrap.rs` | First-time setup endpoints |
 | `handlers/dataplane.rs` | Dataplane operations |
+| `handlers/learning_sessions.rs` | Learning session CRUD + stop endpoint |
+| `handlers/aggregated_schemas.rs` | Schema listing, export, OpenAPI generation (`build_unified_openapi_spec()`) |
+| `handlers/openapi_utils.rs` | Schema-to-OpenAPI conversion helpers |
 | `error.rs` | `ApiError` type, error response formatting |
 | `rate_limit.rs` | Request rate limiting |
 
@@ -117,6 +120,8 @@ Bridges REST, MCP, and CLI into a single operation interface. All three surfaces
 | `filters.rs` | `FilterOperations` — CRUD + attach/detach |
 | `virtual_hosts.rs` | `VirtualHostOperations` — CRUD |
 | `dataplanes.rs` | `DataplaneOperations` — CRUD |
+| `learning.rs` | `LearningSessionOperations` — create, list, get, delete, stop |
+| `schemas.rs` | `AggregatedSchemaOperations` — list, get with team filtering |
 | `auth.rs` | Auth context resolution |
 | `error.rs` | Unified error handling |
 
@@ -163,8 +168,8 @@ xDS protocol implementation — translates domain entities to Envoy protobuf res
 | `src/errors/` | Error types (`Error`, `Result`) |
 | `src/internal_api/` | Internal API endpoints |
 | `src/observability/` | OpenTelemetry tracing, Prometheus metrics |
-| `src/openapi/` | OpenAPI spec generation |
-| `src/schema/` | Schema inference from traffic |
+| `src/openapi/` | OpenAPI spec import + domain model dedup (`domain_models.rs`) |
+| `src/schema/` | Schema inference from traffic (`inference.rs`: enum detection, observed_values) |
 | `src/secrets/` | Vault integration for secret management |
 | `src/utils/` | Shared utilities |
 | `src/validation/` | Input validation |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+## v0.2.1 (2026-04-06)
+
+### Schema Learning Engine
+
+- **Enum detection** — String fields with low cardinality (<=10 unique values, >=10 samples) are automatically promoted to enums in the learned schema. Raw observed values are never exposed in public API output.
+- **Path normalization** — Dynamic URL segments are replaced with contextually named parameters: `/users/123` becomes `/users/{userId}`, `/orders/2024-01-15` becomes `/orders/{orderDate}`. 47 protected keywords and 141 plural-to-singular mappings.
+- **PATCH-aware requirements** — PATCH request bodies no longer mark fields as required (partial update semantics). Response schemas are unaffected.
+- **Confidence scoring** — Improved edge case handling for oneOf schemas and empty field sets, aligned with specwatch reference implementation.
+- **Domain model deduplication** — Structurally identical schemas across endpoints are extracted to `components/schemas` with `$ref` references in the OpenAPI export. Name derivation from path segments (e.g., `/customers/{id}` → `Customer`).
+- **Auto-aggregate mode** — Learning sessions can periodically aggregate schemas while continuing to collect samples. Use `--auto-aggregate` on `learn start` and `learn stop` to trigger final aggregation.
+
+### Named Learning Sessions
+
+- Sessions can be named with `--name` on `learn start`. Auto-generated from route pattern if omitted.
+- All learn subcommands (`get`, `stop`, `cancel`, `export`) accept a session name or UUID.
+- Schema queries can be scoped to a specific session with `--session`.
+
+### Schema CLI
+
+New `flowplane schema` top-level command:
+
+- `flowplane schema list` — list discovered schemas with confidence, sample count, and version
+- `flowplane schema get <ID>` — inspect schema detail including request/response fields, types, and formats
+- `flowplane schema export --all -o api.yaml` — export as OpenAPI 3.1 with domain model deduplication
+- `flowplane learn export` — convenience shortcut for `schema export --all`
+
+### MCP Tools
+
+- **New tool**: `cp_stop_learning` — stop an active session and trigger final aggregation
+- `cp_create_learning_session` — new `name` and `autoAggregate` parameters
+- All learning tools accept session name or UUID for the `id` parameter
+
+### Database Migrations
+
+- `20260406000001_auto_aggregate_support.sql` — adds `auto_aggregate`, `snapshot_count` to `learning_sessions`; adds `session_id`, `snapshot_number` to `aggregated_api_schemas`
+- `20260406000002_add_learning_session_name.sql` — adds `name` column to `learning_sessions` with partial unique index
+
+### UI
+
+- Auto-aggregate toggle on session create form
+- Stop Session button (separate from Cancel) on session detail page
+- Session name display in list and detail views
+- Purple "Auto" badge for auto-aggregate sessions
+
+### Documentation
+
+- [Learning Quickstart](docs/learning-quickstart.md) — end-to-end guide for schema learning with MockBank
+- Updated CLI reference, MCP docs, and Getting Started with new commands and tools
+
+## v0.2.0 (2026-03-31)
+
+See [release notes](https://github.com/rajeevramani/flowplane/releases/tag/v0.2.0).
+
+## v0.1.1 (2026-03-15)
+
+See [release notes](https://github.com/rajeevramani/flowplane/releases/tag/v0.1.1).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ graph LR
 - **xDS control plane** — ADS, LDS, RDS, CDS, EDS, and SDS over gRPC
 - **10 HTTP filters** — JWT auth, OAuth2, CORS, rate limiting, header mutation, ext authz, RBAC, compression, custom response, MCP
 - **68 MCP tools** — AI agents can deploy and manage gateway configuration end-to-end
-- **API schema learning** — capture live traffic, infer JSON schemas, export as OpenAPI
+- **API schema learning** — capture live traffic, infer JSON schemas, export as OpenAPI with enum detection, path normalization, and domain model dedup
 - **Multi-tenant** — org/team hierarchy with Zitadel RBAC
 - **REST API + Web UI** — JSON API and SvelteKit dashboard on port 8080
 
@@ -53,6 +53,7 @@ graph LR
 | Topic | Link |
 |-------|------|
 | Full walkthrough | [Getting Started](docs/getting-started.md) |
+| Learn APIs from traffic | [Learning Quickstart](docs/learning-quickstart.md) |
 | CLI commands | [CLI Reference](docs/cli-reference.md) |
 | Filter configuration | [Filters](docs/filters.md) |
 | MCP tools | [MCP Integration](docs/mcp.md) |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ graph LR
 
 - **xDS control plane** — ADS, LDS, RDS, CDS, EDS, and SDS over gRPC
 - **10 HTTP filters** — JWT auth, OAuth2, CORS, rate limiting, header mutation, ext authz, RBAC, compression, custom response, MCP
-- **68 MCP tools** — AI agents can deploy and manage gateway configuration end-to-end
+- **69 MCP tools** — AI agents can deploy and manage gateway configuration end-to-end
 - **API schema learning** — capture live traffic, infer JSON schemas, export as OpenAPI with enum detection, path normalization, and domain model dedup
 - **Multi-tenant** — org/team hierarchy with Zitadel RBAC
 - **REST API + Web UI** — JSON API and SvelteKit dashboard on port 8080
@@ -76,7 +76,7 @@ This repo ships with [Claude Code](https://claude.ai/code) skills in `.claude/sk
 
 | Skill | Covers |
 |-------|--------|
-| `flowplane-api` | 68 MCP tools, learning sessions, filter attach/detach, routing workflows |
+| `flowplane-api` | 69 MCP tools, learning sessions, filter attach/detach, routing workflows |
 | `flowplane-ops` | Boot recipes, 6 diagnostic MCP tools, troubleshooting playbooks |
 | `flowplane-secrets` | SDS secrets, encryption keys, filter integration |
 | `create-filter-test` | Generate test fixtures for filter configurations |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -688,6 +688,7 @@ Start a learning session to record API traffic and infer schemas.
 
 ```
 flowplane learn start --route-pattern <REGEX> --target-sample-count <N> \
+  [--name <NAME>] [--auto-aggregate] \
   [--cluster-name <NAME>] [--http-methods <M>...] \
   [--max-duration-seconds <N>] [--triggered-by <WHO>] \
   [--deployment-version <VER>] [-o json|yaml|table]
@@ -697,6 +698,8 @@ flowplane learn start --route-pattern <REGEX> --target-sample-count <N> \
 |---|---|---|
 | `--route-pattern` | Yes | Regex to match request paths |
 | `--target-sample-count` | Yes | Number of samples to collect |
+| `--name` | No | Human-readable session name. Auto-generated from route pattern if omitted |
+| `--auto-aggregate` | No | Enable snapshot mode: aggregate every N samples and keep collecting |
 | `--cluster-name` | No | Filter to a specific cluster |
 | `--http-methods` | No | Filter by HTTP methods (space-separated) |
 | `--max-duration-seconds` | No | Max session duration |
@@ -706,9 +709,39 @@ flowplane learn start --route-pattern <REGEX> --target-sample-count <N> \
 Sessions auto-activate and begin collecting immediately. They can collect more samples than the target.
 
 ```bash
-flowplane learn start --route-pattern '^/api/.*' --target-sample-count 50
-flowplane learn start --route-pattern '^/get.*' --target-sample-count 100 \
-  --cluster-name my-cluster --http-methods GET POST
+flowplane learn start --name my-api --route-pattern '^/api/.*' --target-sample-count 50
+flowplane learn start --name continuous --route-pattern '^/api/.*' --target-sample-count 100 --auto-aggregate
+```
+
+### flowplane learn stop
+
+Stop an active session and trigger final schema aggregation. Useful for auto-aggregate sessions that run indefinitely.
+
+```
+flowplane learn stop <NAME_OR_ID> [-o json|yaml|table]
+```
+
+All learn subcommands accept a session **name** or **UUID**.
+
+```bash
+flowplane learn stop my-api
+```
+
+### flowplane learn export
+
+Export schemas from learning sessions as OpenAPI 3.1. Convenience shortcut for `flowplane schema export --all`.
+
+```
+flowplane learn export [--session <NAME_OR_ID>] [--min-confidence <FLOAT>] \
+  [--title <TITLE>] [--version <VER>] [--description <DESC>] [-o <FILE>]
+```
+
+Output goes to stdout as YAML by default. Use `-o file.yaml` or `-o file.json` to write to a file (format auto-detected from extension).
+
+```bash
+flowplane learn export                                    # all schemas, YAML to stdout
+flowplane learn export --session my-api -o api.yaml       # from specific session
+flowplane learn export --min-confidence 0.7 -o api.json   # high-confidence only
 ```
 
 ### flowplane learn list
@@ -727,23 +760,85 @@ flowplane learn list --status active
 ### flowplane learn get
 
 ```
-flowplane learn get <SESSION_ID> [-o json|yaml|table]
+flowplane learn get <NAME_OR_ID> [-o json|yaml|table]
 ```
 
 ```bash
-flowplane learn get <session-id> -o json
+flowplane learn get my-api -o json
 ```
 
 ### flowplane learn cancel
 
 ```
-flowplane learn cancel <SESSION_ID> [--yes]
+flowplane learn cancel <NAME_OR_ID> [--yes]
 ```
 
 > ⚠️ In non-interactive mode (piped stdin), cancel without `--yes` silently does nothing. Always use `--yes` in scripts.
 
 ```bash
-flowplane learn cancel <session-id> --yes
+flowplane learn cancel my-api --yes
+```
+
+---
+
+## Schemas
+
+List, inspect, and export API schemas discovered by learning sessions.
+
+### flowplane schema list
+
+```
+flowplane schema list [--min-confidence <FLOAT>] [--path <PATTERN>] [--method <METHOD>] \
+  [--session <NAME_OR_ID>] [--latest-only] [--limit N] [--offset N] [-o json|yaml|table]
+```
+
+```bash
+flowplane schema list                              # table view
+flowplane schema list --min-confidence 0.7         # high-confidence only
+flowplane schema list --session my-api             # from specific session
+```
+
+### flowplane schema get
+
+```
+flowplane schema get <ID> [-o json|yaml|table]
+```
+
+Table output shows field names, types, formats, and required markers.
+
+```bash
+flowplane schema get 1 -o table
+flowplane schema get 1 -o json
+```
+
+### flowplane schema export
+
+Export schemas as an OpenAPI 3.1 specification. Shared schemas are deduplicated into `components/schemas` with `$ref` references.
+
+```
+flowplane schema export (--all | --id <ID,ID,...>) \
+  [--session <NAME_OR_ID>] [--min-confidence <FLOAT>] \
+  [--title <TITLE>] [--version <VER>] [--description <DESC>] [-o <FILE>]
+```
+
+| Flag | Description |
+|---|---|
+| `--all` | Export all latest schemas |
+| `--id 1,2,3` | Export specific schema IDs (comma-separated) |
+| `--session` | Filter to schemas from a specific learning session |
+| `--min-confidence` | Only export schemas above this confidence threshold |
+| `--title` | API title in the spec (default: "Learned API") |
+| `--version` | API version (default: "1.0.0") |
+| `-o <FILE>` | Write to file. Format auto-detected: `.yaml`/`.yml` = YAML, `.json` = JSON. Stdout defaults to YAML |
+
+Without `--id` or `--all`, shows available schemas and exits with a helpful error.
+
+```bash
+flowplane schema export --all                               # YAML to stdout
+flowplane schema export --all -o api.yaml                   # write to file
+flowplane schema export --id 1,2,3 -o subset.json           # specific schemas
+flowplane schema export --session my-api --all -o api.yaml  # from specific session
+flowplane schema export --all --min-confidence 0.7          # high-confidence only
 ```
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -293,7 +293,7 @@ Browse the full REST API at http://localhost:8080/swagger-ui/.
 
 ### MCP connection
 
-Flowplane exposes 68 MCP tools at `POST /api/v1/mcp`. To connect from Claude Code or another MCP client:
+Flowplane exposes 69 MCP tools at `POST /api/v1/mcp`. To connect from Claude Code or another MCP client:
 
 ```bash
 # Get your dev token
@@ -346,6 +346,7 @@ flowplane auth login              # Opens browser-based PKCE flow
 
 ## Next steps
 
+- [Learning Quickstart](learning-quickstart.md) — discover API schemas from live traffic and export as OpenAPI
 - [CLI Reference](cli-reference.md) — every command, flag, and example
 - [Filters](filters.md) — 10 filter types: rate limiting, JWT auth, CORS, OAuth2, and more
 - [MCP Server](mcp.md) — full tool catalog for AI-driven gateway management

--- a/docs/learning-quickstart.md
+++ b/docs/learning-quickstart.md
@@ -1,0 +1,188 @@
+# Learning Quickstart
+
+Discover API schemas from live traffic and export as OpenAPI — zero source code or annotations required.
+
+## Prerequisites
+
+Complete the [Quickstart](quickstart.md) first (Flowplane + Envoy running in dev mode).
+
+## 1. Start a backend
+
+Start the MockBank demo API:
+
+```bash
+docker compose -f docker-compose-mockbackend.yml up -d
+flowplane expose http://mockbank-api:3000 --name mockbank --path /v2/api
+```
+
+```
+Exposed 'mockbank' -> http://mockbank-api:3000
+  Port:   10001
+  Paths:  /v2/api
+```
+
+Verify: `curl http://localhost:10001/v2/api/customers` should return JSON.
+
+## 2. Start a learning session
+
+```bash
+flowplane learn start \
+  --name mockbank-v1 \
+  --route-pattern '^/v2/.*' \
+  --target-sample-count 50
+```
+
+The session activates immediately and begins observing traffic through Envoy.
+
+## 3. Send traffic
+
+Send varied requests through the gateway — different endpoints, methods, and payloads:
+
+```bash
+# Collection GETs
+for ep in customers accounts transactions cards loans transfers; do
+  curl -s http://localhost:10001/v2/api/$ep > /dev/null
+done
+
+# Individual resource GETs (triggers path normalization)
+for id in 1 2 3; do
+  curl -s http://localhost:10001/v2/api/customers/$id > /dev/null
+  curl -s http://localhost:10001/v2/api/accounts/$id > /dev/null
+done
+
+# Writes
+curl -s -X POST http://localhost:10001/v2/api/customers \
+  -H "Content-Type: application/json" \
+  -d '{"firstName":"Test","lastName":"User","email":"test@example.com","status":"active"}' > /dev/null
+
+curl -s -X PATCH http://localhost:10001/v2/api/customers/2 \
+  -H "Content-Type: application/json" \
+  -d '{"status":"inactive"}' > /dev/null
+
+# Repeat to build up sample count
+for i in $(seq 1 5); do
+  for ep in customers accounts transactions cards loans transfers notifications branches atms; do
+    curl -s http://localhost:10001/v2/api/$ep > /dev/null
+  done
+done
+```
+
+## 4. Check progress
+
+```bash
+flowplane learn get mockbank-v1
+```
+
+```
+ID                                     Name          Status       Samples  Target   Progress
+---------------------------------------------------------------------------------------------
+a1b2c3d4-...                           mockbank-v1   completed    52       50       104.0%
+```
+
+When samples reach the target, the session completes automatically and schemas are aggregated.
+
+## 5. List discovered schemas
+
+```bash
+flowplane schema list
+```
+
+```
+   ID  Method  Path                                          Confidence  Samples Version
+----------------------------------------------------------------------------------------
+    1  GET     /v2/api/accounts                                  69.5%        5       1
+    2  GET     /v2/api/customers                                 69.5%        5       1
+    3  GET     /v2/api/customers/{customerId}                    66.0%        3       1
+    4  POST    /v2/api/customers                                 60.0%        1       1
+    5  PATCH   /v2/api/customers/{customerId}                    60.0%        1       1
+   ...
+```
+
+Note the contextual parameter naming: `/customers/{customerId}`, not `/customers/{id}`.
+
+## 6. Inspect a schema
+
+```bash
+flowplane schema get 3 -o table
+```
+
+```
+Schema #3
+--------------------------------------------------
+  Path:            /v2/api/customers/{customerId}
+  Method:          GET
+  Confidence:      66.0%
+  Samples:         3
+
+  Response 200:
+      id: integer
+      firstName: string
+      lastName: string
+      email: string (email)
+      dateOfBirth: string (date)
+      status: string
+      address: object
+      ...
+```
+
+## 7. Export as OpenAPI
+
+```bash
+# All schemas to stdout (YAML)
+flowplane schema export --all
+
+# To a file
+flowplane schema export --all -o mockbank-api.yaml
+
+# Only high-confidence schemas
+flowplane schema export --all --min-confidence 0.7 -o api.yaml
+
+# From a specific session
+flowplane learn export --session mockbank-v1 -o mockbank-v1.yaml
+
+# Specific schemas by ID
+flowplane schema export --id 1,2,3 -o subset.json
+```
+
+The exported spec includes:
+- **OpenAPI 3.1** with paths, request/response schemas, and status codes
+- **Domain model deduplication** — shared schemas as `$ref` in `components/schemas`
+- **Format detection** — `date`, `email`, `uuid`, `ipv4`, `uri` annotations
+- **Required fields** — inferred from field presence across samples (PATCH bodies excluded)
+
+## What the learning engine detects
+
+| Feature | How it works |
+|---------|-------------|
+| **Types** | JSON type inference: string, integer, number, boolean, object, array, null |
+| **Formats** | String pattern detection: email, UUID, date, datetime, IPv4, URI |
+| **Required fields** | Fields present in 100% of samples marked required (except PATCH bodies) |
+| **Path parameters** | Dynamic segments named from context: `{userId}`, `{orderDate}`, `{productCode}` |
+| **Enum values** | Low-cardinality strings (≤10 unique, ≥10 samples) promoted to enums |
+| **Confidence** | Weighted score: sample size (40%) + field consistency (40%) + type stability (20%) |
+| **Domain models** | Structurally identical schemas across endpoints → shared `$ref` |
+| **Breaking changes** | Compared against previous schema version when re-learning |
+
+## Auto-aggregate mode
+
+For long-running observation, use auto-aggregate to get periodic snapshots:
+
+```bash
+flowplane learn start \
+  --name mockbank-continuous \
+  --route-pattern '^/v2/.*' \
+  --target-sample-count 100 \
+  --auto-aggregate
+```
+
+The session aggregates every 100 samples and keeps collecting. Stop when ready:
+
+```bash
+flowplane learn stop mockbank-continuous
+```
+
+## Next steps
+
+- [MCP Tools](mcp.md) — use `cp_create_learning_session` and `cp_export_schema_openapi` from AI agents
+- [Getting Started](getting-started.md) — full gateway setup walkthrough
+- [Filters](filters.md) — add auth, rate limiting, CORS to your learned endpoints

--- a/docs/learning-quickstart.md
+++ b/docs/learning-quickstart.md
@@ -1,27 +1,38 @@
 # Learning Quickstart
 
-Discover API schemas from live traffic and export as OpenAPI — zero source code or annotations required.
+Discover API schemas from live traffic and export as OpenAPI — zero source code or annotations required. Point it at any HTTP backend, send traffic through the gateway, and get a spec.
 
 ## Prerequisites
 
 Complete the [Quickstart](quickstart.md) first (Flowplane + Envoy running in dev mode).
 
-## 1. Start a backend
+## 1. Expose your backend
 
-Start the MockBank demo API:
+Expose any HTTP service through Envoy. The learning engine observes traffic as it flows through the gateway.
+
+```bash
+flowplane expose http://<your-service>:<port> --name my-api --path /api
+```
+
+**Using your own backend:**
+
+```bash
+# Example: a service running on port 3000
+flowplane expose http://host.docker.internal:3000 --name my-api --path /api
+```
+
+Use `host.docker.internal` to reach services running on the host machine. For Docker services on the same network, use the container/service name directly.
+
+**Using the included MockBank demo** (no setup required):
 
 ```bash
 docker compose -f docker-compose-mockbackend.yml up -d
 flowplane expose http://mockbank-api:3000 --name mockbank --path /v2/api
 ```
 
-```
-Exposed 'mockbank' -> http://mockbank-api:3000
-  Port:   10001
-  Paths:  /v2/api
-```
+This guide uses MockBank for examples, but every command works with any backend.
 
-Verify: `curl http://localhost:10001/v2/api/customers` should return JSON.
+Verify traffic flows: `curl http://localhost:10001/v2/api/customers` (or your endpoint).
 
 ## 2. Start a learning session
 
@@ -180,6 +191,45 @@ The session aggregates every 100 samples and keeps collecting. Stop when ready:
 ```bash
 flowplane learn stop mockbank-continuous
 ```
+
+## CLI Reference
+
+### Learning sessions
+
+| Command | Description |
+|---------|-------------|
+| `flowplane learn start --name <N> --route-pattern <R> --target-sample-count <C>` | Create and activate a session |
+| `flowplane learn list` | List all sessions |
+| `flowplane learn get <name-or-id>` | Session details and progress |
+| `flowplane learn stop <name-or-id>` | Stop session, trigger final aggregation |
+| `flowplane learn cancel <name-or-id> --yes` | Cancel without aggregating |
+| `flowplane learn export [--session <name>] [-o file]` | Export schemas as OpenAPI |
+
+Key flags for `learn start`:
+
+| Flag | Description |
+|------|-------------|
+| `--name` | Human-readable name (auto-generated if omitted) |
+| `--route-pattern` | Regex matching request paths to observe |
+| `--target-sample-count` | Samples to collect before aggregation |
+| `--auto-aggregate` | Aggregate periodically, keep collecting |
+| `--cluster-name` | Filter to traffic for a specific cluster |
+| `--http-methods` | Filter by HTTP method (e.g., `GET POST`) |
+
+### Schemas
+
+| Command | Description |
+|---------|-------------|
+| `flowplane schema list` | List discovered schemas |
+| `flowplane schema list --session <name>` | Schemas from a specific session |
+| `flowplane schema list --min-confidence 0.7` | Filter by confidence |
+| `flowplane schema get <id>` | Schema detail (fields, types, formats) |
+| `flowplane schema get <id> -o table` | Human-readable summary |
+| `flowplane schema export --all -o api.yaml` | Export all as OpenAPI |
+| `flowplane schema export --id 1,2,3 -o api.json` | Export specific schemas |
+| `flowplane schema export --session <name> --all` | Export from specific session |
+
+For the full CLI reference, see [CLI Reference](cli-reference.md).
 
 ## Next steps
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -40,7 +40,7 @@ Any client that supports Streamable HTTP transport can connect. Set the URL to `
 
 ## Tools
 
-Flowplane registers 68 tools. They fall into two categories:
+Flowplane registers 69 tools. They fall into two categories:
 
 - **Control plane tools** (`cp_*`, `ops_*`, `devops_*`, `dev_*`) — manage gateway configuration and diagnose issues.
 - **Gateway API tools** (`api_*`) — proxy calls through the Envoy gateway to upstream services. These are generated dynamically from learned or imported API schemas.
@@ -56,8 +56,8 @@ Flowplane registers 68 tools. They fall into two categories:
 | **Routes** | `cp_list_routes`, `cp_get_route`, `cp_create_route`, `cp_update_route`, `cp_delete_route`, `cp_query_path` | Path-to-cluster routing rules |
 | **Filters** | `cp_list_filters`, `cp_get_filter`, `cp_create_filter`, `cp_update_filter`, `cp_delete_filter`, `cp_attach_filter`, `cp_detach_filter`, `cp_list_filter_attachments`, `cp_list_filter_types`, `cp_get_filter_type` | HTTP filters and filter chains |
 | **Dataplanes** | `cp_list_dataplanes`, `cp_get_dataplane`, `cp_create_dataplane`, `cp_update_dataplane`, `cp_delete_dataplane` | Envoy instance management |
-| **Learning** | `cp_list_learning_sessions`, `cp_get_learning_session`, `cp_create_learning_session`, `cp_activate_learning_session`, `cp_delete_learning_session` | API traffic learning and schema generation |
-| **Schemas** | `cp_list_aggregated_schemas`, `cp_get_aggregated_schema`, `cp_export_schema_openapi` | Aggregated API schemas and OpenAPI export |
+| **Learning** | `cp_list_learning_sessions`, `cp_get_learning_session`, `cp_create_learning_session`, `cp_activate_learning_session`, `cp_stop_learning`, `cp_delete_learning_session` | API traffic learning and schema generation. Sessions support `name` for human-readable references and `autoAggregate` for continuous collection with periodic snapshots |
+| **Schemas** | `cp_list_aggregated_schemas`, `cp_get_aggregated_schema`, `cp_export_schema_openapi` | Aggregated API schemas and OpenAPI 3.1 export with domain model `$ref` deduplication |
 | **OpenAPI Import** | `cp_list_openapi_imports`, `cp_get_openapi_import` | Import routes from OpenAPI specs |
 | **Secrets** | `cp_list_secrets`, `cp_get_secret`, `cp_create_secret`, `cp_delete_secret` | Secrets for filter configs |
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -147,6 +147,7 @@ flowplane auth login
 
 ## Next steps
 
+- [Learning Quickstart](learning-quickstart.md) — discover API schemas from live traffic
 - [Getting Started](getting-started.md) — full walkthrough with MCP examples
 - [CLI Reference](cli-reference.md) — every command, flag, and example
 - [Filters](filters.md) — all 10 filter types and configuration

--- a/migrations/20260406000001_auto_aggregate_support.sql
+++ b/migrations/20260406000001_auto_aggregate_support.sql
@@ -1,0 +1,8 @@
+-- Auto-aggregate support for learning sessions
+ALTER TABLE learning_sessions ADD COLUMN auto_aggregate BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE learning_sessions ADD COLUMN snapshot_count BIGINT NOT NULL DEFAULT 0;
+
+-- Link aggregated schemas to sessions and snapshots
+ALTER TABLE aggregated_api_schemas ADD COLUMN session_id TEXT REFERENCES learning_sessions(id);
+ALTER TABLE aggregated_api_schemas ADD COLUMN snapshot_number BIGINT;
+CREATE INDEX idx_aggregated_schemas_session ON aggregated_api_schemas(session_id);

--- a/migrations/20260406000002_add_learning_session_name.sql
+++ b/migrations/20260406000002_add_learning_session_name.sql
@@ -1,0 +1,6 @@
+-- Add optional name column to learning_sessions for human-friendly session identification
+ALTER TABLE learning_sessions ADD COLUMN name TEXT;
+
+-- Unique constraint on (team, name) where name is not null
+-- Existing sessions get NULL name, new sessions get auto-generated names
+CREATE UNIQUE INDEX idx_learning_sessions_team_name ON learning_sessions(team, name) WHERE name IS NOT NULL;

--- a/src/api/handlers/aggregated_schemas.rs
+++ b/src/api/handlers/aggregated_schemas.rs
@@ -118,6 +118,10 @@ pub struct AggregatedSchemaResponse {
     pub last_observed: String,
     pub created_at: String,
     pub updated_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snapshot_number: Option<i64>,
 }
 
 /// Schema comparison response
@@ -227,6 +231,8 @@ fn schema_response_from_data(
         last_observed: data.last_observed.to_rfc3339(),
         created_at: data.created_at.to_rfc3339(),
         updated_at: data.updated_at.to_rfc3339(),
+        session_id: data.session_id,
+        snapshot_number: data.snapshot_number,
     }
 }
 

--- a/src/api/handlers/aggregated_schemas.rs
+++ b/src/api/handlers/aggregated_schemas.rs
@@ -41,6 +41,10 @@ pub struct ListAggregatedSchemasQuery {
     #[serde(default)]
     #[schema(example = 0.8, minimum = 0.0, maximum = 1.0)]
     pub min_confidence: Option<f64>,
+
+    /// Filter by learning session ID
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 /// Query parameters for schema comparison
@@ -290,6 +294,7 @@ pub async fn list_aggregated_schemas_handler(
             query.path.as_deref(),
             query.http_method.as_deref(),
             query.min_confidence,
+            query.session_id.as_deref(),
         )
         .await
         .map_err(|e| {

--- a/src/api/handlers/aggregated_schemas.rs
+++ b/src/api/handlers/aggregated_schemas.rs
@@ -293,6 +293,24 @@ pub async fn list_aggregated_schemas_handler(
         .as_ref()
         .ok_or_else(|| ApiError::Internal("Repository not configured".to_string()))?;
 
+    // Resolve session name-or-id to session UUID if provided
+    let resolved_session_id = if let Some(ref session_ref) = query.session_id {
+        let pool = state
+            .xds_state
+            .pool
+            .as_ref()
+            .ok_or_else(|| ApiError::Internal("Database pool not configured".to_string()))?;
+        let session_repo =
+            crate::storage::repositories::LearningSessionRepository::new(pool.clone());
+        let session = session_repo.get_by_name_or_id(&team, session_ref).await.map_err(|e| {
+            tracing::warn!(error = %e, session_ref = %session_ref, "Failed to resolve session");
+            ApiError::NotFound(format!("Learning session '{}' not found", session_ref))
+        })?;
+        Some(session.id)
+    } else {
+        None
+    };
+
     // List schemas with filters
     let schemas = repo
         .list_filtered(
@@ -300,7 +318,7 @@ pub async fn list_aggregated_schemas_handler(
             query.path.as_deref(),
             query.http_method.as_deref(),
             query.min_confidence,
-            query.session_id.as_deref(),
+            resolved_session_id.as_deref(),
         )
         .await
         .map_err(|e| {

--- a/src/api/handlers/aggregated_schemas.rs
+++ b/src/api/handlers/aggregated_schemas.rs
@@ -1044,7 +1044,53 @@ pub fn build_unified_openapi_spec(
         }
     }
 
-    let mut components = serde_json::json!({"schemas": {}});
+    // Domain model deduplication: discover shared schemas and replace with $ref
+    let schema_entries: Vec<crate::openapi::domain_models::SchemaEntry> = schemas
+        .iter()
+        .map(|s| {
+            let parsed = parse_path_with_query(&s.path);
+            crate::openapi::domain_models::SchemaEntry {
+                path: parsed.base_path,
+                method: s.http_method.clone(),
+                request_schema: s.request_schema.clone().map(|mut rs| {
+                    strip_internal_attributes(&mut rs);
+                    convert_schema_to_openapi(&rs)
+                }),
+                response_schemas: s.response_schemas.clone().map(|mut rs| {
+                    strip_internal_attributes(&mut rs);
+                    // Convert each response schema within the map
+                    if let Some(map) = rs.as_object_mut() {
+                        for (_code, resp_schema) in map.iter_mut() {
+                            if !resp_schema.is_null() {
+                                *resp_schema = convert_schema_to_openapi(resp_schema);
+                            }
+                        }
+                    }
+                    rs
+                }),
+            }
+        })
+        .collect();
+
+    let discovery = crate::openapi::domain_models::discover_domain_models(&schema_entries);
+
+    // Replace inline schemas in paths with $ref pointers
+    if !discovery.models.is_empty() {
+        crate::openapi::domain_models::replace_with_refs(
+            &mut paths,
+            &discovery.fingerprint_to_name,
+        );
+    }
+
+    // Build components with discovered domain model schemas
+    let mut components = if discovery.models.is_empty() {
+        serde_json::json!({"schemas": {}})
+    } else {
+        let model_schemas =
+            crate::openapi::domain_models::build_components_schemas(&discovery.models);
+        serde_json::json!({"schemas": model_schemas})
+    };
+
     if security_schemes.as_object().is_some_and(|m| !m.is_empty()) {
         components["securitySchemes"] = security_schemes;
     }

--- a/src/api/handlers/aggregated_schemas.rs
+++ b/src/api/handlers/aggregated_schemas.rs
@@ -173,6 +173,7 @@ fn strip_internal_attributes(schema: &mut serde_json::Value) {
             map.remove("confidence");
             map.remove("presence_count");
             map.remove("sample_count");
+            map.remove("observed_values");
 
             // Recursively process ALL nested values in the object
             // This handles properties, items, status codes (200, 201), and any other nested objects
@@ -1254,6 +1255,8 @@ mod tests {
             last_observed: chrono::Utc::now(),
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
+            session_id: None,
+            snapshot_number: None,
         }
     }
 
@@ -1407,6 +1410,8 @@ mod tests {
             last_observed: chrono::Utc::now(),
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
+            session_id: None,
+            snapshot_number: None,
         };
 
         let options = ExportMultipleSchemasRequest {
@@ -1468,6 +1473,8 @@ mod tests {
             last_observed: chrono::Utc::now(),
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
+            session_id: None,
+            snapshot_number: None,
         }
     }
 
@@ -1547,6 +1554,8 @@ mod tests {
             last_observed: chrono::Utc::now(),
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
+            session_id: None,
+            snapshot_number: None,
         };
 
         let options = ExportMultipleSchemasRequest {
@@ -1601,6 +1610,8 @@ mod tests {
                 last_observed: chrono::Utc::now(),
                 created_at: chrono::Utc::now(),
                 updated_at: chrono::Utc::now(),
+                session_id: None,
+                snapshot_number: None,
             }
         }
 

--- a/src/api/handlers/learning_sessions.rs
+++ b/src/api/handlers/learning_sessions.rs
@@ -25,8 +25,8 @@ use crate::{
     auth::models::AuthContext,
     errors::Error,
     storage::repositories::{
-        CreateLearningSessionRequest, LearningSessionRepository, LearningSessionStatus,
-        UpdateLearningSessionRequest,
+        team::TeamRepository, CreateLearningSessionRequest, LearningSessionRepository,
+        LearningSessionStatus, UpdateLearningSessionRequest,
     },
 };
 
@@ -87,6 +87,12 @@ pub struct CreateLearningSessionBody {
     #[serde(default)]
     #[schema(example = false)]
     pub auto_aggregate: Option<bool>,
+
+    /// Optional human-friendly session name (auto-generated from route_pattern if omitted)
+    #[serde(default)]
+    #[validate(length(min = 1, max = 64))]
+    #[schema(example = "v2-api-payments")]
+    pub name: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
@@ -110,6 +116,7 @@ pub struct LearningSessionResponse {
     pub error_message: Option<String>,
     pub auto_aggregate: bool,
     pub snapshot_count: i64,
+    pub name: Option<String>,
 }
 
 #[derive(Debug, Deserialize, ToSchema, Clone)]
@@ -155,6 +162,7 @@ fn session_response_from_data(
         error_message: data.error_message,
         auto_aggregate: data.auto_aggregate,
         snapshot_count: data.snapshot_count,
+        name: data.name,
     }
 }
 
@@ -233,6 +241,20 @@ pub async fn create_learning_session_handler(
 
     let session_repo = LearningSessionRepository::new(repo.pool().clone());
 
+    // Generate session name if not provided
+    let session_name = if let Some(name) = payload.name {
+        Some(name)
+    } else {
+        let generated = crate::services::learning_session_service::generate_unique_session_name(
+            &session_repo,
+            &team_id,
+            &payload.route_pattern,
+        )
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to generate session name: {}", e)))?;
+        Some(generated)
+    };
+
     // Create session using resolved team ID
     let create_request = CreateLearningSessionRequest {
         team: team_id,
@@ -245,6 +267,7 @@ pub async fn create_learning_session_handler(
         deployment_version: payload.deployment_version,
         configuration_snapshot: payload.configuration_snapshot,
         auto_aggregate: payload.auto_aggregate.unwrap_or(false),
+        name: session_name,
     };
 
     let created = session_repo.create(create_request).await.map_err(|e| {
@@ -383,12 +406,23 @@ pub async fn get_learning_session_handler(
 
     let session_repo = LearningSessionRepository::new(repo.pool().clone());
 
-    // Get session by ID (without team filter)
-    let session = session_repo.get_by_id(&id).await.map_err(|e| {
+    // Resolve team name to UUID for name-based lookup
+    let team_repo_ref = team_repo_from_state(&state)?;
+    let resolved_team_ids = team_repo_ref
+        .resolve_team_ids(context.org_id.as_ref(), std::slice::from_ref(&team))
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to resolve team ID: {}", e)))?;
+    let resolved_team_id = resolved_team_ids
+        .into_iter()
+        .next()
+        .ok_or_else(|| ApiError::NotFound(format!("Team '{}' not found", team)))?;
+
+    // Get session by name or ID
+    let session = session_repo.get_by_name_or_id(&resolved_team_id, &id).await.map_err(|e| {
         tracing::error!(error = %e, session_id = %id, "Failed to get learning session");
         match e {
             Error::NotFound { .. } => {
-                ApiError::NotFound(format!("Learning session with ID '{}' not found", id))
+                ApiError::NotFound(format!("Learning session '{}' not found", id))
             }
             _ => ApiError::Internal(format!("Failed to get learning session: {}", e)),
         }
@@ -444,11 +478,22 @@ pub async fn delete_learning_session_handler(
 
     let session_repo = LearningSessionRepository::new(repo.pool().clone());
 
-    // First, get the session by ID (without team filter)
-    let session = session_repo.get_by_id(&id).await.map_err(|e| {
+    // Resolve team name to UUID for name-based lookup
+    let team_repo_ref = team_repo_from_state(&state)?;
+    let resolved_team_ids = team_repo_ref
+        .resolve_team_ids(context.org_id.as_ref(), std::slice::from_ref(&team))
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to resolve team ID: {}", e)))?;
+    let resolved_team_id = resolved_team_ids
+        .into_iter()
+        .next()
+        .ok_or_else(|| ApiError::NotFound(format!("Team '{}' not found", team)))?;
+
+    // Get session by name or ID
+    let session = session_repo.get_by_name_or_id(&resolved_team_id, &id).await.map_err(|e| {
         tracing::error!(error = %e, session_id = %id, "Failed to get learning session for cancellation");
         match e {
-            Error::NotFound { .. } => ApiError::NotFound(format!("Learning session with ID '{}' not found", id)),
+            Error::NotFound { .. } => ApiError::NotFound(format!("Learning session '{}' not found", id)),
             _ => ApiError::Internal(format!("Failed to get learning session: {}", e)),
         }
     })?;
@@ -499,7 +544,7 @@ pub async fn delete_learning_session_handler(
     if let Some(learning_service) = state.xds_state.get_learning_session_service() {
         // If session is active, we need to unregister from Access Log Service
         // The cancel_session method handles this
-        learning_service.cancel_session(&id).await.map_err(|e| {
+        learning_service.cancel_session(&session.id).await.map_err(|e| {
             tracing::error!(error = %e, session_id = %id, team = %session.team, "Failed to cancel learning session via service");
             ApiError::Internal(format!("Failed to cancel learning session: {}", e))
         })?;
@@ -514,7 +559,7 @@ pub async fn delete_learning_session_handler(
             error_message: Some("Cancelled by user".to_string()),
         };
 
-        session_repo.update(&id, update_request).await.map_err(|e| {
+        session_repo.update(&session.id, update_request).await.map_err(|e| {
             tracing::error!(error = %e, session_id = %id, team = %session.team, "Failed to cancel learning session");
             ApiError::Internal(format!("Failed to cancel learning session: {}", e))
         })?;
@@ -562,12 +607,23 @@ pub async fn stop_learning_session_handler(
 
     let session_repo = LearningSessionRepository::new(repo.pool().clone());
 
-    // Get session by ID
-    let session = session_repo.get_by_id(&id).await.map_err(|e| {
+    // Resolve team name to UUID for name-based lookup
+    let team_repo_ref = team_repo_from_state(&state)?;
+    let resolved_team_ids = team_repo_ref
+        .resolve_team_ids(context.org_id.as_ref(), std::slice::from_ref(&team))
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to resolve team ID: {}", e)))?;
+    let resolved_team_id = resolved_team_ids
+        .into_iter()
+        .next()
+        .ok_or_else(|| ApiError::NotFound(format!("Team '{}' not found", team)))?;
+
+    // Get session by name or ID
+    let session = session_repo.get_by_name_or_id(&resolved_team_id, &id).await.map_err(|e| {
         tracing::error!(error = %e, session_id = %id, "Failed to get learning session for stop");
         match e {
             Error::NotFound { .. } => {
-                ApiError::NotFound(format!("Learning session with ID '{}' not found", id))
+                ApiError::NotFound(format!("Learning session '{}' not found", id))
             }
             _ => ApiError::Internal(format!("Failed to get learning session: {}", e)),
         }
@@ -582,7 +638,7 @@ pub async fn stop_learning_session_handler(
         .get_learning_session_service()
         .ok_or_else(|| ApiError::Internal("Learning session service not available".to_string()))?;
 
-    let completed = learning_service.stop_session(&id).await.map_err(|e| {
+    let completed = learning_service.stop_session(&session.id).await.map_err(|e| {
         tracing::error!(error = %e, session_id = %id, "Failed to stop learning session");
         ApiError::BadRequest(format!("Failed to stop learning session: {}", e))
     })?;
@@ -622,6 +678,7 @@ mod tests {
                 updated_at: chrono::Utc::now(),
                 auto_aggregate: false,
                 snapshot_count: 0,
+                name: None,
             }
         }
 
@@ -768,6 +825,7 @@ mod tests {
                 updated_at: chrono::Utc::now(),
                 auto_aggregate: false,
                 snapshot_count: 0,
+                name: None,
             }
         }
 
@@ -849,6 +907,7 @@ mod tests {
                 deployment_version: None,
                 configuration_snapshot: None,
                 auto_aggregate: Some(false),
+                name: None,
             };
 
             use validator::Validate;
@@ -868,6 +927,7 @@ mod tests {
                 deployment_version: None,
                 configuration_snapshot: None,
                 auto_aggregate: Some(false),
+                name: None,
             };
 
             use validator::Validate;
@@ -887,6 +947,7 @@ mod tests {
                 deployment_version: None,
                 configuration_snapshot: None,
                 auto_aggregate: Some(false),
+                name: None,
             };
 
             use validator::Validate;
@@ -906,6 +967,7 @@ mod tests {
                 deployment_version: None,
                 configuration_snapshot: None,
                 auto_aggregate: Some(false),
+                name: None,
             };
 
             use validator::Validate;
@@ -926,6 +988,7 @@ mod tests {
                 deployment_version: None,
                 configuration_snapshot: None,
                 auto_aggregate: Some(false),
+                name: None,
             };
 
             use validator::Validate;
@@ -942,6 +1005,7 @@ mod tests {
                 deployment_version: None,
                 configuration_snapshot: None,
                 auto_aggregate: Some(false),
+                name: None,
             };
 
             assert!(body_max.validate().is_ok());

--- a/src/api/handlers/learning_sessions.rs
+++ b/src/api/handlers/learning_sessions.rs
@@ -82,6 +82,11 @@ pub struct CreateLearningSessionBody {
     /// Optional configuration snapshot (JSON)
     #[serde(default)]
     pub configuration_snapshot: Option<serde_json::Value>,
+
+    /// Enable auto-aggregate snapshot mode (default: false)
+    #[serde(default)]
+    #[schema(example = false)]
+    pub auto_aggregate: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
@@ -103,6 +108,8 @@ pub struct LearningSessionResponse {
     pub triggered_by: Option<String>,
     pub deployment_version: Option<String>,
     pub error_message: Option<String>,
+    pub auto_aggregate: bool,
+    pub snapshot_count: i64,
 }
 
 #[derive(Debug, Deserialize, ToSchema, Clone)]
@@ -146,6 +153,8 @@ fn session_response_from_data(
         triggered_by: data.triggered_by,
         deployment_version: data.deployment_version,
         error_message: data.error_message,
+        auto_aggregate: data.auto_aggregate,
+        snapshot_count: data.snapshot_count,
     }
 }
 
@@ -235,6 +244,7 @@ pub async fn create_learning_session_handler(
         triggered_by: payload.triggered_by,
         deployment_version: payload.deployment_version,
         configuration_snapshot: payload.configuration_snapshot,
+        auto_aggregate: payload.auto_aggregate.unwrap_or(false),
     };
 
     let created = session_repo.create(create_request).await.map_err(|e| {
@@ -513,6 +523,75 @@ pub async fn delete_learning_session_handler(
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/v1/teams/{team}/learning-sessions/{id}/stop",
+    params(
+        ("team" = String, Path, description = "Team name"),
+        ("id" = String, Path, description = "Learning session ID")
+    ),
+    responses(
+        (status = 200, description = "Learning session stopped", body = LearningSessionResponse),
+        (status = 400, description = "Invalid state - session not active"),
+        (status = 403, description = "Forbidden - insufficient permissions"),
+        (status = 404, description = "Learning session not found"),
+        (status = 503, description = "Service unavailable")
+    ),
+    tag = "API Discovery"
+)]
+#[instrument(skip(state), fields(team = %team, session_id = %id, user_id = ?context.user_id))]
+pub async fn stop_learning_session_handler(
+    State(state): State<ApiState>,
+    Extension(context): Extension<AuthContext>,
+    Path((team, id)): Path<(String, String)>,
+) -> Result<Json<LearningSessionResponse>, ApiError> {
+    // Authorization: require learning-sessions:execute scope for the team from path
+    require_resource_access_resolved(&state, &context, "learning-sessions", "execute", Some(&team))
+        .await?;
+
+    // Get effective team scopes for access verification
+    let team_repo = team_repo_from_state(&state)?;
+    let team_scopes = get_effective_team_ids(&context, team_repo, context.org_id.as_ref()).await?;
+
+    // Get repository
+    let repo = state
+        .xds_state
+        .cluster_repository
+        .as_ref()
+        .ok_or_else(|| ApiError::Internal("Repository not configured".to_string()))?;
+
+    let session_repo = LearningSessionRepository::new(repo.pool().clone());
+
+    // Get session by ID
+    let session = session_repo.get_by_id(&id).await.map_err(|e| {
+        tracing::error!(error = %e, session_id = %id, "Failed to get learning session for stop");
+        match e {
+            Error::NotFound { .. } => {
+                ApiError::NotFound(format!("Learning session with ID '{}' not found", id))
+            }
+            _ => ApiError::Internal(format!("Failed to get learning session: {}", e)),
+        }
+    })?;
+
+    // Verify team access
+    verify_team_access(session.clone(), &team_scopes).await?;
+
+    // Use the learning session service to stop
+    let learning_service = state
+        .xds_state
+        .get_learning_session_service()
+        .ok_or_else(|| ApiError::Internal("Learning session service not available".to_string()))?;
+
+    let completed = learning_service.stop_session(&id).await.map_err(|e| {
+        tracing::error!(error = %e, session_id = %id, "Failed to stop learning session");
+        ApiError::BadRequest(format!("Failed to stop learning session: {}", e))
+    })?;
+
+    let response = session_response_from_data(completed);
+
+    Ok(Json(response))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -541,6 +620,8 @@ mod tests {
                 configuration_snapshot: None,
                 error_message: None,
                 updated_at: chrono::Utc::now(),
+                auto_aggregate: false,
+                snapshot_count: 0,
             }
         }
 
@@ -628,6 +709,27 @@ mod tests {
         }
 
         #[test]
+        fn test_session_response_auto_aggregate_fields() {
+            let mut data = sample_session_data();
+            data.auto_aggregate = true;
+            data.snapshot_count = 5;
+
+            let response = session_response_from_data(data);
+
+            assert!(response.auto_aggregate);
+            assert_eq!(response.snapshot_count, 5);
+        }
+
+        #[test]
+        fn test_session_response_auto_aggregate_defaults() {
+            let data = sample_session_data();
+            let response = session_response_from_data(data);
+
+            assert!(!response.auto_aggregate);
+            assert_eq!(response.snapshot_count, 0);
+        }
+
+        #[test]
         fn test_session_response_with_error_message() {
             let mut data = sample_session_data();
             data.status = LearningSessionStatus::Failed;
@@ -664,6 +766,8 @@ mod tests {
                 configuration_snapshot: None,
                 error_message: None,
                 updated_at: chrono::Utc::now(),
+                auto_aggregate: false,
+                snapshot_count: 0,
             }
         }
 
@@ -744,6 +848,7 @@ mod tests {
                 triggered_by: None,
                 deployment_version: None,
                 configuration_snapshot: None,
+                auto_aggregate: Some(false),
             };
 
             use validator::Validate;
@@ -762,6 +867,7 @@ mod tests {
                 triggered_by: None,
                 deployment_version: None,
                 configuration_snapshot: None,
+                auto_aggregate: Some(false),
             };
 
             use validator::Validate;
@@ -780,6 +886,7 @@ mod tests {
                 triggered_by: None,
                 deployment_version: None,
                 configuration_snapshot: None,
+                auto_aggregate: Some(false),
             };
 
             use validator::Validate;
@@ -798,6 +905,7 @@ mod tests {
                 triggered_by: None,
                 deployment_version: None,
                 configuration_snapshot: None,
+                auto_aggregate: Some(false),
             };
 
             use validator::Validate;
@@ -817,6 +925,7 @@ mod tests {
                 triggered_by: None,
                 deployment_version: None,
                 configuration_snapshot: None,
+                auto_aggregate: Some(false),
             };
 
             use validator::Validate;
@@ -832,6 +941,7 @@ mod tests {
                 triggered_by: None,
                 deployment_version: None,
                 configuration_snapshot: None,
+                auto_aggregate: Some(false),
             };
 
             assert!(body_max.validate().is_ok());

--- a/src/api/handlers/mod.rs
+++ b/src/api/handlers/mod.rs
@@ -71,7 +71,7 @@ pub use filters::{
 pub use health::health_handler;
 pub use learning_sessions::{
     create_learning_session_handler, delete_learning_session_handler, get_learning_session_handler,
-    list_learning_sessions_handler,
+    list_learning_sessions_handler, stop_learning_session_handler,
 };
 pub use listeners::{
     create_listener_handler, delete_listener_handler, get_listener_handler, list_listeners_handler,

--- a/src/api/handlers/openapi_utils.rs
+++ b/src/api/handlers/openapi_utils.rs
@@ -319,8 +319,17 @@ pub fn convert_schema_to_openapi(schema: &serde_json::Value) -> serde_json::Valu
                         result.insert("items".to_string(), convert_schema_to_openapi(value));
                     }
 
+                    // Emit enum_values as standard OpenAPI "enum"
+                    "enum_values" => {
+                        if let Some(arr) = value.as_array() {
+                            if !arr.is_empty() {
+                                result.insert("enum".to_string(), value.clone());
+                            }
+                        }
+                    }
+
                     // Skip internal metadata fields (these shouldn't appear after strip_internal_attributes)
-                    "confidence" | "presence_count" | "sample_count" => {
+                    "confidence" | "presence_count" | "sample_count" | "observed_values" => {
                         // Skip these internal fields
                     }
 
@@ -1117,5 +1126,53 @@ mod tests {
 
         assert!(!has_resource_id_param("/users"));
         assert!(!has_resource_id_param("/v2/api/users"));
+    }
+
+    #[test]
+    fn test_convert_schema_enum_values_emitted() {
+        let schema = serde_json::json!({
+            "type": "string",
+            "enum_values": ["active", "inactive", "pending"]
+        });
+
+        let result = convert_schema_to_openapi(&schema);
+        let enum_arr = result.get("enum").and_then(|v| v.as_array());
+        assert!(enum_arr.is_some(), "enum should be emitted in OpenAPI output");
+        let values: Vec<&str> =
+            enum_arr.map(|a| a.iter().filter_map(|v| v.as_str()).collect()).unwrap_or_default();
+        assert_eq!(values, vec!["active", "inactive", "pending"]);
+        // enum_values key should not appear in output
+        assert!(result.get("enum_values").is_none());
+    }
+
+    #[test]
+    fn test_convert_schema_observed_values_stripped() {
+        let schema = serde_json::json!({
+            "type": "string",
+            "observed_values": ["foo", "bar"]
+        });
+
+        let result = convert_schema_to_openapi(&schema);
+        assert!(result.get("observed_values").is_none(), "observed_values should be stripped");
+        assert!(result.get("enum").is_none(), "No enum without enum_values");
+    }
+
+    #[test]
+    fn test_convert_schema_enum_values_nested_in_properties() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum_values": ["on", "off"]
+                }
+            }
+        });
+
+        let result = convert_schema_to_openapi(&schema);
+        let status = result.get("properties").and_then(|p| p.get("status"));
+        assert!(status.is_some());
+        let enum_arr = status.and_then(|s| s.get("enum"));
+        assert!(enum_arr.is_some(), "Nested enum_values should be converted");
     }
 }

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -71,8 +71,8 @@ use super::{
         list_secrets_handler, list_team_members, list_teams_handler,
         list_virtual_host_filters_handler, list_virtual_hosts_handler, refresh_mcp_schema_handler,
         reload_filter_schemas_handler, remove_filter_configuration_handler, remove_team_member,
-        revoke_certificate_handler, set_app_status_handler, unexpose_handler,
-        uninstall_filter_handler, update_cluster_handler, update_filter_handler,
+        revoke_certificate_handler, set_app_status_handler, stop_learning_session_handler,
+        unexpose_handler, uninstall_filter_handler, update_cluster_handler, update_filter_handler,
         update_listener_handler, update_mcp_tool_handler, update_org_team,
         update_route_config_handler, update_secret_handler,
     },
@@ -472,6 +472,7 @@ pub fn build_router_with_registry(
         .route("/api/v1/teams/{team}/learning-sessions", post(create_learning_session_handler))
         .route("/api/v1/teams/{team}/learning-sessions/{id}", get(get_learning_session_handler))
         .route("/api/v1/teams/{team}/learning-sessions/{id}", delete(delete_learning_session_handler))
+        .route("/api/v1/teams/{team}/learning-sessions/{id}/stop", post(stop_learning_session_handler))
         // Dataplane endpoints (team-scoped Envoy instances with gateway_host)
         .route("/api/v1/dataplanes", get(list_all_dataplanes_handler))
         .route("/api/v1/teams/{team}/dataplanes", get(list_dataplanes_handler))

--- a/src/cli/learn.rs
+++ b/src/cli/learn.rs
@@ -7,6 +7,7 @@ use clap::Subcommand;
 use serde::{Deserialize, Serialize};
 
 use super::client::FlowplaneClient;
+use super::schema;
 
 #[derive(Subcommand)]
 pub enum LearnCommands {
@@ -120,6 +121,33 @@ pub enum LearnCommands {
         #[arg(short, long, default_value = "json", value_parser = ["json", "yaml", "table"])]
         output: String,
     },
+
+    /// Export discovered schemas as OpenAPI spec
+    #[command(
+        long_about = "Export schemas discovered by learning sessions as an OpenAPI 3.1 spec.\n\nConvenience shortcut for `flowplane schema export --all`.\nExports all latest schemas to stdout (YAML) or to a file.",
+        after_help = "EXAMPLES:\n    # Export all schemas as YAML to stdout\n    flowplane learn export\n\n    # Export to a file\n    flowplane learn export -o api.yaml\n\n    # Export only high-confidence schemas\n    flowplane learn export --min-confidence 0.7 -o api.json"
+    )]
+    Export {
+        /// Minimum confidence filter
+        #[arg(long)]
+        min_confidence: Option<f64>,
+
+        /// API title in the OpenAPI spec
+        #[arg(long, default_value = "Learned API")]
+        title: String,
+
+        /// API version in the OpenAPI spec
+        #[arg(long, default_value = "1.0.0")]
+        version: String,
+
+        /// API description
+        #[arg(long)]
+        description: Option<String>,
+
+        /// Output file (auto-detects format from extension; stdout if omitted)
+        #[arg(short, long)]
+        output: Option<String>,
+    },
 }
 
 /// Learning session response matching the API response
@@ -212,6 +240,21 @@ pub async fn handle_learn_command(
         }
         LearnCommands::Get { session_id, output } => {
             get_session(client, team, &session_id, &output).await?
+        }
+        LearnCommands::Export { min_confidence, title, version, description, output } => {
+            // Thin wrapper: delegates to schema::export_schemas with --all
+            schema::export_schemas(
+                client,
+                team,
+                None,
+                true,
+                min_confidence,
+                title,
+                version,
+                description,
+                output,
+            )
+            .await?
         }
     }
 

--- a/src/cli/learn.rs
+++ b/src/cli/learn.rs
@@ -17,6 +17,10 @@ pub enum LearnCommands {
         after_help = "EXAMPLES:\n    # Start learning all /api/v2 traffic with 500 samples\n    flowplane learn start --route-pattern '^/api/v2/.*' --target-sample-count 500\n\n    # Start learning with cluster filter and HTTP method filter\n    flowplane learn start --route-pattern '^/api/v1/users/.*' --cluster-name users-api \\\n        --http-methods GET POST --target-sample-count 1000\n\n    # Start with a max duration of 2 hours\n    flowplane learn start --route-pattern '^/api/.*' --target-sample-count 500 \\\n        --max-duration-seconds 7200 --triggered-by 'deploy-v2.3'"
     )]
     Start {
+        /// Session name (auto-generated if omitted)
+        #[arg(long)]
+        name: Option<String>,
+
         /// Route pattern (regex) to match for learning
         #[arg(long)]
         route_pattern: String,
@@ -60,9 +64,9 @@ pub enum LearnCommands {
         after_help = "EXAMPLES:\n    # Stop a session by ID\n    flowplane learn stop abc-123-def\n\n    # Stop and get JSON output\n    flowplane learn stop abc-123-def --output json"
     )]
     Stop {
-        /// Session ID to stop
-        #[arg(value_name = "SESSION_ID")]
-        session_id: String,
+        /// Session name or UUID
+        #[arg(value_name = "NAME_OR_ID")]
+        name_or_id: String,
 
         /// Output format (json, yaml, or table)
         #[arg(short, long, default_value = "json", value_parser = ["json", "yaml", "table"])]
@@ -75,9 +79,9 @@ pub enum LearnCommands {
         after_help = "EXAMPLES:\n    # Cancel a session by ID\n    flowplane learn cancel abc-123-def\n\n    # Cancel without confirmation\n    flowplane learn cancel abc-123-def --yes"
     )]
     Cancel {
-        /// Session ID to cancel
-        #[arg(value_name = "SESSION_ID")]
-        session_id: String,
+        /// Session name or UUID
+        #[arg(value_name = "NAME_OR_ID")]
+        name_or_id: String,
 
         /// Skip confirmation prompt
         #[arg(short, long)]
@@ -113,9 +117,9 @@ pub enum LearnCommands {
         after_help = "EXAMPLES:\n    # Get session details in JSON\n    flowplane learn get abc-123-def\n\n    # Get in table format\n    flowplane learn get abc-123-def --output table"
     )]
     Get {
-        /// Session ID to retrieve
-        #[arg(value_name = "SESSION_ID")]
-        session_id: String,
+        /// Session name or UUID
+        #[arg(value_name = "NAME_OR_ID")]
+        name_or_id: String,
 
         /// Output format (json, yaml, or table)
         #[arg(short, long, default_value = "json", value_parser = ["json", "yaml", "table"])]
@@ -128,6 +132,10 @@ pub enum LearnCommands {
         after_help = "EXAMPLES:\n    # Export all schemas as YAML to stdout\n    flowplane learn export\n\n    # Export to a file\n    flowplane learn export -o api.yaml\n\n    # Export only high-confidence schemas\n    flowplane learn export --min-confidence 0.7 -o api.json"
     )]
     Export {
+        /// Export schemas from a specific session (name or UUID)
+        #[arg(long)]
+        session: Option<String>,
+
         /// Minimum confidence filter
         #[arg(long)]
         min_confidence: Option<f64>,
@@ -156,6 +164,8 @@ pub enum LearnCommands {
 pub struct LearningSessionResponse {
     pub id: String,
     pub team: String,
+    #[serde(default)]
+    pub name: Option<String>,
     pub route_pattern: String,
     pub cluster_name: Option<String>,
     pub http_methods: Option<Vec<String>>,
@@ -180,6 +190,8 @@ pub struct LearningSessionResponse {
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct CreateLearningSessionRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
     route_pattern: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     cluster_name: Option<String>,
@@ -204,6 +216,7 @@ pub async fn handle_learn_command(
 ) -> Result<()> {
     match command {
         LearnCommands::Start {
+            name,
             route_pattern,
             cluster_name,
             http_methods,
@@ -217,6 +230,7 @@ pub async fn handle_learn_command(
             start_session(
                 client,
                 team,
+                name,
                 route_pattern,
                 cluster_name,
                 http_methods,
@@ -229,19 +243,19 @@ pub async fn handle_learn_command(
             )
             .await?
         }
-        LearnCommands::Stop { session_id, output } => {
-            stop_session(client, team, &session_id, &output).await?
+        LearnCommands::Stop { name_or_id, output } => {
+            stop_session(client, team, &name_or_id, &output).await?
         }
-        LearnCommands::Cancel { session_id, yes } => {
-            cancel_session(client, team, &session_id, yes).await?
+        LearnCommands::Cancel { name_or_id, yes } => {
+            cancel_session(client, team, &name_or_id, yes).await?
         }
         LearnCommands::List { status, limit, offset, output } => {
             list_sessions(client, team, status, limit, offset, &output).await?
         }
-        LearnCommands::Get { session_id, output } => {
-            get_session(client, team, &session_id, &output).await?
+        LearnCommands::Get { name_or_id, output } => {
+            get_session(client, team, &name_or_id, &output).await?
         }
-        LearnCommands::Export { min_confidence, title, version, description, output } => {
+        LearnCommands::Export { session, min_confidence, title, version, description, output } => {
             // Thin wrapper: delegates to schema::export_schemas with --all
             schema::export_schemas(
                 client,
@@ -253,6 +267,7 @@ pub async fn handle_learn_command(
                 version,
                 description,
                 output,
+                session,
             )
             .await?
         }
@@ -265,6 +280,7 @@ pub async fn handle_learn_command(
 async fn start_session(
     client: &FlowplaneClient,
     team: &str,
+    name: Option<String>,
     route_pattern: String,
     cluster_name: Option<String>,
     http_methods: Option<Vec<String>>,
@@ -276,6 +292,7 @@ async fn start_session(
     output: &str,
 ) -> Result<()> {
     let body = CreateLearningSessionRequest {
+        name,
         route_pattern,
         cluster_name,
         http_methods,
@@ -419,15 +436,17 @@ fn print_sessions_table(sessions: &[LearningSessionResponse]) {
 
     println!();
     println!(
-        "{:<38} {:<12} {:<30} {:<8} {:<8} {:<8}",
-        "ID", "Status", "Route Pattern", "Samples", "Target", "Progress"
+        "{:<38} {:<20} {:<12} {:<30} {:<8} {:<8} {:<8}",
+        "ID", "Name", "Status", "Route Pattern", "Samples", "Target", "Progress"
     );
-    println!("{}", "-".repeat(110));
+    println!("{}", "-".repeat(130));
 
     for session in sessions {
+        let name_display = session.name.as_deref().unwrap_or("-");
         println!(
-            "{:<38} {:<12} {:<30} {:<8} {:<8} {:.1}%",
+            "{:<38} {:<20} {:<12} {:<30} {:<8} {:<8} {:.1}%",
             truncate(&session.id, 36),
+            truncate(name_display, 18),
             session.status,
             truncate(&session.route_pattern, 28),
             session.current_sample_count,

--- a/src/cli/learn.rs
+++ b/src/cli/learn.rs
@@ -44,6 +44,25 @@ pub enum LearnCommands {
         #[arg(long)]
         deployment_version: Option<String>,
 
+        /// Enable auto-aggregate snapshot mode (session continues after each aggregation)
+        #[arg(long)]
+        auto_aggregate: bool,
+
+        /// Output format (json, yaml, or table)
+        #[arg(short, long, default_value = "json", value_parser = ["json", "yaml", "table"])]
+        output: String,
+    },
+
+    /// Stop an active learning session (triggers final aggregation)
+    #[command(
+        long_about = "Stop an active learning session and trigger final schema aggregation.\n\nThis is especially useful for auto-aggregate sessions that run indefinitely.\nThe stop triggers a final schema aggregation from all collected samples.",
+        after_help = "EXAMPLES:\n    # Stop a session by ID\n    flowplane learn stop abc-123-def\n\n    # Stop and get JSON output\n    flowplane learn stop abc-123-def --output json"
+    )]
+    Stop {
+        /// Session ID to stop
+        #[arg(value_name = "SESSION_ID")]
+        session_id: String,
+
         /// Output format (json, yaml, or table)
         #[arg(short, long, default_value = "json", value_parser = ["json", "yaml", "table"])]
         output: String,
@@ -123,6 +142,10 @@ pub struct LearningSessionResponse {
     pub triggered_by: Option<String>,
     pub deployment_version: Option<String>,
     pub error_message: Option<String>,
+    #[serde(default)]
+    pub auto_aggregate: bool,
+    #[serde(default)]
+    pub snapshot_count: i64,
 }
 
 /// Request body for creating a learning session
@@ -141,6 +164,8 @@ struct CreateLearningSessionRequest {
     triggered_by: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     deployment_version: Option<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    auto_aggregate: bool,
 }
 
 /// Handle learn commands
@@ -158,6 +183,7 @@ pub async fn handle_learn_command(
             max_duration_seconds,
             triggered_by,
             deployment_version,
+            auto_aggregate,
             output,
         } => {
             start_session(
@@ -170,9 +196,13 @@ pub async fn handle_learn_command(
                 max_duration_seconds,
                 triggered_by,
                 deployment_version,
+                auto_aggregate,
                 &output,
             )
             .await?
+        }
+        LearnCommands::Stop { session_id, output } => {
+            stop_session(client, team, &session_id, &output).await?
         }
         LearnCommands::Cancel { session_id, yes } => {
             cancel_session(client, team, &session_id, yes).await?
@@ -199,6 +229,7 @@ async fn start_session(
     max_duration_seconds: Option<i64>,
     triggered_by: Option<String>,
     deployment_version: Option<String>,
+    auto_aggregate: bool,
     output: &str,
 ) -> Result<()> {
     let body = CreateLearningSessionRequest {
@@ -209,10 +240,29 @@ async fn start_session(
         max_duration_seconds,
         triggered_by,
         deployment_version,
+        auto_aggregate,
     };
 
     let path = format!("/api/v1/teams/{team}/learning-sessions");
     let response: LearningSessionResponse = client.post_json(&path, &body).await?;
+
+    if output == "table" {
+        print_sessions_table(&[response]);
+    } else {
+        print_output(&response, output)?;
+    }
+
+    Ok(())
+}
+
+async fn stop_session(
+    client: &FlowplaneClient,
+    team: &str,
+    session_id: &str,
+    output: &str,
+) -> Result<()> {
+    let path = format!("/api/v1/teams/{team}/learning-sessions/{session_id}/stop");
+    let response: LearningSessionResponse = client.post_json(&path, &serde_json::json!({})).await?;
 
     if output == "table" {
         print_sessions_table(&[response]);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,6 +21,7 @@ pub mod listeners;
 pub mod logs;
 pub mod output;
 pub mod routes;
+pub mod schema;
 pub mod secrets;
 pub mod status;
 pub mod teams;
@@ -189,6 +190,12 @@ EXAMPLES:
     Learn {
         #[command(subcommand)]
         command: learn::LearnCommands,
+    },
+
+    /// List, inspect, and export discovered API schemas
+    Schema {
+        #[command(subcommand)]
+        command: schema::SchemaCommands,
     },
 
     /// Filter management commands (CRUD + attach/detach)
@@ -365,6 +372,11 @@ async fn run_cli_commands(
             let client = create_http_client(token, token_file, base_url, timeout, verbose)?;
             let team = config::resolve_team(team_flag)?;
             learn::handle_learn_command(command, &client, &team).await?
+        }
+        Commands::Schema { command } => {
+            let client = create_http_client(token, token_file, base_url, timeout, verbose)?;
+            let team = config::resolve_team(team_flag)?;
+            schema::handle_schema_command(command, &client, &team).await?
         }
         Commands::Config { command } => config_cmd::handle_config_command(command).await?,
         Commands::Team { command } => {

--- a/src/cli/schema.rs
+++ b/src/cli/schema.rs
@@ -1,0 +1,436 @@
+//! Schema CLI commands
+//!
+//! Provides command-line interface for listing, inspecting, and exporting
+//! aggregated API schemas discovered by learning sessions.
+
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use serde::{Deserialize, Serialize};
+
+use super::client::FlowplaneClient;
+
+#[derive(Subcommand)]
+pub enum SchemaCommands {
+    /// List discovered API schemas
+    #[command(
+        long_about = "List aggregated API schemas discovered by learning sessions.\n\nShows path, HTTP method, confidence score, sample count, and version for each schema.",
+        after_help = "EXAMPLES:\n    # List all schemas\n    flowplane schema list\n\n    # Filter by confidence\n    flowplane schema list --min-confidence 0.7\n\n    # Filter by HTTP method\n    flowplane schema list --method GET\n\n    # JSON output for scripting\n    flowplane schema list -o json"
+    )]
+    List {
+        /// Minimum confidence score (0.0 - 1.0)
+        #[arg(long)]
+        min_confidence: Option<f64>,
+
+        /// Filter by path pattern
+        #[arg(long)]
+        path: Option<String>,
+
+        /// Filter by HTTP method
+        #[arg(long)]
+        method: Option<String>,
+
+        /// Show only latest version of each schema
+        #[arg(long)]
+        latest_only: bool,
+
+        /// Maximum number of results
+        #[arg(long)]
+        limit: Option<i32>,
+
+        /// Offset for pagination
+        #[arg(long)]
+        offset: Option<i32>,
+
+        /// Output format
+        #[arg(short, long, default_value = "table", value_parser = ["json", "yaml", "table"])]
+        output: String,
+    },
+
+    /// Get schema details
+    #[command(
+        long_about = "Show full details of an aggregated schema including request/response schemas,\nheaders, confidence, sample count, version, and breaking changes.",
+        after_help = "EXAMPLES:\n    # View schema details\n    flowplane schema get 1\n\n    # Table summary\n    flowplane schema get 1 -o table"
+    )]
+    Get {
+        /// Schema ID
+        #[arg(value_name = "ID")]
+        id: i64,
+
+        /// Output format
+        #[arg(short, long, default_value = "json", value_parser = ["json", "yaml", "table"])]
+        output: String,
+    },
+
+    /// Export schemas as OpenAPI 3.1 spec
+    #[command(
+        long_about = "Export aggregated schemas as an OpenAPI 3.1 specification.\n\nOutput goes to stdout by default (pipeable). Use -o to write to a file.\nFile format is auto-detected from extension (.yaml/.yml = YAML, .json = JSON).\nStdout defaults to YAML.",
+        after_help = "EXAMPLES:\n    # Export all schemas as YAML to stdout\n    flowplane schema export --all\n\n    # Export specific schemas to a file\n    flowplane schema export --id 1,2,3 -o api.yaml\n\n    # Export high-confidence schemas as JSON\n    flowplane schema export --all --min-confidence 0.7 -o api.json\n\n    # Pipe to another tool\n    flowplane schema export --all | yq '.paths'"
+    )]
+    Export {
+        /// Schema IDs to export (comma-separated)
+        #[arg(long, value_delimiter = ',')]
+        id: Option<Vec<i64>>,
+
+        /// Export all latest schemas
+        #[arg(long)]
+        all: bool,
+
+        /// Minimum confidence filter (used with --all)
+        #[arg(long)]
+        min_confidence: Option<f64>,
+
+        /// API title in the OpenAPI spec
+        #[arg(long, default_value = "Learned API")]
+        title: String,
+
+        /// API version in the OpenAPI spec
+        #[arg(long, default_value = "1.0.0")]
+        version: String,
+
+        /// API description
+        #[arg(long)]
+        description: Option<String>,
+
+        /// Output file (auto-detects format from extension; stdout if omitted)
+        #[arg(short, long)]
+        output: Option<String>,
+    },
+}
+
+/// Aggregated schema response from the API
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AggregatedSchemaResponse {
+    pub id: i64,
+    pub team: String,
+    pub path: String,
+    pub http_method: String,
+    pub version: i64,
+    pub previous_version_id: Option<i64>,
+    pub request_schema: Option<serde_json::Value>,
+    pub response_schemas: Option<serde_json::Value>,
+    pub sample_count: i64,
+    pub confidence_score: f64,
+    pub breaking_changes: Option<Vec<serde_json::Value>>,
+    pub first_observed: String,
+    pub last_observed: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Export request body
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ExportRequest {
+    schema_ids: Vec<i64>,
+    title: String,
+    version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+}
+
+pub async fn handle_schema_command(
+    command: SchemaCommands,
+    client: &FlowplaneClient,
+    team: &str,
+) -> Result<()> {
+    match command {
+        SchemaCommands::List {
+            min_confidence,
+            path,
+            method,
+            latest_only,
+            limit,
+            offset,
+            output,
+        } => {
+            let schemas = list_schemas(
+                client,
+                team,
+                min_confidence,
+                path,
+                method,
+                latest_only,
+                limit,
+                offset,
+            )
+            .await?;
+            if output == "table" {
+                print_schemas_table(&schemas);
+            } else {
+                print_output(&schemas, &output)?;
+            }
+        }
+        SchemaCommands::Get { id, output } => {
+            let schema = get_schema(client, team, id).await?;
+            if output == "table" {
+                print_schema_detail(&schema);
+            } else {
+                print_output(&schema, &output)?;
+            }
+        }
+        SchemaCommands::Export { id, all, min_confidence, title, version, description, output } => {
+            export_schemas(
+                client,
+                team,
+                id,
+                all,
+                min_confidence,
+                title,
+                version,
+                description,
+                output,
+            )
+            .await?;
+        }
+    }
+
+    Ok(())
+}
+
+/// List schemas — reused by both `schema list` and `learn export`
+#[allow(clippy::too_many_arguments)]
+pub async fn list_schemas(
+    client: &FlowplaneClient,
+    team: &str,
+    min_confidence: Option<f64>,
+    path: Option<String>,
+    method: Option<String>,
+    latest_only: bool,
+    limit: Option<i32>,
+    offset: Option<i32>,
+) -> Result<Vec<AggregatedSchemaResponse>> {
+    let mut query_path = format!("/api/v1/teams/{team}/aggregated-schemas?");
+    let mut params = Vec::new();
+
+    if let Some(c) = min_confidence {
+        params.push(format!("minConfidence={c}"));
+    }
+    if let Some(p) = &path {
+        params.push(format!("path={p}"));
+    }
+    if let Some(m) = &method {
+        params.push(format!("httpMethod={m}"));
+    }
+    if latest_only {
+        params.push("latestOnly=true".to_string());
+    }
+    if let Some(l) = limit {
+        params.push(format!("limit={l}"));
+    }
+    if let Some(o) = offset {
+        params.push(format!("offset={o}"));
+    }
+
+    query_path.push_str(&params.join("&"));
+
+    client.get_json(&query_path).await
+}
+
+/// Export schemas as OpenAPI — reused by both `schema export` and `learn export`
+#[allow(clippy::too_many_arguments)]
+pub async fn export_schemas(
+    client: &FlowplaneClient,
+    team: &str,
+    ids: Option<Vec<i64>>,
+    all: bool,
+    min_confidence: Option<f64>,
+    title: String,
+    version: String,
+    description: Option<String>,
+    output: Option<String>,
+) -> Result<()> {
+    // Resolve schema IDs
+    let schema_ids = if let Some(ids) = ids {
+        if ids.is_empty() {
+            anyhow::bail!("No schema IDs provided. Use --id 1,2,3 or --all");
+        }
+        ids
+    } else if all {
+        let schemas =
+            list_schemas(client, team, min_confidence, None, None, true, None, None).await?;
+        if schemas.is_empty() {
+            anyhow::bail!("No schemas found. Run a learning session first.");
+        }
+        schemas.iter().map(|s| s.id).collect()
+    } else {
+        // Show available schemas and error
+        let schemas = list_schemas(client, team, None, None, None, true, Some(10), None).await?;
+        if schemas.is_empty() {
+            anyhow::bail!("No schemas found. Run a learning session first.");
+        }
+        eprintln!("Available schemas:");
+        for s in &schemas {
+            eprintln!(
+                "  [{:3}] {:6} {:40} conf={:.2}  samples={}",
+                s.id, s.http_method, s.path, s.confidence_score, s.sample_count
+            );
+        }
+        anyhow::bail!("Specify schemas with --id 1,2,3 or use --all to export everything");
+    };
+
+    let body = ExportRequest { schema_ids, title, version, description };
+
+    let export_path = format!("/api/v1/teams/{team}/aggregated-schemas/export");
+    let spec: serde_json::Value = client.post_json(&export_path, &body).await?;
+
+    // Determine output format and destination
+    match output {
+        Some(ref file_path) => {
+            let content = if file_path.ends_with(".json") {
+                serde_json::to_string_pretty(&spec).context("Failed to serialize to JSON")?
+            } else {
+                // Default to YAML for .yaml, .yml, or any other extension
+                serde_yaml::to_string(&spec).context("Failed to serialize to YAML")?
+            };
+            std::fs::write(file_path, &content)
+                .with_context(|| format!("Failed to write to {file_path}"))?;
+            eprintln!("Exported OpenAPI spec to {file_path}");
+        }
+        None => {
+            // Stdout — default to YAML (more readable for humans)
+            let yaml = serde_yaml::to_string(&spec).context("Failed to serialize to YAML")?;
+            print!("{yaml}");
+        }
+    }
+
+    Ok(())
+}
+
+async fn get_schema(
+    client: &FlowplaneClient,
+    team: &str,
+    id: i64,
+) -> Result<AggregatedSchemaResponse> {
+    let path = format!("/api/v1/teams/{team}/aggregated-schemas/{id}");
+    client.get_json(&path).await
+}
+
+fn print_schemas_table(schemas: &[AggregatedSchemaResponse]) {
+    if schemas.is_empty() {
+        println!("No schemas found. Run a learning session to discover API schemas.");
+        return;
+    }
+
+    println!();
+    println!(
+        "{:>5}  {:<7} {:<45} {:>10} {:>8} {:>7}",
+        "ID", "Method", "Path", "Confidence", "Samples", "Version"
+    );
+    println!("{}", "-".repeat(88));
+
+    for s in schemas {
+        println!(
+            "{:>5}  {:<7} {:<45} {:>9.2}% {:>8} {:>7}",
+            s.id,
+            s.http_method,
+            truncate(&s.path, 43),
+            s.confidence_score * 100.0,
+            s.sample_count,
+            s.version,
+        );
+    }
+
+    let total_samples: i64 = schemas.iter().map(|s| s.sample_count).sum();
+    let avg_confidence: f64 =
+        schemas.iter().map(|s| s.confidence_score).sum::<f64>() / schemas.len() as f64;
+    println!("{}", "-".repeat(88));
+    println!(
+        "{:>5}  {:<7} {:<45} {:>9.2}% {:>8}",
+        schemas.len(),
+        "total",
+        "",
+        avg_confidence * 100.0,
+        total_samples,
+    );
+    println!();
+}
+
+fn print_schema_detail(s: &AggregatedSchemaResponse) {
+    println!();
+    println!("Schema #{}", s.id);
+    println!("{}", "-".repeat(50));
+    println!("  Path:            {}", s.path);
+    println!("  Method:          {}", s.http_method);
+    println!("  Confidence:      {:.1}%", s.confidence_score * 100.0);
+    println!("  Samples:         {}", s.sample_count);
+    println!("  Version:         {}", s.version);
+    println!("  First observed:  {}", s.first_observed);
+    println!("  Last observed:   {}", s.last_observed);
+
+    if let Some(ref changes) = s.breaking_changes {
+        if !changes.is_empty() {
+            println!("  Breaking changes: {}", changes.len());
+        }
+    }
+
+    if let Some(ref req) = s.request_schema {
+        println!();
+        println!("  Request Schema:");
+        if let Some(props) = req.get("properties").and_then(|p| p.as_object()) {
+            for (name, prop) in props {
+                let type_str = prop.get("type").and_then(|t| t.as_str()).unwrap_or("unknown");
+                let format_str = prop.get("format").and_then(|f| f.as_str());
+                let required = req
+                    .get("required")
+                    .and_then(|r| r.as_array())
+                    .map(|arr| arr.iter().any(|v| v.as_str() == Some(name)))
+                    .unwrap_or(false);
+                let req_marker = if required { "*" } else { " " };
+                match format_str {
+                    Some(fmt) => println!("    {req_marker} {name}: {type_str} ({fmt})"),
+                    None => println!("    {req_marker} {name}: {type_str}"),
+                }
+            }
+            println!("    (* = required)");
+        }
+    }
+
+    if let Some(ref resp) = s.response_schemas {
+        if let Some(obj) = resp.as_object() {
+            for (code, schema) in obj {
+                println!();
+                println!("  Response {code}:");
+                if let Some(props) = schema.get("properties").and_then(|p| p.as_object()) {
+                    for (name, prop) in props {
+                        let type_str =
+                            prop.get("type").and_then(|t| t.as_str()).unwrap_or("unknown");
+                        let format_str = prop.get("format").and_then(|f| f.as_str());
+                        match format_str {
+                            Some(fmt) => println!("      {name}: {type_str} ({fmt})"),
+                            None => println!("      {name}: {type_str}"),
+                        }
+                    }
+                } else if let Some(type_str) = schema.get("type").and_then(|t| t.as_str()) {
+                    println!("      type: {type_str}");
+                }
+            }
+        }
+    }
+    println!();
+}
+
+fn print_output<T: Serialize>(data: &T, format: &str) -> Result<()> {
+    match format {
+        "json" => {
+            let json = serde_json::to_string_pretty(data).context("Failed to serialize to JSON")?;
+            println!("{json}");
+        }
+        "yaml" => {
+            let yaml = serde_yaml::to_string(data).context("Failed to serialize to YAML")?;
+            println!("{yaml}");
+        }
+        _ => {
+            anyhow::bail!("Unsupported output format: {}. Use 'json', 'yaml', or 'table'.", format);
+        }
+    }
+    Ok(())
+}
+
+fn truncate(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max_len.saturating_sub(3)])
+    }
+}

--- a/src/cli/schema.rs
+++ b/src/cli/schema.rs
@@ -17,6 +17,10 @@ pub enum SchemaCommands {
         after_help = "EXAMPLES:\n    # List all schemas\n    flowplane schema list\n\n    # Filter by confidence\n    flowplane schema list --min-confidence 0.7\n\n    # Filter by HTTP method\n    flowplane schema list --method GET\n\n    # JSON output for scripting\n    flowplane schema list -o json"
     )]
     List {
+        /// Filter by learning session (name or UUID)
+        #[arg(long)]
+        session: Option<String>,
+
         /// Minimum confidence score (0.0 - 1.0)
         #[arg(long)]
         min_confidence: Option<f64>,
@@ -67,6 +71,10 @@ pub enum SchemaCommands {
         after_help = "EXAMPLES:\n    # Export all schemas as YAML to stdout\n    flowplane schema export --all\n\n    # Export specific schemas to a file\n    flowplane schema export --id 1,2,3 -o api.yaml\n\n    # Export high-confidence schemas as JSON\n    flowplane schema export --all --min-confidence 0.7 -o api.json\n\n    # Pipe to another tool\n    flowplane schema export --all | yq '.paths'"
     )]
     Export {
+        /// Export schemas from a specific session (name or UUID)
+        #[arg(long)]
+        session: Option<String>,
+
         /// Schema IDs to export (comma-separated)
         #[arg(long, value_delimiter = ',')]
         id: Option<Vec<i64>>,
@@ -136,6 +144,7 @@ pub async fn handle_schema_command(
 ) -> Result<()> {
     match command {
         SchemaCommands::List {
+            session,
             min_confidence,
             path,
             method,
@@ -153,6 +162,7 @@ pub async fn handle_schema_command(
                 latest_only,
                 limit,
                 offset,
+                session,
             )
             .await?;
             if output == "table" {
@@ -169,7 +179,16 @@ pub async fn handle_schema_command(
                 print_output(&schema, &output)?;
             }
         }
-        SchemaCommands::Export { id, all, min_confidence, title, version, description, output } => {
+        SchemaCommands::Export {
+            session,
+            id,
+            all,
+            min_confidence,
+            title,
+            version,
+            description,
+            output,
+        } => {
             export_schemas(
                 client,
                 team,
@@ -180,6 +199,7 @@ pub async fn handle_schema_command(
                 version,
                 description,
                 output,
+                session,
             )
             .await?;
         }
@@ -199,6 +219,7 @@ pub async fn list_schemas(
     latest_only: bool,
     limit: Option<i32>,
     offset: Option<i32>,
+    session: Option<String>,
 ) -> Result<Vec<AggregatedSchemaResponse>> {
     let mut query_path = format!("/api/v1/teams/{team}/aggregated-schemas?");
     let mut params = Vec::new();
@@ -221,6 +242,9 @@ pub async fn list_schemas(
     if let Some(o) = offset {
         params.push(format!("offset={o}"));
     }
+    if let Some(s) = &session {
+        params.push(format!("sessionId={s}"));
+    }
 
     query_path.push_str(&params.join("&"));
 
@@ -239,6 +263,7 @@ pub async fn export_schemas(
     version: String,
     description: Option<String>,
     output: Option<String>,
+    session: Option<String>,
 ) -> Result<()> {
     // Resolve schema IDs
     let schema_ids = if let Some(ids) = ids {
@@ -248,14 +273,16 @@ pub async fn export_schemas(
         ids
     } else if all {
         let schemas =
-            list_schemas(client, team, min_confidence, None, None, true, None, None).await?;
+            list_schemas(client, team, min_confidence, None, None, true, None, None, session)
+                .await?;
         if schemas.is_empty() {
             anyhow::bail!("No schemas found. Run a learning session first.");
         }
         schemas.iter().map(|s| s.id).collect()
     } else {
         // Show available schemas and error
-        let schemas = list_schemas(client, team, None, None, None, true, Some(10), None).await?;
+        let schemas =
+            list_schemas(client, team, None, None, None, true, Some(10), None, None).await?;
         if schemas.is_empty() {
             anyhow::bail!("No schemas found. Run a learning session first.");
         }

--- a/src/cli/schema.rs
+++ b/src/cli/schema.rs
@@ -124,6 +124,10 @@ pub struct AggregatedSchemaResponse {
     pub last_observed: String,
     pub created_at: String,
     pub updated_at: String,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub snapshot_number: Option<i64>,
 }
 
 /// Export request body

--- a/src/internal_api/learning.rs
+++ b/src/internal_api/learning.rs
@@ -140,6 +140,45 @@ impl LearningSessionOperations {
         Ok(session)
     }
 
+    /// Resolve a learning session by name or ID
+    ///
+    /// Tries UUID parse first (lookup by ID), falls back to name lookup
+    /// within the user's accessible teams.
+    #[instrument(skip(self, auth), fields(name_or_id = %name_or_id))]
+    pub async fn resolve_session(
+        &self,
+        name_or_id: &str,
+        auth: &InternalAuthContext,
+    ) -> Result<LearningSessionData, InternalError> {
+        let cluster_repo = self
+            .xds_state
+            .cluster_repository
+            .as_ref()
+            .ok_or_else(|| InternalError::service_unavailable("Repository not configured"))?;
+        let repository = crate::storage::repositories::LearningSessionRepository::new(
+            cluster_repo.pool().clone(),
+        );
+
+        // Try UUID-based lookup first
+        if uuid::Uuid::parse_str(name_or_id).is_ok() {
+            if let Ok(session) = repository.get_by_id(name_or_id).await {
+                if auth.is_admin || auth.can_access_team(Some(&session.team)) {
+                    return Ok(session);
+                }
+                return Err(InternalError::not_found("Learning session", name_or_id));
+            }
+        }
+
+        // Fall back to name lookup across allowed teams
+        for team in &auth.allowed_teams {
+            if let Ok(session) = repository.get_by_name(team, name_or_id).await {
+                return Ok(session);
+            }
+        }
+
+        Err(InternalError::not_found("Learning session", name_or_id))
+    }
+
     /// Create a new learning session
     ///
     /// # Arguments
@@ -191,6 +230,23 @@ impl LearningSessionOperations {
             cluster_repo.pool().clone(),
         );
 
+        // Generate session name if not provided
+        let session_name = if let Some(name) = req.name {
+            Some(name)
+        } else {
+            let generated =
+                crate::services::learning_session_service::generate_unique_session_name(
+                    &repository,
+                    &team,
+                    &req.route_pattern,
+                )
+                .await
+                .map_err(|e| {
+                    InternalError::internal(format!("Failed to generate session name: {}", e))
+                })?;
+            Some(generated)
+        };
+
         let create_request = CreateLearningSessionRequest {
             team: team.clone(),
             route_pattern: req.route_pattern.clone(),
@@ -202,6 +258,7 @@ impl LearningSessionOperations {
             deployment_version: None,
             configuration_snapshot: None,
             auto_aggregate: req.auto_aggregate.unwrap_or(false),
+            name: session_name,
         };
 
         let created = repository.create(create_request).await.map_err(InternalError::from)?;
@@ -273,8 +330,8 @@ impl LearningSessionOperations {
         id: &str,
         auth: &InternalAuthContext,
     ) -> Result<OperationResult<LearningSessionData>, InternalError> {
-        // Verify access
-        let session = self.get(id, auth).await?;
+        // Verify access — resolve name or ID
+        let session = self.resolve_session(id, auth).await?;
 
         // Validate state
         if session.status != LearningSessionStatus::Active {
@@ -290,12 +347,12 @@ impl LearningSessionOperations {
         })?;
 
         let completed = service
-            .stop_session(id)
+            .stop_session(&session.id)
             .await
             .map_err(|e| InternalError::internal(format!("Failed to stop session: {}", e)))?;
 
         info!(
-            session_id = %id,
+            session_id = %session.id,
             team = %completed.team,
             "Learning session stopped via internal API"
         );
@@ -321,8 +378,8 @@ impl LearningSessionOperations {
         id: &str,
         auth: &InternalAuthContext,
     ) -> Result<OperationResult<()>, InternalError> {
-        // 1. Get existing session and verify access
-        let existing = self.get(id, auth).await?;
+        // 1. Resolve session by name or ID and verify access
+        let existing = self.resolve_session(id, auth).await?;
 
         // 2. Validate state - can only delete pending or active sessions
         match existing.status {
@@ -353,23 +410,23 @@ impl LearningSessionOperations {
             cluster_repo.pool().clone(),
         );
 
-        repository.delete(id, &existing.team).await.map_err(InternalError::from)?;
+        repository.delete(&existing.id, &existing.team).await.map_err(InternalError::from)?;
 
         // 4. If session was active, unregister from access log service
         if existing.status == LearningSessionStatus::Active {
             if let Some(access_log_service) = &self.xds_state.access_log_service {
-                access_log_service.remove_session(id).await;
+                access_log_service.remove_session(&existing.id).await;
                 info!(
-                    session_id = %id,
+                    session_id = %existing.id,
                     "Unregistered learning session from Access Log Service"
                 );
             }
 
             // Unregister from ExtProc service
             if let Some(ext_proc_service) = &self.xds_state.ext_proc_service {
-                ext_proc_service.remove_session(id).await;
+                ext_proc_service.remove_session(&existing.id).await;
                 info!(
-                    session_id = %id,
+                    session_id = %existing.id,
                     "Unregistered learning session from ExtProc Service"
                 );
             }
@@ -377,20 +434,20 @@ impl LearningSessionOperations {
             // Trigger LDS update to remove access log configuration
             if let Err(e) = self.xds_state.refresh_listeners_from_repository().await {
                 tracing::error!(
-                    session_id = %id,
+                    session_id = %existing.id,
                     error = %e,
                     "Failed to refresh listeners after session deletion"
                 );
             } else {
                 info!(
-                    session_id = %id,
+                    session_id = %existing.id,
                     "Triggered LDS update to remove access log configuration"
                 );
             }
         }
 
         info!(
-            session_id = %id,
+            session_id = %existing.id,
             team = %existing.team,
             "Learning session deleted via internal API"
         );
@@ -424,6 +481,7 @@ mod tests {
             target_sample_count: 100,
             auto_start: Some(false),
             auto_aggregate: None,
+            name: None,
         };
 
         let result = ops.create(req, &auth).await;
@@ -450,6 +508,7 @@ mod tests {
             target_sample_count: 50,
             auto_start: Some(false),
             auto_aggregate: None,
+            name: None,
         };
 
         let result = ops.create(req, &auth).await;
@@ -470,6 +529,7 @@ mod tests {
             target_sample_count: 50,
             auto_start: Some(false),
             auto_aggregate: None,
+            name: None,
         };
 
         let result = ops.create(req, &auth).await;
@@ -491,6 +551,7 @@ mod tests {
             target_sample_count: 0, // Invalid
             auto_start: Some(false),
             auto_aggregate: None,
+            name: None,
         };
 
         let result = ops.create(req, &auth).await;
@@ -524,6 +585,7 @@ mod tests {
             target_sample_count: 100,
             auto_start: Some(false),
             auto_aggregate: None,
+            name: None,
         };
         let created = ops.create(req, &admin_auth).await.expect("create session");
 
@@ -554,6 +616,7 @@ mod tests {
                     target_sample_count: 100,
                     auto_start: Some(false),
                     auto_aggregate: None,
+                    name: None,
                 };
                 ops.create(req, &admin_auth).await.expect("create session");
             }
@@ -586,6 +649,7 @@ mod tests {
             target_sample_count: 100,
             auto_start: Some(false),
             auto_aggregate: None,
+            name: None,
         };
         let created = ops.create(create_req, &auth).await.expect("create session");
 

--- a/src/internal_api/learning.rs
+++ b/src/internal_api/learning.rs
@@ -201,6 +201,7 @@ impl LearningSessionOperations {
             triggered_by: None,
             deployment_version: None,
             configuration_snapshot: None,
+            auto_aggregate: req.auto_aggregate.unwrap_or(false),
         };
 
         let created = repository.create(create_request).await.map_err(InternalError::from)?;
@@ -255,6 +256,54 @@ impl LearningSessionOperations {
         };
 
         Ok(OperationResult::with_message(session, message))
+    }
+
+    /// Stop an active learning session (trigger final aggregation + complete)
+    ///
+    /// # Arguments
+    /// * `id` - The session ID to stop
+    /// * `auth` - Authentication context for access control
+    ///
+    /// # Returns
+    /// * `Ok(OperationResult)` with the completed session
+    /// * `Err(InternalError)` on failure
+    #[instrument(skip(self, auth), fields(session_id = %id))]
+    pub async fn stop(
+        &self,
+        id: &str,
+        auth: &InternalAuthContext,
+    ) -> Result<OperationResult<LearningSessionData>, InternalError> {
+        // Verify access
+        let session = self.get(id, auth).await?;
+
+        // Validate state
+        if session.status != LearningSessionStatus::Active {
+            return Err(InternalError::conflict(format!(
+                "Cannot stop session in '{}' state. Must be 'active'",
+                session.status
+            )));
+        }
+
+        // Use the learning session service to stop (triggers final aggregation + completion)
+        let service = self.xds_state.get_learning_session_service().ok_or_else(|| {
+            InternalError::service_unavailable("Learning session service not available")
+        })?;
+
+        let completed = service
+            .stop_session(id)
+            .await
+            .map_err(|e| InternalError::internal(format!("Failed to stop session: {}", e)))?;
+
+        info!(
+            session_id = %id,
+            team = %completed.team,
+            "Learning session stopped via internal API"
+        );
+
+        Ok(OperationResult::with_message(
+            completed,
+            "Learning session stopped and final aggregation triggered.",
+        ))
     }
 
     /// Delete (cancel) a learning session
@@ -374,6 +423,7 @@ mod tests {
             http_methods: Some(vec!["GET".to_string(), "POST".to_string()]),
             target_sample_count: 100,
             auto_start: Some(false),
+            auto_aggregate: None,
         };
 
         let result = ops.create(req, &auth).await;
@@ -399,6 +449,7 @@ mod tests {
             http_methods: None,
             target_sample_count: 50,
             auto_start: Some(false),
+            auto_aggregate: None,
         };
 
         let result = ops.create(req, &auth).await;
@@ -418,6 +469,7 @@ mod tests {
             http_methods: None,
             target_sample_count: 50,
             auto_start: Some(false),
+            auto_aggregate: None,
         };
 
         let result = ops.create(req, &auth).await;
@@ -438,6 +490,7 @@ mod tests {
             http_methods: None,
             target_sample_count: 0, // Invalid
             auto_start: Some(false),
+            auto_aggregate: None,
         };
 
         let result = ops.create(req, &auth).await;
@@ -470,6 +523,7 @@ mod tests {
             http_methods: None,
             target_sample_count: 100,
             auto_start: Some(false),
+            auto_aggregate: None,
         };
         let created = ops.create(req, &admin_auth).await.expect("create session");
 
@@ -499,6 +553,7 @@ mod tests {
                     http_methods: None,
                     target_sample_count: 100,
                     auto_start: Some(false),
+                    auto_aggregate: None,
                 };
                 ops.create(req, &admin_auth).await.expect("create session");
             }
@@ -530,6 +585,7 @@ mod tests {
             http_methods: None,
             target_sample_count: 100,
             auto_start: Some(false),
+            auto_aggregate: None,
         };
         let created = ops.create(create_req, &auth).await.expect("create session");
 

--- a/src/internal_api/schemas.rs
+++ b/src/internal_api/schemas.rs
@@ -268,6 +268,8 @@ mod tests {
             first_observed: chrono::Utc::now(),
             last_observed: chrono::Utc::now(),
             previous_version_id: None,
+            session_id: None,
+            snapshot_number: None,
         };
 
         repo.create(request).await.expect("create schema")
@@ -361,6 +363,8 @@ mod tests {
             first_observed: chrono::Utc::now(),
             last_observed: chrono::Utc::now(),
             previous_version_id: Some(schema_v1.id),
+            session_id: None,
+            snapshot_number: None,
         };
         repo.create(request_v2).await.expect("create v2");
 
@@ -451,6 +455,8 @@ mod tests {
                 first_observed: chrono::Utc::now(),
                 last_observed: chrono::Utc::now(),
                 previous_version_id: if i == 2 { Some(schema_v1.id) } else { None },
+                session_id: None,
+                snapshot_number: None,
             };
             repo.create(request).await.expect("create version");
         }

--- a/src/internal_api/schemas.rs
+++ b/src/internal_api/schemas.rs
@@ -73,6 +73,7 @@ impl AggregatedSchemaOperations {
             } else if req.path.is_some()
                 || req.http_method.is_some()
                 || req.min_confidence.is_some()
+                || req.session_id.is_some()
             {
                 // Use filtered query
                 repository
@@ -81,6 +82,7 @@ impl AggregatedSchemaOperations {
                         req.path.as_deref(),
                         req.http_method.as_deref(),
                         req.min_confidence,
+                        req.session_id.as_deref(),
                     )
                     .await
                     .map_err(InternalError::from)?

--- a/src/internal_api/types.rs
+++ b/src/internal_api/types.rs
@@ -421,6 +421,8 @@ pub struct CreateLearningSessionInternalRequest {
     pub target_sample_count: i64,
     /// Whether to automatically start the session after creation
     pub auto_start: Option<bool>,
+    /// Whether to use auto-aggregate snapshot mode
+    pub auto_aggregate: Option<bool>,
 }
 
 /// Request to list learning sessions with pagination

--- a/src/internal_api/types.rs
+++ b/src/internal_api/types.rs
@@ -423,6 +423,8 @@ pub struct CreateLearningSessionInternalRequest {
     pub auto_start: Option<bool>,
     /// Whether to use auto-aggregate snapshot mode
     pub auto_aggregate: Option<bool>,
+    /// Optional human-friendly session name (auto-generated if omitted)
+    pub name: Option<String>,
 }
 
 /// Request to list learning sessions with pagination
@@ -455,6 +457,8 @@ pub struct ListSchemasRequest {
     pub limit: Option<i32>,
     /// Offset for pagination
     pub offset: Option<i32>,
+    /// Filter by learning session ID
+    pub session_id: Option<String>,
 }
 
 /// Response for listing aggregated schemas

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -753,6 +753,7 @@ impl McpHandler {
             | "cp_create_learning_session"
             | "cp_activate_learning_session"
             | "cp_delete_learning_session"
+            | "cp_stop_learning"
             | "ops_learning_session_health"
             | "cp_create_cluster"
             | "cp_update_cluster"
@@ -1176,6 +1177,15 @@ impl McpHandler {
                     }
                     "cp_delete_learning_session" => {
                         tools::execute_delete_learning_session(
+                            xds_state,
+                            &tool_team,
+                            self.context.org_id.as_ref(),
+                            args,
+                        )
+                        .await
+                    }
+                    "cp_stop_learning" => {
+                        tools::execute_stop_learning_session(
                             xds_state,
                             &tool_team,
                             self.context.org_id.as_ref(),

--- a/src/mcp/tools/learning.rs
+++ b/src/mcp/tools/learning.rs
@@ -114,7 +114,7 @@ RELATED TOOLS: cp_list_learning_sessions (discovery), cp_create_learning_session
             "properties": {
                 "id": {
                     "type": "string",
-                    "description": "Learning session UUID"
+                    "description": "Learning session UUID or name"
                 }
             },
             "required": ["id"]
@@ -201,6 +201,10 @@ Authorization: Requires learning-sessions:create scope.
                 "autoAggregate": {
                     "type": "boolean",
                     "description": "Enable snapshot mode: when target is reached, aggregate and reset instead of completing. Session continues until explicitly stopped with cp_stop_learning. (default: false)"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Optional human-friendly session name (auto-generated from route_pattern if omitted). Must be unique within the team."
                 }
             },
             "required": ["routePattern", "targetSampleCount"]
@@ -250,7 +254,7 @@ Authorization: Requires learning-sessions:delete scope.
             "properties": {
                 "id": {
                     "type": "string",
-                    "description": "Learning session UUID to delete"
+                    "description": "Learning session UUID or name to delete"
                 }
             },
             "required": ["id"]
@@ -286,6 +290,7 @@ pub async fn execute_list_learning_sessions(
         "sessions": sessions.iter().map(|s| {
             json!({
                 "id": s.id,
+                "name": s.name,
                 "team": s.team,
                 "route_pattern": s.route_pattern,
                 "cluster_name": s.cluster_name,
@@ -331,10 +336,11 @@ pub async fn execute_get_learning_session(
         .ok_or_else(|| McpError::InternalError("Team repository unavailable".to_string()))?;
     let auth = super::resolve_mcp_auth(team, org_id, team_repo).await?;
 
-    let session = ops.get(id, &auth).await?;
+    let session = ops.resolve_session(id, &auth).await?;
 
     let result = json!({
         "id": session.id,
+        "name": session.name,
         "team": session.team,
         "route_pattern": session.route_pattern,
         "cluster_name": session.cluster_name,
@@ -386,6 +392,7 @@ pub async fn execute_create_learning_session(
     });
     let auto_start = args.get("autoStart").and_then(|v| v.as_bool());
     let auto_aggregate = args.get("autoAggregate").and_then(|v| v.as_bool());
+    let name = args.get("name").and_then(|v| v.as_str()).map(String::from);
 
     tracing::debug!(
         team = %team,
@@ -417,6 +424,7 @@ pub async fn execute_create_learning_session(
         target_sample_count,
         auto_start,
         auto_aggregate,
+        name,
     };
 
     let result = ops.create(req, &auth).await?;
@@ -424,6 +432,7 @@ pub async fn execute_create_learning_session(
     // 5. Format success response — include status so agents can verify activation
     let mut output =
         build_create_response("learning_session", &result.data.route_pattern, &result.data.id);
+    output["name"] = json!(result.data.name);
     output["status"] = json!(result.data.status.to_string());
     output["started_at"] = match &result.data.started_at {
         Some(ts) => json!(ts.to_rfc3339()),
@@ -523,7 +532,7 @@ Authorization: Requires learning-sessions:execute scope.
             "properties": {
                 "id": {
                     "type": "string",
-                    "description": "Learning session UUID to stop"
+                    "description": "Learning session UUID or name to stop"
                 }
             },
             "required": ["id"]
@@ -642,7 +651,7 @@ pub async fn execute_activate_learning_session(
     let auth = super::resolve_mcp_auth(team, org_id, team_repo).await?;
 
     // Verify the session exists and belongs to this team
-    let session = ops.get(id, &auth).await?;
+    let session = ops.resolve_session(id, &auth).await?;
     if session.status.to_string() != "pending" {
         return Err(McpError::InvalidParams(format!(
             "Cannot activate session in '{}' state — must be 'pending'",
@@ -656,7 +665,7 @@ pub async fn execute_activate_learning_session(
     })?;
 
     let activated = service
-        .activate_session(id)
+        .activate_session(&session.id)
         .await
         .map_err(|e| McpError::InternalError(format!("Failed to activate session: {}", e)))?;
 
@@ -744,7 +753,7 @@ pub async fn execute_ops_learning_session_health(
         .ok_or_else(|| McpError::InternalError("Team repository unavailable".to_string()))?;
     let auth = super::resolve_mcp_auth(team, org_id, team_repo).await?;
 
-    let session = ops.get(id, &auth).await?;
+    let session = ops.resolve_session(id, &auth).await?;
 
     let status_str = session.status.to_string();
     let mut checks: Vec<Value> = Vec::new();

--- a/src/mcp/tools/learning.rs
+++ b/src/mcp/tools/learning.rs
@@ -197,6 +197,10 @@ Authorization: Requires learning-sessions:create scope.
                 "autoStart": {
                     "type": "boolean",
                     "description": "Whether to automatically start the session (default: true)"
+                },
+                "autoAggregate": {
+                    "type": "boolean",
+                    "description": "Enable snapshot mode: when target is reached, aggregate and reset instead of completing. Session continues until explicitly stopped with cp_stop_learning. (default: false)"
                 }
             },
             "required": ["routePattern", "targetSampleCount"]
@@ -381,6 +385,7 @@ pub async fn execute_create_learning_session(
         })
     });
     let auto_start = args.get("autoStart").and_then(|v| v.as_bool());
+    let auto_aggregate = args.get("autoAggregate").and_then(|v| v.as_bool());
 
     tracing::debug!(
         team = %team,
@@ -411,6 +416,7 @@ pub async fn execute_create_learning_session(
         http_methods,
         target_sample_count,
         auto_start,
+        auto_aggregate,
     };
 
     let result = ops.create(req, &auth).await?;
@@ -472,6 +478,94 @@ pub async fn execute_delete_learning_session(
     let text = serde_json::to_string(&output).map_err(McpError::SerializationError)?;
 
     tracing::info!(team = %team, session_id = %id, "Successfully deleted learning session via MCP");
+
+    Ok(ToolCallResult::text(text))
+}
+
+// =============================================================================
+// STOP LEARNING SESSION
+// =============================================================================
+
+/// Tool definition for stopping a learning session
+pub fn cp_stop_learning_session_tool() -> Tool {
+    Tool::new(
+        "cp_stop_learning",
+        r#"Stop an active learning session, triggering final schema aggregation.
+
+PURPOSE: Explicitly stop a session that is actively collecting traffic. This triggers a final schema aggregation and marks the session as completed.
+
+WHEN TO USE:
+- Stop an auto-aggregate session that would otherwise run indefinitely
+- End a session early before it reaches its target sample count
+- Trigger immediate schema generation from collected samples
+
+BEHAVIOR:
+- Triggers final schema aggregation from all collected samples
+- Transitions session from 'active' to 'completing' to 'completed'
+- Unregisters from traffic collection pipeline
+- Generated schemas available via cp_list_aggregated_schemas
+
+PREREQUISITES:
+- Session must be in 'active' state
+- Sessions in other states cannot be stopped (use cp_delete_learning_session to cancel pending sessions)
+
+Required Parameters:
+- id: Session UUID to stop
+
+AFTER STOPPING:
+- Check generated schemas with cp_list_aggregated_schemas
+- View session final state with cp_get_learning_session
+
+Authorization: Requires learning-sessions:execute scope.
+"#,
+        json!({
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Learning session UUID to stop"
+                }
+            },
+            "required": ["id"]
+        }),
+    )
+}
+
+/// Execute stop learning session
+#[instrument(skip(xds_state, args), fields(team = %team), name = "mcp_execute_stop_learning_session")]
+pub async fn execute_stop_learning_session(
+    xds_state: &Arc<XdsState>,
+    team: &str,
+    org_id: Option<&OrgId>,
+    args: Value,
+) -> Result<ToolCallResult, McpError> {
+    let id = args["id"]
+        .as_str()
+        .ok_or_else(|| McpError::InvalidParams("Missing required parameter: id".to_string()))?;
+
+    // Use internal API layer for access control
+    let ops = LearningSessionOperations::new(xds_state.clone());
+    let team_repo = xds_state
+        .team_repository
+        .as_ref()
+        .ok_or_else(|| McpError::InternalError("Team repository unavailable".to_string()))?;
+    let auth = super::resolve_mcp_auth(team, org_id, team_repo).await?;
+
+    let result = ops.stop(id, &auth).await?;
+
+    let mut output = build_action_response(true, None);
+    output["status"] = json!(result.data.status.to_string());
+    output["completed_at"] = match &result.data.completed_at {
+        Some(ts) => json!(ts.to_rfc3339()),
+        None => json!(null),
+    };
+    output["snapshot_count"] = json!(result.data.snapshot_count);
+    output["next_step"] =
+        json!("Session completed. Use cp_list_aggregated_schemas to view generated schemas.");
+
+    let text = serde_json::to_string(&output).map_err(McpError::SerializationError)?;
+
+    tracing::info!(team = %team, session_id = %id, "Learning session stopped via MCP");
 
     Ok(ToolCallResult::text(text))
 }
@@ -896,6 +990,26 @@ mod tests {
     }
 
     #[test]
+    fn test_cp_stop_learning_session_tool_definition() {
+        let tool = cp_stop_learning_session_tool();
+        assert_eq!(tool.name, "cp_stop_learning");
+        assert!(tool.description.as_ref().unwrap().contains("Stop"));
+
+        let required = tool.input_schema["required"].as_array().unwrap();
+        assert!(required.contains(&json!("id")));
+    }
+
+    #[test]
+    fn test_cp_create_tool_has_auto_aggregate_param() {
+        let tool = cp_create_learning_session_tool();
+        let properties = tool.input_schema["properties"].as_object().unwrap();
+        assert!(
+            properties.contains_key("autoAggregate"),
+            "create tool should have autoAggregate parameter"
+        );
+    }
+
+    #[test]
     fn test_tool_names_are_unique() {
         let tools = [
             cp_list_learning_sessions_tool(),
@@ -903,6 +1017,7 @@ mod tests {
             cp_create_learning_session_tool(),
             cp_activate_learning_session_tool(),
             cp_delete_learning_session_tool(),
+            cp_stop_learning_session_tool(),
             ops_learning_session_health_tool(),
         ];
 

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -91,12 +91,12 @@ pub use schemas::{execute_get_aggregated_schema, execute_list_aggregated_schemas
 pub use learning::{
     cp_activate_learning_session_tool, cp_create_learning_session_tool,
     cp_delete_learning_session_tool, cp_get_learning_session_tool, cp_list_learning_sessions_tool,
-    ops_learning_session_health_tool,
+    cp_stop_learning_session_tool, ops_learning_session_health_tool,
 };
 pub use learning::{
     execute_activate_learning_session, execute_create_learning_session,
     execute_delete_learning_session, execute_get_learning_session, execute_list_learning_sessions,
-    execute_ops_learning_session_health,
+    execute_ops_learning_session_health, execute_stop_learning_session,
 };
 
 // Re-export OpenAPI import tools
@@ -264,6 +264,7 @@ pub fn get_all_tools() -> Vec<Tool> {
         cp_create_learning_session_tool(),
         cp_activate_learning_session_tool(),
         cp_delete_learning_session_tool(),
+        cp_stop_learning_session_tool(),
         // Learning session diagnostic tools
         ops_learning_session_health_tool(),
         // OpenAPI import tools
@@ -342,8 +343,8 @@ mod tests {
     #[test]
     fn test_get_all_tools() {
         let tools = get_all_tools();
-        // 16 read-only tools + 18 CRUD tools + 3 filter attachment + 3 learning session + 1 learning diag + 2 openapi + 5 dataplane + 2 filter types + 1 devops + 2 query-first + 2 status + 6 ops agent + 3 dev agent + 4 secrets = 68 total
-        assert_eq!(tools.len(), 68);
+        // 16 read-only tools + 18 CRUD tools + 3 filter attachment + 4 learning session + 1 learning diag + 2 openapi + 5 dataplane + 2 filter types + 1 devops + 2 query-first + 2 status + 6 ops agent + 3 dev agent + 4 secrets = 69 total
+        assert_eq!(tools.len(), 69);
 
         let tool_names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
 

--- a/src/mcp/tools/schemas.rs
+++ b/src/mcp/tools/schemas.rs
@@ -316,7 +316,15 @@ pub async fn execute_list_aggregated_schemas(
         .ok_or_else(|| McpError::InternalError("Team repository unavailable".to_string()))?;
     let auth = super::resolve_mcp_auth(team, org_id, team_repo).await?;
 
-    let req = ListSchemasRequest { path, http_method, min_confidence, latest_only, limit, offset };
+    let req = ListSchemasRequest {
+        path,
+        http_method,
+        min_confidence,
+        latest_only,
+        limit,
+        offset,
+        session_id: None,
+    };
 
     let response = ops.list(req, &auth).await?;
 

--- a/src/openapi/domain_models.rs
+++ b/src/openapi/domain_models.rs
@@ -1,0 +1,1265 @@
+//! Domain model deduplication for OpenAPI export
+//!
+//! When multiple endpoints return the same object structure (e.g., `User` in both
+//! `GET /users/{id}` and `GET /teams/{id}/members`), the exported OpenAPI spec
+//! should use `$ref` references to a shared schema in `components/schemas/` instead
+//! of duplicating the schema inline for each endpoint.
+//!
+//! This module implements:
+//! - **Fingerprinting**: Structural hashing of JSON schemas, ignoring stats/format/required/enum
+//! - **Discovery**: Finding schemas that appear in 2+ distinct endpoints with 2+ properties
+//! - **Name derivation**: Generating human-readable model names from API paths
+//! - **Ref replacement**: Replacing inline schemas with `$ref` pointers
+
+use std::collections::{HashMap, HashSet};
+
+use crate::services::singularize;
+
+/// Represents where a schema was found in the API
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct SchemaLocation {
+    /// The API path (e.g., "/v2/api/customers/{customerId}")
+    pub path: String,
+    /// The HTTP method (e.g., "GET", "POST")
+    pub method: String,
+    /// Where in the request/response (e.g., "request", "response.200")
+    pub position: String,
+}
+
+/// A discovered domain model that should be promoted to `components/schemas/`
+#[derive(Debug, Clone)]
+pub struct DomainModel {
+    /// The derived model name (e.g., "Customer")
+    pub name: String,
+    /// The structural fingerprint
+    pub fingerprint: String,
+    /// The canonical schema value (first occurrence)
+    pub schema: serde_json::Value,
+    /// All locations where this schema appears
+    pub locations: Vec<SchemaLocation>,
+}
+
+/// Intermediate tracking of a fingerprinted schema during discovery
+#[derive(Debug, Clone)]
+struct FingerprintedSchema {
+    fingerprint: String,
+    schema: serde_json::Value,
+    location: SchemaLocation,
+}
+
+/// Compute a structural fingerprint for a JSON schema.
+///
+/// The fingerprint captures the shape of the schema (property names, types, nesting)
+/// while ignoring runtime metadata like stats, format, required, enum values, etc.
+/// Two schemas with the same fingerprint are structurally identical.
+pub fn fingerprint(schema: &serde_json::Value) -> String {
+    match schema {
+        serde_json::Value::Object(map) => {
+            // Check for oneOf (our internal format uses lowercase "oneof" inside "type")
+            if let Some(type_val) = map.get("type") {
+                if let Some(type_obj) = type_val.as_object() {
+                    if let Some(oneof_arr) = type_obj.get("oneof").and_then(|v| v.as_array()) {
+                        let mut variant_fps: Vec<String> =
+                            oneof_arr.iter().map(fingerprint).collect();
+                        variant_fps.sort();
+                        return format!("oneOf({})", variant_fps.join("|"));
+                    }
+                }
+
+                // Check for standard OpenAPI oneOf at top level
+                if let Some(oneof_arr) = map.get("oneOf").and_then(|v| v.as_array()) {
+                    let mut variant_fps: Vec<String> = oneof_arr.iter().map(fingerprint).collect();
+                    variant_fps.sort();
+                    return format!("oneOf({})", variant_fps.join("|"));
+                }
+
+                let type_str = type_val.as_str().unwrap_or("unknown");
+
+                // Object with properties
+                if type_str == "object" {
+                    if let Some(props) = map.get("properties").and_then(|p| p.as_object()) {
+                        let mut prop_fps: Vec<String> = props
+                            .iter()
+                            .map(|(k, v)| format!("{}:{}", k, fingerprint(v)))
+                            .collect();
+                        prop_fps.sort();
+                        return format!("{{{}}}", prop_fps.join(","));
+                    }
+                    // Object without properties
+                    return "object".to_string();
+                }
+
+                // Array with items
+                if type_str == "array" {
+                    if let Some(items) = map.get("items") {
+                        return format!("[{}]", fingerprint(items));
+                    }
+                    return "array".to_string();
+                }
+
+                // Primitive type
+                return type_str.to_string();
+            }
+
+            // No type field — check for oneOf at top level (standard OpenAPI)
+            if let Some(oneof_arr) = map.get("oneOf").and_then(|v| v.as_array()) {
+                let mut variant_fps: Vec<String> = oneof_arr.iter().map(fingerprint).collect();
+                variant_fps.sort();
+                return format!("oneOf({})", variant_fps.join("|"));
+            }
+
+            // Unknown object — treat as opaque
+            "object".to_string()
+        }
+        serde_json::Value::String(s) => {
+            // Bare type string (e.g., in oneOf variants: ["string", "null"])
+            s.clone()
+        }
+        _ => "unknown".to_string(),
+    }
+}
+
+/// Extract all object schemas from a JSON schema recursively.
+///
+/// Returns a list of (schema, json_path) tuples for every object-typed schema
+/// found at any nesting level (including the root if it's an object).
+fn extract_object_schemas(
+    schema: &serde_json::Value,
+    location: &SchemaLocation,
+) -> Vec<FingerprintedSchema> {
+    let mut results = Vec::new();
+    extract_objects_recursive(schema, location, &mut results);
+    results
+}
+
+fn extract_objects_recursive(
+    schema: &serde_json::Value,
+    location: &SchemaLocation,
+    results: &mut Vec<FingerprintedSchema>,
+) {
+    let map = match schema.as_object() {
+        Some(m) => m,
+        None => return,
+    };
+
+    let type_str = map.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+    if type_str == "object" {
+        if let Some(props) = map.get("properties").and_then(|p| p.as_object()) {
+            // This is an object with properties — fingerprint it
+            let fp = fingerprint(schema);
+            results.push(FingerprintedSchema {
+                fingerprint: fp,
+                schema: schema.clone(),
+                location: location.clone(),
+            });
+
+            // Recurse into each property to find nested objects
+            for (_key, prop_schema) in props {
+                extract_objects_recursive(prop_schema, location, results);
+            }
+        }
+    } else if type_str == "array" {
+        // Recurse into array items
+        if let Some(items) = map.get("items") {
+            extract_objects_recursive(items, location, results);
+        }
+    }
+}
+
+/// Derive a model name from an API path.
+///
+/// Uses the last non-parameter segment of the path, singularized and title-cased.
+/// For example:
+/// - `/v2/api/customers/{customerId}` -> `Customer`
+/// - `/v2/api/customers` -> `Customer`
+/// - `/users/{id}/orders` -> `Order`
+fn derive_model_name(path: &str, _method: &str) -> String {
+    let segments: Vec<&str> =
+        path.split('/').filter(|s| !s.is_empty() && !s.starts_with('{')).collect();
+
+    let resource_name = match segments.last() {
+        Some(name) => name,
+        None => return "Model".to_string(),
+    };
+
+    let singular = singularize(resource_name);
+    title_case(&singular)
+}
+
+/// Derive a model name with priority rules:
+/// 1. Single-resource GET (`GET /users/{id}`) -> "User"
+/// 2. Collection GET array items (`GET /users`) -> "User"
+/// 3. Fallback to first usage path
+fn derive_name_from_locations(locations: &[SchemaLocation]) -> String {
+    // Priority 1: Look for single-resource GET (path ends with parameter)
+    for loc in locations {
+        if loc.method.eq_ignore_ascii_case("GET") && loc.path.ends_with('}') {
+            return derive_model_name(&loc.path, &loc.method);
+        }
+    }
+
+    // Priority 2: Look for collection GET
+    for loc in locations {
+        if loc.method.eq_ignore_ascii_case("GET") && !loc.path.ends_with('}') {
+            return derive_model_name(&loc.path, &loc.method);
+        }
+    }
+
+    // Fallback: use first location
+    if let Some(loc) = locations.first() {
+        return derive_model_name(&loc.path, &loc.method);
+    }
+
+    "Model".to_string()
+}
+
+/// Convert a string to TitleCase (first letter uppercase, rest lowercase)
+fn title_case(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => {
+            let upper: String = first.to_uppercase().collect();
+            let rest: String = chars.collect();
+            format!("{}{}", upper, rest)
+        }
+    }
+}
+
+/// Input schema data for domain model discovery
+#[derive(Debug, Clone)]
+pub struct SchemaEntry {
+    /// The API path
+    pub path: String,
+    /// The HTTP method
+    pub method: String,
+    /// Request body schema (if any)
+    pub request_schema: Option<serde_json::Value>,
+    /// Response schemas keyed by status code (if any)
+    pub response_schemas: Option<serde_json::Value>,
+}
+
+/// Result of domain model discovery
+#[derive(Debug, Clone)]
+pub struct DiscoveryResult {
+    /// Domain models to place in `components/schemas/`
+    pub models: Vec<DomainModel>,
+    /// Map from fingerprint to model name for quick lookup during ref replacement
+    pub fingerprint_to_name: HashMap<String, String>,
+}
+
+/// Discover domain models from a set of aggregated schemas.
+///
+/// Scans all request and response schemas, fingerprints object types,
+/// groups by fingerprint, and promotes to domain model if used in 2+ distinct
+/// endpoints with 2+ properties.
+pub fn discover_domain_models(entries: &[SchemaEntry]) -> DiscoveryResult {
+    // Step 1: Extract all object schemas from all entries
+    let mut all_fingerprinted: Vec<FingerprintedSchema> = Vec::new();
+
+    for entry in entries {
+        // Extract from request schema
+        if let Some(ref req_schema) = entry.request_schema {
+            let location = SchemaLocation {
+                path: entry.path.clone(),
+                method: entry.method.clone(),
+                position: "request".to_string(),
+            };
+            all_fingerprinted.extend(extract_object_schemas(req_schema, &location));
+        }
+
+        // Extract from response schemas
+        if let Some(ref resp_schemas) = entry.response_schemas {
+            if let Some(resp_map) = resp_schemas.as_object() {
+                for (status_code, resp_schema) in resp_map {
+                    if resp_schema.is_null() {
+                        continue;
+                    }
+                    let location = SchemaLocation {
+                        path: entry.path.clone(),
+                        method: entry.method.clone(),
+                        position: format!("response.{}", status_code),
+                    };
+                    all_fingerprinted.extend(extract_object_schemas(resp_schema, &location));
+                }
+            }
+        }
+    }
+
+    // Step 2: Group by fingerprint
+    let mut groups: HashMap<String, Vec<FingerprintedSchema>> = HashMap::new();
+    for fps in all_fingerprinted {
+        groups.entry(fps.fingerprint.clone()).or_default().push(fps);
+    }
+
+    // Step 3: Filter and promote
+    let mut models: Vec<DomainModel> = Vec::new();
+    let mut used_names: HashMap<String, usize> = HashMap::new();
+
+    // Sort fingerprints for deterministic output
+    let mut sorted_fps: Vec<String> = groups.keys().cloned().collect();
+    sorted_fps.sort();
+
+    for fp in sorted_fps {
+        let group = match groups.get(&fp) {
+            Some(g) => g,
+            None => continue,
+        };
+
+        // Count distinct endpoints (path + method pairs)
+        let distinct_endpoints: HashSet<String> =
+            group.iter().map(|s| format!("{} {}", s.location.method, s.location.path)).collect();
+
+        if distinct_endpoints.len() < 2 {
+            continue;
+        }
+
+        // Check property count (2+ properties required)
+        let representative = &group[0];
+        let prop_count = representative
+            .schema
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .map(|p| p.len())
+            .unwrap_or(0);
+
+        if prop_count < 2 {
+            continue;
+        }
+
+        // Derive name
+        let locations: Vec<SchemaLocation> = group.iter().map(|s| s.location.clone()).collect();
+        let base_name = derive_name_from_locations(&locations);
+
+        // Handle collisions
+        let name = if let Some(count) = used_names.get_mut(&base_name) {
+            *count += 1;
+            format!("{}{}", base_name, count)
+        } else {
+            used_names.insert(base_name.clone(), 1);
+            base_name
+        };
+
+        models.push(DomainModel {
+            name,
+            fingerprint: fp,
+            schema: representative.schema.clone(),
+            locations,
+        });
+    }
+
+    // Build lookup map
+    let fingerprint_to_name: HashMap<String, String> =
+        models.iter().map(|m| (m.fingerprint.clone(), m.name.clone())).collect();
+
+    DiscoveryResult { models, fingerprint_to_name }
+}
+
+/// Replace inline schemas with `$ref` references to discovered domain models.
+///
+/// Walks the OpenAPI paths object and replaces any inline schema whose fingerprint
+/// matches a domain model with `{"$ref": "#/components/schemas/ModelName"}`.
+pub fn replace_with_refs(
+    paths: &mut serde_json::Value,
+    fingerprint_to_name: &HashMap<String, String>,
+) {
+    if let Some(paths_obj) = paths.as_object_mut() {
+        for (_path, methods) in paths_obj.iter_mut() {
+            if let Some(methods_obj) = methods.as_object_mut() {
+                for (_method, operation) in methods_obj.iter_mut() {
+                    // Replace in request body
+                    replace_in_request_body(operation, fingerprint_to_name);
+
+                    // Replace in responses
+                    replace_in_responses(operation, fingerprint_to_name);
+                }
+            }
+        }
+    }
+}
+
+fn replace_in_request_body(
+    operation: &mut serde_json::Value,
+    fingerprint_to_name: &HashMap<String, String>,
+) {
+    let schema_ptr = &["requestBody", "content", "application/json", "schema"];
+    if let Some(schema) = get_nested_mut(operation, schema_ptr) {
+        replace_schema_recursive(schema, fingerprint_to_name);
+    }
+}
+
+fn replace_in_responses(
+    operation: &mut serde_json::Value,
+    fingerprint_to_name: &HashMap<String, String>,
+) {
+    if let Some(responses) = operation.get_mut("responses").and_then(|r| r.as_object_mut()) {
+        for (_status, response) in responses.iter_mut() {
+            let schema_ptr = &["content", "application/json", "schema"];
+            if let Some(schema) = get_nested_mut(response, schema_ptr) {
+                replace_schema_recursive(schema, fingerprint_to_name);
+            }
+        }
+    }
+}
+
+/// Recursively replace schemas with $ref if they match a domain model fingerprint.
+fn replace_schema_recursive(
+    schema: &mut serde_json::Value,
+    fingerprint_to_name: &HashMap<String, String>,
+) {
+    let fp = fingerprint(schema);
+
+    // If this schema matches a domain model, replace with $ref
+    if let Some(model_name) = fingerprint_to_name.get(&fp) {
+        // Only replace object schemas (not primitives/arrays that happen to match)
+        let is_object = schema
+            .as_object()
+            .and_then(|m| m.get("type"))
+            .and_then(|t| t.as_str())
+            .map(|t| t == "object")
+            .unwrap_or(false);
+
+        if is_object {
+            *schema = serde_json::json!({
+                "$ref": format!("#/components/schemas/{}", model_name)
+            });
+            return;
+        }
+    }
+
+    // Recurse into nested schemas
+    if let Some(map) = schema.as_object_mut() {
+        // Recurse into properties
+        if let Some(props) = map.get_mut("properties") {
+            if let Some(props_obj) = props.as_object_mut() {
+                for (_key, prop_schema) in props_obj.iter_mut() {
+                    replace_schema_recursive(prop_schema, fingerprint_to_name);
+                }
+            }
+        }
+
+        // Recurse into array items
+        if let Some(items) = map.get_mut("items") {
+            replace_schema_recursive(items, fingerprint_to_name);
+        }
+
+        // Recurse into oneOf variants
+        if let Some(oneof) = map.get_mut("oneOf") {
+            if let Some(arr) = oneof.as_array_mut() {
+                for variant in arr.iter_mut() {
+                    replace_schema_recursive(variant, fingerprint_to_name);
+                }
+            }
+        }
+    }
+}
+
+/// Navigate into nested JSON by a sequence of keys, returning a mutable reference.
+fn get_nested_mut<'a>(
+    value: &'a mut serde_json::Value,
+    keys: &[&str],
+) -> Option<&'a mut serde_json::Value> {
+    let mut current = value;
+    for key in keys {
+        current = current.get_mut(*key)?;
+    }
+    Some(current)
+}
+
+/// Build the `components.schemas` object from discovered domain models.
+///
+/// Each model's canonical schema (with internal attributes already stripped)
+/// is placed under its derived name.
+pub fn build_components_schemas(models: &[DomainModel]) -> serde_json::Value {
+    let mut schemas = serde_json::Map::new();
+    for model in models {
+        schemas.insert(model.name.clone(), model.schema.clone());
+    }
+    serde_json::Value::Object(schemas)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // === Fingerprinting tests ===
+
+    #[test]
+    fn test_fingerprint_primitive_string() {
+        let schema = json!({"type": "string"});
+        assert_eq!(fingerprint(&schema), "string");
+    }
+
+    #[test]
+    fn test_fingerprint_primitive_integer() {
+        let schema = json!({"type": "integer"});
+        assert_eq!(fingerprint(&schema), "integer");
+    }
+
+    #[test]
+    fn test_fingerprint_primitive_number() {
+        let schema = json!({"type": "number"});
+        assert_eq!(fingerprint(&schema), "number");
+    }
+
+    #[test]
+    fn test_fingerprint_primitive_boolean() {
+        let schema = json!({"type": "boolean"});
+        assert_eq!(fingerprint(&schema), "boolean");
+    }
+
+    #[test]
+    fn test_fingerprint_object_with_properties() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"}
+            }
+        });
+        // Properties should be sorted alphabetically
+        assert_eq!(fingerprint(&schema), "{age:integer,name:string}");
+    }
+
+    #[test]
+    fn test_fingerprint_object_ignores_metadata() {
+        // Two schemas with same structure but different metadata should match
+        let schema1 = json!({
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "format": "email"},
+                "id": {"type": "integer"}
+            },
+            "required": ["name", "id"],
+            "confidence": 0.95,
+            "sample_count": 100
+        });
+
+        let schema2 = json!({
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "id": {"type": "integer"}
+            }
+        });
+
+        assert_eq!(fingerprint(&schema1), fingerprint(&schema2));
+    }
+
+    #[test]
+    fn test_fingerprint_array_with_items() {
+        let schema = json!({
+            "type": "array",
+            "items": {"type": "string"}
+        });
+        assert_eq!(fingerprint(&schema), "[string]");
+    }
+
+    #[test]
+    fn test_fingerprint_nested_object() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "object",
+                    "properties": {
+                        "street": {"type": "string"},
+                        "city": {"type": "string"}
+                    }
+                },
+                "name": {"type": "string"}
+            }
+        });
+        assert_eq!(fingerprint(&schema), "{address:{city:string,street:string},name:string}");
+    }
+
+    #[test]
+    fn test_fingerprint_oneof_internal_format() {
+        // Internal flowplane format: type is an object with "oneof" key
+        let schema = json!({
+            "type": {"oneof": ["string", "null"]}
+        });
+        assert_eq!(fingerprint(&schema), "oneOf(null|string)");
+    }
+
+    #[test]
+    fn test_fingerprint_oneof_standard_format() {
+        let schema = json!({
+            "oneOf": [
+                {"type": "string"},
+                {"type": "integer"}
+            ]
+        });
+        assert_eq!(fingerprint(&schema), "oneOf(integer|string)");
+    }
+
+    #[test]
+    fn test_fingerprint_array_of_objects() {
+        let schema = json!({
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "name": {"type": "string"}
+                }
+            }
+        });
+        assert_eq!(fingerprint(&schema), "[{id:integer,name:string}]");
+    }
+
+    #[test]
+    fn test_fingerprint_property_order_independent() {
+        let schema1 = json!({
+            "type": "object",
+            "properties": {
+                "z_field": {"type": "string"},
+                "a_field": {"type": "integer"}
+            }
+        });
+        let schema2 = json!({
+            "type": "object",
+            "properties": {
+                "a_field": {"type": "integer"},
+                "z_field": {"type": "string"}
+            }
+        });
+        assert_eq!(fingerprint(&schema1), fingerprint(&schema2));
+    }
+
+    // === Discovery tests ===
+
+    #[test]
+    fn test_discover_shared_response_schema() {
+        let user_schema = json!({
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "name": {"type": "string"},
+                "email": {"type": "string"}
+            }
+        });
+
+        let entries = vec![
+            SchemaEntry {
+                path: "/users/{userId}".to_string(),
+                method: "GET".to_string(),
+                request_schema: None,
+                response_schemas: Some(json!({"200": user_schema.clone()})),
+            },
+            SchemaEntry {
+                path: "/teams/{teamId}/members".to_string(),
+                method: "GET".to_string(),
+                request_schema: None,
+                response_schemas: Some(json!({
+                    "200": {
+                        "type": "array",
+                        "items": user_schema.clone()
+                    }
+                })),
+            },
+        ];
+
+        let result = discover_domain_models(&entries);
+
+        assert_eq!(result.models.len(), 1);
+        assert_eq!(result.models[0].name, "User");
+        assert_eq!(result.models[0].locations.len(), 2);
+    }
+
+    #[test]
+    fn test_discover_no_models_when_unique() {
+        let entries = vec![
+            SchemaEntry {
+                path: "/users".to_string(),
+                method: "GET".to_string(),
+                request_schema: None,
+                response_schemas: Some(json!({
+                    "200": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "integer"},
+                            "name": {"type": "string"}
+                        }
+                    }
+                })),
+            },
+            SchemaEntry {
+                path: "/orders".to_string(),
+                method: "GET".to_string(),
+                request_schema: None,
+                response_schemas: Some(json!({
+                    "200": {
+                        "type": "object",
+                        "properties": {
+                            "orderId": {"type": "integer"},
+                            "total": {"type": "number"}
+                        }
+                    }
+                })),
+            },
+        ];
+
+        let result = discover_domain_models(&entries);
+        assert_eq!(result.models.len(), 0);
+    }
+
+    #[test]
+    fn test_discover_not_promoted_single_property() {
+        // Schema with only 1 property should not be promoted even if shared
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"}
+            }
+        });
+
+        let entries = vec![
+            SchemaEntry {
+                path: "/users".to_string(),
+                method: "GET".to_string(),
+                request_schema: None,
+                response_schemas: Some(json!({"200": schema.clone()})),
+            },
+            SchemaEntry {
+                path: "/orders".to_string(),
+                method: "GET".to_string(),
+                request_schema: None,
+                response_schemas: Some(json!({"200": schema.clone()})),
+            },
+        ];
+
+        let result = discover_domain_models(&entries);
+        assert_eq!(result.models.len(), 0);
+    }
+
+    #[test]
+    fn test_discover_not_promoted_single_endpoint() {
+        // Schema used in only 1 endpoint should not be promoted
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "name": {"type": "string"}
+            }
+        });
+
+        let entries = vec![SchemaEntry {
+            path: "/users".to_string(),
+            method: "GET".to_string(),
+            request_schema: None,
+            response_schemas: Some(json!({"200": schema})),
+        }];
+
+        let result = discover_domain_models(&entries);
+        assert_eq!(result.models.len(), 0);
+    }
+
+    // === Name derivation tests ===
+
+    #[test]
+    fn test_name_from_parameterized_path() {
+        assert_eq!(derive_model_name("/users/{userId}", "GET"), "User");
+    }
+
+    #[test]
+    fn test_name_from_collection_path() {
+        assert_eq!(derive_model_name("/users", "GET"), "User");
+    }
+
+    #[test]
+    fn test_name_from_nested_path() {
+        assert_eq!(derive_model_name("/teams/{teamId}/members", "GET"), "Member");
+    }
+
+    #[test]
+    fn test_name_from_versioned_path() {
+        assert_eq!(derive_model_name("/v2/api/customers/{customerId}", "GET"), "Customer");
+    }
+
+    #[test]
+    fn test_name_priority_single_resource_get() {
+        let locations = vec![
+            SchemaLocation {
+                path: "/users".to_string(),
+                method: "POST".to_string(),
+                position: "request".to_string(),
+            },
+            SchemaLocation {
+                path: "/users/{userId}".to_string(),
+                method: "GET".to_string(),
+                position: "response.200".to_string(),
+            },
+        ];
+        assert_eq!(derive_name_from_locations(&locations), "User");
+    }
+
+    #[test]
+    fn test_name_priority_collection_get() {
+        let locations = vec![
+            SchemaLocation {
+                path: "/users".to_string(),
+                method: "POST".to_string(),
+                position: "request".to_string(),
+            },
+            SchemaLocation {
+                path: "/users".to_string(),
+                method: "GET".to_string(),
+                position: "response.200".to_string(),
+            },
+        ];
+        assert_eq!(derive_name_from_locations(&locations), "User");
+    }
+
+    #[test]
+    fn test_name_collision_handling() {
+        // Two different schemas that both derive to "User"
+        let user_schema_v1 = json!({
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "name": {"type": "string"}
+            }
+        });
+
+        let user_schema_v2 = json!({
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "email": {"type": "string"}
+            }
+        });
+
+        let entries = vec![
+            // First "User" schema — appears in /users and /teams endpoints
+            SchemaEntry {
+                path: "/users/{userId}".to_string(),
+                method: "GET".to_string(),
+                request_schema: None,
+                response_schemas: Some(json!({"200": user_schema_v1.clone()})),
+            },
+            SchemaEntry {
+                path: "/teams/{teamId}/users".to_string(),
+                method: "GET".to_string(),
+                request_schema: None,
+                response_schemas: Some(json!({
+                    "200": {
+                        "type": "array",
+                        "items": user_schema_v1.clone()
+                    }
+                })),
+            },
+            // Second "User" schema (different structure) — appears in /admins and /managers
+            SchemaEntry {
+                path: "/admin/users/{userId}".to_string(),
+                method: "GET".to_string(),
+                request_schema: None,
+                response_schemas: Some(json!({"200": user_schema_v2.clone()})),
+            },
+            SchemaEntry {
+                path: "/managers/users".to_string(),
+                method: "GET".to_string(),
+                request_schema: None,
+                response_schemas: Some(json!({
+                    "200": {
+                        "type": "array",
+                        "items": user_schema_v2.clone()
+                    }
+                })),
+            },
+        ];
+
+        let result = discover_domain_models(&entries);
+
+        assert_eq!(result.models.len(), 2);
+
+        let names: Vec<&str> = result.models.iter().map(|m| m.name.as_str()).collect();
+        assert!(names.contains(&"User"));
+        assert!(names.contains(&"User2"));
+    }
+
+    // === Ref replacement tests ===
+
+    #[test]
+    fn test_replace_with_refs_in_response() {
+        let user_fp = "{email:string,id:integer,name:string}";
+        let mut fp_map = HashMap::new();
+        fp_map.insert(user_fp.to_string(), "User".to_string());
+
+        let mut paths = json!({
+            "/users/{userId}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {"type": "integer"},
+                                            "name": {"type": "string"},
+                                            "email": {"type": "string"}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        replace_with_refs(&mut paths, &fp_map);
+
+        let schema = &paths["/users/{userId}"]["get"]["responses"]["200"]["content"]
+            ["application/json"]["schema"];
+        assert_eq!(schema, &json!({"$ref": "#/components/schemas/User"}));
+    }
+
+    #[test]
+    fn test_replace_with_refs_in_request_body() {
+        let user_fp = "{email:string,id:integer,name:string}";
+        let mut fp_map = HashMap::new();
+        fp_map.insert(user_fp.to_string(), "User".to_string());
+
+        let mut paths = json!({
+            "/users": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {"type": "integer"},
+                                        "name": {"type": "string"},
+                                        "email": {"type": "string"}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "responses": {}
+                }
+            }
+        });
+
+        replace_with_refs(&mut paths, &fp_map);
+
+        let schema =
+            &paths["/users"]["post"]["requestBody"]["content"]["application/json"]["schema"];
+        assert_eq!(schema, &json!({"$ref": "#/components/schemas/User"}));
+    }
+
+    #[test]
+    fn test_replace_with_refs_in_array_items() {
+        let user_fp = "{email:string,id:integer,name:string}";
+        let mut fp_map = HashMap::new();
+        fp_map.insert(user_fp.to_string(), "User".to_string());
+
+        let mut paths = json!({
+            "/users": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "id": {"type": "integer"},
+                                                "name": {"type": "string"},
+                                                "email": {"type": "string"}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        replace_with_refs(&mut paths, &fp_map);
+
+        let items = &paths["/users"]["get"]["responses"]["200"]["content"]["application/json"]
+            ["schema"]["items"];
+        assert_eq!(items, &json!({"$ref": "#/components/schemas/User"}));
+    }
+
+    #[test]
+    fn test_build_components_schemas() {
+        let models = vec![
+            DomainModel {
+                name: "User".to_string(),
+                fingerprint: "fp1".to_string(),
+                schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "integer"},
+                        "name": {"type": "string"}
+                    }
+                }),
+                locations: vec![],
+            },
+            DomainModel {
+                name: "Order".to_string(),
+                fingerprint: "fp2".to_string(),
+                schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "orderId": {"type": "integer"},
+                        "total": {"type": "number"}
+                    }
+                }),
+                locations: vec![],
+            },
+        ];
+
+        let components = build_components_schemas(&models);
+        assert!(components.get("User").is_some());
+        assert!(components.get("Order").is_some());
+    }
+
+    // === End-to-end integration test ===
+
+    #[test]
+    fn test_full_discovery_and_replacement() {
+        let customer_schema = json!({
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "name": {"type": "string"},
+                "email": {"type": "string"}
+            }
+        });
+
+        let entries = vec![
+            SchemaEntry {
+                path: "/v2/api/customers".to_string(),
+                method: "GET".to_string(),
+                request_schema: None,
+                response_schemas: Some(json!({
+                    "200": {
+                        "type": "array",
+                        "items": customer_schema.clone()
+                    }
+                })),
+            },
+            SchemaEntry {
+                path: "/v2/api/customers/{customerId}".to_string(),
+                method: "GET".to_string(),
+                request_schema: None,
+                response_schemas: Some(json!({"200": customer_schema.clone()})),
+            },
+            SchemaEntry {
+                path: "/v2/api/customers".to_string(),
+                method: "POST".to_string(),
+                request_schema: Some(customer_schema.clone()),
+                response_schemas: Some(json!({"201": customer_schema.clone()})),
+            },
+        ];
+
+        let result = discover_domain_models(&entries);
+
+        assert_eq!(result.models.len(), 1);
+        assert_eq!(result.models[0].name, "Customer");
+
+        // Build components
+        let components = build_components_schemas(&result.models);
+        assert!(components.get("Customer").is_some());
+
+        // Build a mock paths object and replace
+        let mut paths = json!({
+            "/v2/api/customers": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "array",
+                                        "items": customer_schema.clone()
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": customer_schema.clone()
+                            }
+                        }
+                    },
+                    "responses": {
+                        "201": {
+                            "content": {
+                                "application/json": {
+                                    "schema": customer_schema.clone()
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "/v2/api/customers/{customerId}": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": customer_schema.clone()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        replace_with_refs(&mut paths, &result.fingerprint_to_name);
+
+        // Verify all inline customer schemas are replaced with $ref
+        let ref_value = json!({"$ref": "#/components/schemas/Customer"});
+
+        // GET /customers — array items should be ref
+        let items = &paths["/v2/api/customers"]["get"]["responses"]["200"]["content"]
+            ["application/json"]["schema"]["items"];
+        assert_eq!(items, &ref_value);
+
+        // POST /customers — request body should be ref
+        let req = &paths["/v2/api/customers"]["post"]["requestBody"]["content"]["application/json"]
+            ["schema"];
+        assert_eq!(req, &ref_value);
+
+        // POST /customers — 201 response should be ref
+        let resp_201 = &paths["/v2/api/customers"]["post"]["responses"]["201"]["content"]
+            ["application/json"]["schema"];
+        assert_eq!(resp_201, &ref_value);
+
+        // GET /customers/{customerId} — response should be ref
+        let detail = &paths["/v2/api/customers/{customerId}"]["get"]["responses"]["200"]["content"]
+            ["application/json"]["schema"];
+        assert_eq!(detail, &ref_value);
+    }
+
+    #[test]
+    fn test_discover_from_request_and_response() {
+        // Same schema in request body of one endpoint and response of another
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "description": {"type": "string"},
+                "status": {"type": "string"}
+            }
+        });
+
+        let entries = vec![
+            SchemaEntry {
+                path: "/tasks".to_string(),
+                method: "POST".to_string(),
+                request_schema: Some(schema.clone()),
+                response_schemas: None,
+            },
+            SchemaEntry {
+                path: "/tasks/{taskId}".to_string(),
+                method: "GET".to_string(),
+                request_schema: None,
+                response_schemas: Some(json!({"200": schema.clone()})),
+            },
+        ];
+
+        let result = discover_domain_models(&entries);
+
+        assert_eq!(result.models.len(), 1);
+        assert_eq!(result.models[0].name, "Task");
+    }
+
+    #[test]
+    fn test_fingerprint_object_without_properties() {
+        let schema = json!({"type": "object"});
+        assert_eq!(fingerprint(&schema), "object");
+    }
+
+    #[test]
+    fn test_fingerprint_array_without_items() {
+        let schema = json!({"type": "array"});
+        assert_eq!(fingerprint(&schema), "array");
+    }
+
+    #[test]
+    fn test_derive_name_empty_path() {
+        assert_eq!(derive_model_name("/", "GET"), "Model");
+        assert_eq!(derive_model_name("", "GET"), "Model");
+    }
+
+    #[test]
+    fn test_nested_object_discovery() {
+        // A nested "address" object that appears in both customer and supplier schemas
+        let address = json!({
+            "type": "object",
+            "properties": {
+                "street": {"type": "string"},
+                "city": {"type": "string"},
+                "zip": {"type": "string"}
+            }
+        });
+
+        let customer_schema = json!({
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "address": address.clone()
+            }
+        });
+
+        let supplier_schema = json!({
+            "type": "object",
+            "properties": {
+                "company": {"type": "string"},
+                "address": address.clone()
+            }
+        });
+
+        let entries = vec![
+            SchemaEntry {
+                path: "/customers".to_string(),
+                method: "GET".to_string(),
+                request_schema: None,
+                response_schemas: Some(json!({"200": customer_schema})),
+            },
+            SchemaEntry {
+                path: "/suppliers".to_string(),
+                method: "GET".to_string(),
+                request_schema: None,
+                response_schemas: Some(json!({"200": supplier_schema})),
+            },
+        ];
+
+        let result = discover_domain_models(&entries);
+
+        // The nested address object should be discovered as a domain model
+        // (it appears in 2 distinct endpoints and has 3 properties)
+        let address_models: Vec<&DomainModel> = result
+            .models
+            .iter()
+            .filter(|m| {
+                m.schema
+                    .get("properties")
+                    .and_then(|p| p.as_object())
+                    .map(|p| p.contains_key("street"))
+                    .unwrap_or(false)
+            })
+            .collect();
+        assert_eq!(address_models.len(), 1);
+    }
+}

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -22,6 +22,7 @@ use crate::{
 const EXTENSION_GLOBAL_FILTERS: &str = "x-flowplane-filters";
 
 pub mod defaults;
+pub mod domain_models;
 
 /// Listener mode for import operations
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/schema/inference.rs
+++ b/src/schema/inference.rs
@@ -14,6 +14,11 @@ use tracing::debug;
 
 use crate::errors::{Error, Result};
 
+/// Maximum string length for tracking observed values for enum detection
+pub const MAX_STRING_LENGTH_FOR_TRACKING: usize = 100;
+/// Maximum number of observed values to track per field
+pub const MAX_OBSERVED_VALUES: usize = 100;
+
 lazy_static! {
     static ref UUID_PATTERN: Regex = Regex::new(
         r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
@@ -273,6 +278,14 @@ pub struct InferredSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub field_mapping: Option<HashMap<String, String>>,
 
+    /// Observed string values for enum detection (transient — stripped from aggregated output)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_values: Option<Vec<String>>,
+
+    /// Promoted enum values (public output — included in aggregated schemas and OpenAPI)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enum_values: Option<Vec<String>>,
+
     /// Field statistics
     #[serde(flatten)]
     pub stats: FieldStats,
@@ -290,6 +303,8 @@ impl InferredSchema {
             items: None,
             properties: None,
             required: None,
+            observed_values: None,
+            enum_values: None,
             stats: FieldStats::new(),
         }
     }
@@ -341,6 +356,39 @@ impl InferredSchema {
             items.merge(other_items);
         }
 
+        // Merge observed_values for enum detection (deduplicate, cap at MAX_OBSERVED_VALUES)
+        match (&mut self.observed_values, &other.observed_values) {
+            (Some(ref mut self_vals), Some(other_vals)) => {
+                let existing: HashSet<String> = self_vals.iter().cloned().collect();
+                for val in other_vals {
+                    if !existing.contains(val) && self_vals.len() < MAX_OBSERVED_VALUES {
+                        self_vals.push(val.clone());
+                    }
+                }
+            }
+            (None, Some(other_vals)) => {
+                self.observed_values = Some(other_vals.clone());
+            }
+            _ => {}
+        }
+
+        // Merge enum_values (take union, sorted)
+        match (&mut self.enum_values, &other.enum_values) {
+            (Some(ref mut self_vals), Some(other_vals)) => {
+                let mut combined: HashSet<String> = self_vals.drain(..).collect();
+                for val in other_vals {
+                    combined.insert(val.clone());
+                }
+                let mut sorted: Vec<String> = combined.into_iter().collect();
+                sorted.sort();
+                *self_vals = sorted;
+            }
+            (None, Some(other_vals)) => {
+                self.enum_values = Some(other_vals.clone());
+            }
+            _ => {}
+        }
+
         // Update stats
         self.stats.sample_count += other.stats.sample_count;
         self.stats.presence_count += other.stats.presence_count;
@@ -366,7 +414,30 @@ impl InferredSchema {
             );
         }
 
+        // Strip observed_values from output — they contain raw payload data
+        // and must never appear in the exported JSON schema.
+        strip_observed_values(&mut schema);
+
         Ok(schema)
+    }
+}
+
+/// Recursively remove `observed_values` keys from a JSON value tree.
+/// These contain raw payload data that must never leak into exported schemas.
+fn strip_observed_values(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            map.remove("observed_values");
+            for v in map.values_mut() {
+                strip_observed_values(v);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                strip_observed_values(v);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -455,6 +526,10 @@ impl SchemaInferenceEngine {
                 let detected_format = self.detect_string_format(s);
                 if detected_format != StringFormat::None {
                     schema.format = Some(detected_format);
+                } else if s.len() <= MAX_STRING_LENGTH_FOR_TRACKING {
+                    // Track observed values for potential enum detection
+                    // Only for unformatted strings under the length threshold
+                    schema.observed_values = Some(vec![s.clone()]);
                 }
                 Ok(schema)
             }
@@ -1545,5 +1620,112 @@ mod tests {
         // -0.0 should be detected as Number
         let schema = engine.infer_from_value(&serde_json::json!(-0.0)).unwrap();
         assert_eq!(schema.schema_type, SchemaType::Number);
+    }
+
+    // === Enum detection tests ===
+
+    #[test]
+    fn test_string_value_tracking_no_format() {
+        let engine = SchemaInferenceEngine::new();
+        let schema = engine.infer_from_value(&Value::String("active".to_string())).ok();
+        let schema = schema.as_ref().and_then(|s| s.observed_values.as_ref());
+        assert_eq!(schema, Some(&vec!["active".to_string()]));
+    }
+
+    #[test]
+    fn test_string_value_tracking_with_format_excluded() {
+        let engine = SchemaInferenceEngine::new();
+        // UUID has a detected format — should NOT track observed_values
+        let schema = engine
+            .infer_from_value(&Value::String("550e8400-e29b-41d4-a716-446655440000".to_string()))
+            .ok();
+        let observed = schema.as_ref().and_then(|s| s.observed_values.as_ref());
+        assert!(observed.is_none(), "Formatted strings should not be tracked");
+    }
+
+    #[test]
+    fn test_string_value_tracking_email_excluded() {
+        let engine = SchemaInferenceEngine::new();
+        let schema = engine.infer_from_value(&Value::String("user@example.com".to_string())).ok();
+        let observed = schema.as_ref().and_then(|s| s.observed_values.as_ref());
+        assert!(observed.is_none(), "Email strings should not be tracked");
+    }
+
+    #[test]
+    fn test_string_value_tracking_long_string_excluded() {
+        let engine = SchemaInferenceEngine::new();
+        let long_string = "a".repeat(MAX_STRING_LENGTH_FOR_TRACKING + 1);
+        let schema = engine.infer_from_value(&Value::String(long_string)).ok();
+        let observed = schema.as_ref().and_then(|s| s.observed_values.as_ref());
+        assert!(observed.is_none(), "Long strings should not be tracked");
+    }
+
+    #[test]
+    fn test_merge_observed_values_dedup() {
+        let engine = SchemaInferenceEngine::new();
+        let mut s1 = engine.infer_from_value(&Value::String("active".to_string())).unwrap();
+        let s2 = engine.infer_from_value(&Value::String("active".to_string())).unwrap();
+        s1.merge(&s2);
+        let observed = s1.observed_values.as_ref();
+        assert_eq!(observed.map(|v| v.len()), Some(1), "Duplicate values should be deduped");
+        assert_eq!(observed.map(|v| v[0].as_str()), Some("active"));
+    }
+
+    #[test]
+    fn test_merge_observed_values_combines() {
+        let engine = SchemaInferenceEngine::new();
+        let mut s1 = engine.infer_from_value(&Value::String("active".to_string())).unwrap();
+        let s2 = engine.infer_from_value(&Value::String("inactive".to_string())).unwrap();
+        s1.merge(&s2);
+        let observed = s1.observed_values.as_ref();
+        assert_eq!(observed.map(|v| v.len()), Some(2));
+    }
+
+    #[test]
+    fn test_merge_observed_values_cap_at_max() {
+        let engine = SchemaInferenceEngine::new();
+        // Build a schema with MAX_OBSERVED_VALUES values
+        let mut base = engine.infer_from_value(&Value::String("val_0".to_string())).unwrap();
+        for i in 1..MAX_OBSERVED_VALUES {
+            let other = engine.infer_from_value(&Value::String(format!("val_{}", i))).unwrap();
+            base.merge(&other);
+        }
+        assert_eq!(base.observed_values.as_ref().map(|v| v.len()), Some(MAX_OBSERVED_VALUES));
+
+        // One more should not exceed the cap
+        let extra = engine.infer_from_value(&Value::String("overflow_value".to_string())).unwrap();
+        base.merge(&extra);
+        assert_eq!(
+            base.observed_values.as_ref().map(|v| v.len()),
+            Some(MAX_OBSERVED_VALUES),
+            "Should not exceed MAX_OBSERVED_VALUES"
+        );
+    }
+
+    #[test]
+    fn test_observed_values_serde_roundtrip() {
+        let engine = SchemaInferenceEngine::new();
+        let schema = engine.infer_from_value(&Value::String("pending".to_string())).unwrap();
+        let json = serde_json::to_string(&schema).unwrap();
+        let deserialized: InferredSchema = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.observed_values, Some(vec!["pending".to_string()]));
+    }
+
+    #[test]
+    fn test_observed_values_backward_compat_deserialization() {
+        // Old schemas without observed_values should deserialize with None
+        let json = r#"{"type":"string","sample_count":1,"presence_count":1,"confidence":1.0}"#;
+        let schema: InferredSchema = serde_json::from_str(json).unwrap();
+        assert!(schema.observed_values.is_none());
+        assert!(schema.enum_values.is_none());
+    }
+
+    #[test]
+    fn test_enum_values_serde_roundtrip() {
+        let mut schema = InferredSchema::new(SchemaType::String);
+        schema.enum_values = Some(vec!["a".to_string(), "b".to_string()]);
+        let json = serde_json::to_string(&schema).unwrap();
+        let deserialized: InferredSchema = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.enum_values, Some(vec!["a".to_string(), "b".to_string()]));
     }
 }

--- a/src/services/learning_session_service.rs
+++ b/src/services/learning_session_service.rs
@@ -193,14 +193,16 @@ impl LearningSessionService {
         Ok(updated)
     }
 
-    /// Check if a session should be completed and transition if needed
+    /// Check if a session should be completed (or snapshotted) and transition if needed
     #[instrument(skip(self), fields(session_id = %session_id), name = "check_learning_session_completion")]
     ///
     /// This method checks:
     /// 1. Has the target sample count been reached?
     /// 2. Has the session timed out (ends_at exceeded)?
     ///
-    /// If either condition is true: active → completing → completed
+    /// For auto_aggregate sessions: target reached → snapshot (stay active)
+    /// For normal sessions: target reached → completing → completed
+    /// Timeout always completes regardless of auto_aggregate.
     pub async fn check_completion(&self, session_id: &str) -> Result<Option<LearningSessionData>> {
         let session = self.repository.get_by_id(session_id).await?;
 
@@ -209,43 +211,160 @@ impl LearningSessionService {
             return Ok(None);
         }
 
-        let should_complete = self.should_complete(&session);
+        let target_reached = session.current_sample_count >= session.target_sample_count;
+        let timed_out = session.ends_at.is_some_and(|ends_at| chrono::Utc::now() >= ends_at);
 
-        if should_complete {
+        if target_reached && session.auto_aggregate && !timed_out {
+            // Auto-aggregate mode: trigger snapshot, stay active
+            self.snapshot_session(session_id).await.map(Some)
+        } else if target_reached || timed_out {
+            // Normal mode or timeout: complete the session
+            if target_reached {
+                info!(
+                    session_id = %session.id,
+                    current = session.current_sample_count,
+                    target = session.target_sample_count,
+                    "Session reached target sample count"
+                );
+            }
+            if timed_out {
+                warn!(
+                    session_id = %session.id,
+                    ends_at = %session.ends_at.map(|t| t.to_rfc3339()).unwrap_or_default(),
+                    "Session timed out"
+                );
+            }
             self.complete_session(session_id).await.map(Some)
         } else {
             Ok(None)
         }
     }
 
-    /// Determine if a session should be completed
+    /// Determine if a session should be completed (used by tests; does NOT account for auto_aggregate snapshot)
+    #[cfg(test)]
     fn should_complete(&self, session: &LearningSessionData) -> bool {
         let now = chrono::Utc::now();
-
-        // Check if target sample count reached
         let target_reached = session.current_sample_count >= session.target_sample_count;
-
-        // Check if session timed out
         let timed_out = session.ends_at.is_some_and(|ends_at| now >= ends_at);
-
-        if target_reached {
-            info!(
-                session_id = %session.id,
-                current = session.current_sample_count,
-                target = session.target_sample_count,
-                "Session reached target sample count"
-            );
-        }
-
-        if timed_out {
-            warn!(
-                session_id = %session.id,
-                ends_at = %session.ends_at.map(|t| t.to_rfc3339()).unwrap_or_default(),
-                "Session timed out"
-            );
-        }
-
         target_reached || timed_out
+    }
+
+    /// Take a snapshot of the current session state (auto-aggregate mode)
+    ///
+    /// Triggers aggregation as a snapshot, resets current_sample_count, increments
+    /// snapshot_count, and keeps the session Active for continued collection.
+    #[instrument(skip(self), fields(session_id = %session_id), name = "snapshot_learning_session")]
+    pub async fn snapshot_session(&self, session_id: &str) -> Result<LearningSessionData> {
+        let session = self.repository.get_by_id(session_id).await?;
+
+        if session.status != LearningSessionStatus::Active {
+            return Err(Error::validation(format!(
+                "Cannot snapshot session in '{}' state. Must be 'active'",
+                session.status
+            )));
+        }
+
+        if !session.auto_aggregate {
+            return Err(Error::validation(
+                "Cannot snapshot a session that is not in auto-aggregate mode".to_string(),
+            ));
+        }
+
+        // Calculate the next snapshot number
+        let next_snapshot = session.snapshot_count + 1;
+
+        info!(
+            session_id = %session_id,
+            snapshot_number = next_snapshot,
+            current_samples = session.current_sample_count,
+            "Taking snapshot of learning session"
+        );
+
+        // Trigger schema aggregation with snapshot metadata
+        if let Some(schema_aggregator) = &self.schema_aggregator {
+            match schema_aggregator
+                .aggregate_session_with_snapshot(
+                    session_id,
+                    Some(session_id.to_string()),
+                    Some(next_snapshot),
+                )
+                .await
+            {
+                Ok(aggregated_ids) => {
+                    info!(
+                        session_id = %session_id,
+                        snapshot_number = next_snapshot,
+                        aggregated_count = aggregated_ids.len(),
+                        "Successfully aggregated snapshot schemas"
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        session_id = %session_id,
+                        snapshot_number = next_snapshot,
+                        error = %e,
+                        "Failed to aggregate snapshot schemas — continuing with snapshot"
+                    );
+                }
+            }
+        } else {
+            warn!(
+                session_id = %session_id,
+                "Schema aggregator not configured — skipping snapshot aggregation"
+            );
+        }
+
+        // Reset sample count and increment snapshot count atomically
+        let new_snapshot_count =
+            self.repository.reset_sample_count_and_increment_snapshot(session_id).await?;
+
+        info!(
+            session_id = %session_id,
+            snapshot_count = new_snapshot_count,
+            "Snapshot complete — session continues collecting"
+        );
+
+        // Publish webhook event
+        if let Some(webhook_service) = &self.webhook_service {
+            let event = LearningSessionWebhookEvent::snapshot_completed(
+                session.id.clone(),
+                session.team.clone(),
+                session.route_pattern.clone(),
+                session.target_sample_count,
+                session.current_sample_count,
+                new_snapshot_count,
+            );
+            webhook_service.publish_event(event).await;
+        }
+
+        self.repository.get_by_id(session_id).await
+    }
+
+    /// Stop an auto-aggregate session (trigger final aggregation + complete)
+    ///
+    /// This is called by cp_stop_learning to explicitly end a session that
+    /// would otherwise continue collecting indefinitely.
+    #[instrument(skip(self), fields(session_id = %session_id), name = "stop_learning_session")]
+    pub async fn stop_session(&self, session_id: &str) -> Result<LearningSessionData> {
+        let session = self.repository.get_by_id(session_id).await?;
+
+        if session.status != LearningSessionStatus::Active {
+            return Err(Error::validation(format!(
+                "Cannot stop session in '{}' state. Must be 'active'",
+                session.status
+            )));
+        }
+
+        info!(
+            session_id = %session_id,
+            auto_aggregate = session.auto_aggregate,
+            snapshot_count = session.snapshot_count,
+            current_samples = session.current_sample_count,
+            "Stopping learning session — triggering final aggregation"
+        );
+
+        // Complete the session (which triggers final aggregation)
+        self.complete_session(session_id).await
     }
 
     /// Complete a learning session (active → completing → completed)
@@ -638,6 +757,8 @@ mod tests {
             configuration_snapshot: None,
             error_message: None,
             updated_at: chrono::Utc::now(),
+            auto_aggregate: false,
+            snapshot_count: 0,
         };
 
         let (_db, service) = create_test_service().await;
@@ -664,6 +785,8 @@ mod tests {
             configuration_snapshot: None,
             error_message: None,
             updated_at: chrono::Utc::now(),
+            auto_aggregate: false,
+            snapshot_count: 0,
         };
 
         let (_db, service) = create_test_service().await;
@@ -690,6 +813,8 @@ mod tests {
             configuration_snapshot: None,
             error_message: None,
             updated_at: chrono::Utc::now(),
+            auto_aggregate: false,
+            snapshot_count: 0,
         };
 
         let (_db, service) = create_test_service().await;
@@ -716,6 +841,8 @@ mod tests {
             configuration_snapshot: None,
             error_message: None,
             updated_at: chrono::Utc::now(),
+            auto_aggregate: false,
+            snapshot_count: 0,
         };
 
         let result = convert_to_access_log_session(&session);
@@ -725,6 +852,65 @@ mod tests {
         assert_eq!(learning_session.id, "test-session");
         assert_eq!(learning_session.route_patterns.len(), 1);
         assert_eq!(learning_session.methods, Some(vec!["GET".to_string(), "POST".to_string()]));
+    }
+
+    #[tokio::test]
+    async fn test_should_complete_auto_aggregate_target_reached() {
+        // should_complete returns true even for auto_aggregate sessions
+        // (the snapshot vs complete branching is in check_completion, not should_complete)
+        let session = LearningSessionData {
+            id: "test-session".to_string(),
+            team: "test-team".to_string(),
+            route_pattern: "^/api/.*".to_string(),
+            cluster_name: None,
+            http_methods: None,
+            status: LearningSessionStatus::Active,
+            created_at: chrono::Utc::now(),
+            started_at: Some(chrono::Utc::now()),
+            ends_at: Some(chrono::Utc::now() + chrono::Duration::hours(1)),
+            completed_at: None,
+            target_sample_count: 100,
+            current_sample_count: 100, // Target reached
+            triggered_by: None,
+            deployment_version: None,
+            configuration_snapshot: None,
+            error_message: None,
+            updated_at: chrono::Utc::now(),
+            auto_aggregate: true, // Auto-aggregate enabled
+            snapshot_count: 2,    // Already had 2 snapshots
+        };
+
+        let (_db, service) = create_test_service().await;
+        // should_complete is a basic check — always true when target reached
+        assert!(service.should_complete(&session));
+    }
+
+    #[tokio::test]
+    async fn test_should_not_complete_auto_aggregate_below_target() {
+        let session = LearningSessionData {
+            id: "test-session".to_string(),
+            team: "test-team".to_string(),
+            route_pattern: "^/api/.*".to_string(),
+            cluster_name: None,
+            http_methods: None,
+            status: LearningSessionStatus::Active,
+            created_at: chrono::Utc::now(),
+            started_at: Some(chrono::Utc::now()),
+            ends_at: Some(chrono::Utc::now() + chrono::Duration::hours(1)),
+            completed_at: None,
+            target_sample_count: 500,
+            current_sample_count: 250, // Below target
+            triggered_by: None,
+            deployment_version: None,
+            configuration_snapshot: None,
+            error_message: None,
+            updated_at: chrono::Utc::now(),
+            auto_aggregate: true,
+            snapshot_count: 0,
+        };
+
+        let (_db, service) = create_test_service().await;
+        assert!(!service.should_complete(&session));
     }
 
     #[test]
@@ -747,6 +933,8 @@ mod tests {
             configuration_snapshot: None,
             error_message: None,
             updated_at: chrono::Utc::now(),
+            auto_aggregate: false,
+            snapshot_count: 0,
         };
 
         let result = convert_to_access_log_session(&session);

--- a/src/services/learning_session_service.rs
+++ b/src/services/learning_session_service.rs
@@ -711,6 +711,79 @@ impl LearningSessionService {
     }
 }
 
+/// Generate a human-friendly session name from a route pattern.
+///
+/// Strips regex metacharacters, replaces `/` with `-`, collapses dashes,
+/// and truncates to 48 chars. Returns e.g. `"v2-api"` from `"^/v2/api/.*"`.
+pub fn generate_session_name(route_pattern: &str) -> String {
+    let name: String = route_pattern
+        .chars()
+        .map(|c| match c {
+            '^' | '$' | '.' | '*' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '|' | '\\' => {
+                ' '
+            }
+            '/' => '-',
+            _ => c,
+        })
+        .collect();
+
+    // Collapse whitespace and dashes, trim
+    let mut result = String::with_capacity(name.len());
+    let mut last_was_dash = true; // true to trim leading dash
+    for c in name.chars() {
+        if c == '-' || c == ' ' {
+            if !last_was_dash {
+                result.push('-');
+                last_was_dash = true;
+            }
+        } else {
+            result.push(c);
+            last_was_dash = false;
+        }
+    }
+
+    // Trim trailing dash
+    let result = result.trim_end_matches('-');
+
+    // Truncate to 48 chars
+    if result.len() > 48 {
+        result[..48].trim_end_matches('-').to_string()
+    } else {
+        result.to_string()
+    }
+}
+
+/// Generate a unique session name, appending `-2`, `-3`, etc. on conflict.
+///
+/// Tries the base name first, then appends a numeric suffix until no UNIQUE
+/// violation occurs (up to 100 attempts).
+pub async fn generate_unique_session_name(
+    repo: &crate::storage::repositories::LearningSessionRepository,
+    team: &str,
+    route_pattern: &str,
+) -> Result<String> {
+    let base = generate_session_name(route_pattern);
+    if base.is_empty() {
+        return Ok(format!("session-{}", &uuid::Uuid::new_v4().to_string()[..8]));
+    }
+
+    // Try the base name first
+    if repo.get_by_name(team, &base).await.is_err() {
+        return Ok(base);
+    }
+
+    // Append suffix until unique
+    for i in 2..=100 {
+        let candidate = format!("{}-{}", base, i);
+        if repo.get_by_name(team, &candidate).await.is_err() {
+            return Ok(candidate);
+        }
+    }
+
+    // Fallback to uuid suffix
+    Ok(format!("{}-{}", base, &uuid::Uuid::new_v4().to_string()[..8]))
+}
+
 /// Convert a LearningSessionData to an Access Log Service LearningSession
 fn convert_to_access_log_session(session: &LearningSessionData) -> Result<LearningSession> {
     let pattern = regex::Regex::new(&session.route_pattern).map_err(|e| {
@@ -759,6 +832,7 @@ mod tests {
             updated_at: chrono::Utc::now(),
             auto_aggregate: false,
             snapshot_count: 0,
+            name: None,
         };
 
         let (_db, service) = create_test_service().await;
@@ -787,6 +861,7 @@ mod tests {
             updated_at: chrono::Utc::now(),
             auto_aggregate: false,
             snapshot_count: 0,
+            name: None,
         };
 
         let (_db, service) = create_test_service().await;
@@ -815,6 +890,7 @@ mod tests {
             updated_at: chrono::Utc::now(),
             auto_aggregate: false,
             snapshot_count: 0,
+            name: None,
         };
 
         let (_db, service) = create_test_service().await;
@@ -843,6 +919,7 @@ mod tests {
             updated_at: chrono::Utc::now(),
             auto_aggregate: false,
             snapshot_count: 0,
+            name: None,
         };
 
         let result = convert_to_access_log_session(&session);
@@ -878,6 +955,7 @@ mod tests {
             updated_at: chrono::Utc::now(),
             auto_aggregate: true, // Auto-aggregate enabled
             snapshot_count: 2,    // Already had 2 snapshots
+            name: None,
         };
 
         let (_db, service) = create_test_service().await;
@@ -907,6 +985,7 @@ mod tests {
             updated_at: chrono::Utc::now(),
             auto_aggregate: true,
             snapshot_count: 0,
+            name: None,
         };
 
         let (_db, service) = create_test_service().await;
@@ -935,9 +1014,60 @@ mod tests {
             updated_at: chrono::Utc::now(),
             auto_aggregate: false,
             snapshot_count: 0,
+            name: None,
         };
 
         let result = convert_to_access_log_session(&session);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_generate_session_name_basic() {
+        assert_eq!(generate_session_name("^/v2/api/.*"), "v2-api");
+    }
+
+    #[test]
+    fn test_generate_session_name_users_endpoint() {
+        assert_eq!(generate_session_name("^/api/v1/users/.*"), "api-v1-users");
+    }
+
+    #[test]
+    fn test_generate_session_name_complex_regex() {
+        assert_eq!(generate_session_name("^/api/v[0-9]+/orders/[0-9]+$"), "api-v-0-9-orders-0-9");
+    }
+
+    #[test]
+    fn test_generate_session_name_simple_path() {
+        assert_eq!(generate_session_name("/api/health"), "api-health");
+    }
+
+    #[test]
+    fn test_generate_session_name_empty() {
+        assert_eq!(generate_session_name(""), "");
+    }
+
+    #[test]
+    fn test_generate_session_name_only_regex_chars() {
+        assert_eq!(generate_session_name("^.*$"), "");
+    }
+
+    #[test]
+    fn test_generate_session_name_truncation() {
+        let long_pattern = "^/api/v1/this/is/a/very/long/path/that/exceeds/the/limit/of/forty/eight/characters/definitely/.*";
+        let result = generate_session_name(long_pattern);
+        assert!(result.len() <= 48);
+        assert!(!result.ends_with('-'));
+    }
+
+    #[test]
+    fn test_generate_session_name_no_leading_trailing_dashes() {
+        assert_eq!(generate_session_name("/api/users/"), "api-users");
+        assert_eq!(generate_session_name("^/api/"), "api");
+    }
+
+    #[test]
+    fn test_generate_session_name_collapse_dashes() {
+        // Multiple slashes should collapse to single dash
+        assert_eq!(generate_session_name("/api///users"), "api-users");
     }
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -40,6 +40,7 @@ pub use listener_service::ListenerService;
 pub use mcp_service::{
     EnableMcpRequest, McpService, McpServiceError, McpStatusResponse, RefreshSchemaResult,
 };
+pub(crate) use path_normalizer::singularize;
 pub use path_normalizer::{normalize_path, PathNormalizationConfig};
 pub use route_hierarchy_sync::RouteHierarchySyncService;
 pub use route_service::RouteService;

--- a/src/services/path_normalizer.rs
+++ b/src/services/path_normalizer.rs
@@ -367,7 +367,7 @@ static PLURAL_MAP: &[(&str, &str)] = &[
 /// - `-ies` → `-y` (e.g., `categories` → `category`)
 /// - `-ses` → `-s` but not `-sses` (e.g., `addresses` → `address`, but `processes` → `process`)
 /// - `-s` → strip but not `-ss` (e.g., `users` → `user`, but `class` stays `class`)
-fn singularize(word: &str) -> String {
+pub(crate) fn singularize(word: &str) -> String {
     let lower = word.to_lowercase();
 
     // Lookup table (binary search on sorted array)

--- a/src/services/path_normalizer.rs
+++ b/src/services/path_normalizer.rs
@@ -1,36 +1,44 @@
 //! Path normalization module for API schema aggregation
 //!
 //! This module provides functionality to detect and normalize path parameters in API endpoints,
-//! converting literal paths like `/users/123` into parameterized templates like `/users/{id}`.
+//! converting literal paths like `/users/123` into parameterized templates like `/users/{userId}`.
 //!
 //! ## Integration with Schema Aggregation
 //!
 //! Path normalization is applied during access log processing (before storing to `inferred_schemas`),
 //! ensuring that all observations of the same endpoint pattern are grouped together during aggregation:
 //!
-//! 1. **Access Log Processing**: Raw paths → Normalized paths (e.g., `/users/101`, `/users/102` → `/users/{id}`)
+//! 1. **Access Log Processing**: Raw paths → Normalized paths (e.g., `/users/101`, `/users/102` → `/users/{userId}`)
 //! 2. **Schema Storage**: Normalized paths stored in `inferred_schemas.path_pattern`
 //! 3. **Schema Aggregation**: Groups by `(http_method, path_pattern, response_status_code)`
 //!    - Without normalization: 5 separate schemas for `/users/101`, `/users/102`, etc.
-//!    - With normalization: 1 aggregated schema for `/users/{id}` with 5+ samples
+//!    - With normalization: 1 aggregated schema for `/users/{userId}` with 5+ samples
 //!
 //! This improves schema quality, confidence scoring, and API catalog usability.
 //!
 //! ## Supported Parameter Types
 //!
-//! - **Numeric IDs**: `/users/123` → `/users/{id}`
-//! - **UUIDs**: `/orders/550e8400-e29b-41d4-a716-446655440000` → `/orders/{id}`
-//! - **Alphanumeric codes**: `/products/ABC123` → `/products/{code}`
-//! - **Date parameters**: `/events/2024-01-15` → `/events/{date}`
-//! - **Timestamp parameters**: `/logs/1640000000` → `/logs/{timestamp}`
+//! - **Numeric IDs**: `/users/123` → `/users/{userId}`
+//! - **UUIDs**: `/orders/550e8400-e29b-41d4-a716-446655440000` → `/orders/{orderId}`
+//! - **Alphanumeric codes**: `/products/ABC123` → `/products/{productCode}`
+//! - **Date parameters**: `/events/2024-01-15` → `/events/{eventDate}`
+//! - **DateTime parameters**: `/logs/2024-01-15T10:30:00Z` → `/logs/{logTimestamp}`
+//! - **Hyphenated IDs**: `/team-123/resource` → `/{id}/resource`
 //! - **Composite paths**: `/users/123/orders/456` → `/users/{userId}/orders/{orderId}`
+//!
+//! ## Singularization
+//!
+//! When `enable_plural_conversion` is true, preceding resource names are singularized using
+//! a 137-entry lookup table (covering common REST resources) plus heuristic fallback rules:
+//! - Lookup: `categories` → `category`, `addresses` → `address`, `statuses` → `status`
+//! - Fallback: `-ies` → `-y`, `-ses` → `-s` (not `-sses`), `-s` → strip (not `-ss`)
 //!
 //! ## Configuration
 //!
 //! The module supports API-agnostic configuration with presets for common API styles:
 //!
 //! - **Default**: Minimal assumptions, no plural conversion, no protected keywords
-//! - **REST API** (`rest_defaults()`): English plural conversion, common REST keywords protected
+//! - **REST API** (`rest_defaults()`): English plural conversion, 47 common REST keywords protected
 //! - **GraphQL** (`graphql_defaults()`): No plural conversion, GraphQL keywords protected
 //! - **Custom**: Fully configurable via `PathNormalizationConfig`
 //!
@@ -86,6 +94,9 @@ impl Default for PathNormalizationConfig {
 
 impl PathNormalizationConfig {
     /// Create a config with common REST API defaults
+    ///
+    /// Includes 47 protected keywords covering common REST endpoint segments
+    /// and enables English plural-to-singular conversion for parameter naming.
     pub fn rest_defaults() -> Self {
         Self {
             enabled: true,
@@ -96,9 +107,49 @@ impl PathNormalizationConfig {
                 "v1".to_string(),
                 "v2".to_string(),
                 "v3".to_string(),
+                "v4".to_string(),
+                "v5".to_string(),
                 "admin".to_string(),
                 "public".to_string(),
                 "private".to_string(),
+                "internal".to_string(),
+                "health".to_string(),
+                "status".to_string(),
+                "metrics".to_string(),
+                "docs".to_string(),
+                "swagger".to_string(),
+                "openapi".to_string(),
+                "graphql".to_string(),
+                "rest".to_string(),
+                "rpc".to_string(),
+                "ws".to_string(),
+                "wss".to_string(),
+                "auth".to_string(),
+                "login".to_string(),
+                "logout".to_string(),
+                "register".to_string(),
+                "callback".to_string(),
+                "webhook".to_string(),
+                "webhooks".to_string(),
+                "search".to_string(),
+                "upload".to_string(),
+                "download".to_string(),
+                "export".to_string(),
+                "import".to_string(),
+                "batch".to_string(),
+                "bulk".to_string(),
+                "stream".to_string(),
+                "feed".to_string(),
+                "feeds".to_string(),
+                "config".to_string(),
+                "settings".to_string(),
+                "preferences".to_string(),
+                "notifications".to_string(),
+                "events".to_string(),
+                "actions".to_string(),
+                "jobs".to_string(),
+                "tasks".to_string(),
+                "queue".to_string(),
             ],
             enable_plural_conversion: true,
         }
@@ -124,43 +175,234 @@ impl PathNormalizationConfig {
 /// Types of path parameters that can be detected
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ParameterType {
-    /// Numeric ID (integers)
+    /// Numeric ID (pure digits, any length)
     NumericId,
-    /// UUID (v4 format)
+    /// UUID (v4 format: 8-4-4-4-12 hex)
     Uuid,
-    /// Alphanumeric code (mixed letters and numbers)
+    /// Alphanumeric code (mixed letters and digits, no special chars)
     AlphanumericCode,
     /// Date (YYYY-MM-DD format)
     Date,
-    /// Timestamp (Unix timestamp or ISO8601)
-    Timestamp,
+    /// ISO 8601 DateTime (YYYY-MM-DDTHH:MM...)
+    DateTime,
+    /// Hyphenated or underscored segment containing digits
+    HyphenatedId,
 }
 
 impl ParameterType {
-    /// Get the default placeholder name for this parameter type
+    /// Get the default placeholder name for this parameter type (no preceding context)
     fn default_placeholder(&self) -> &'static str {
         match self {
-            ParameterType::NumericId => "id",
-            ParameterType::Uuid => "id",
+            ParameterType::NumericId | ParameterType::Uuid | ParameterType::HyphenatedId => "id",
             ParameterType::AlphanumericCode => "code",
             ParameterType::Date => "date",
-            ParameterType::Timestamp => "timestamp",
+            ParameterType::DateTime => "timestamp",
+        }
+    }
+
+    /// Get the suffix to append when naming from a preceding segment
+    fn contextual_suffix(&self) -> &'static str {
+        match self {
+            ParameterType::NumericId | ParameterType::Uuid | ParameterType::HyphenatedId => "Id",
+            ParameterType::AlphanumericCode => "Code",
+            ParameterType::Date => "Date",
+            ParameterType::DateTime => "Timestamp",
         }
     }
 }
 
+// ---------------------------------------------------------------------------
+// Plural-to-singular lookup table (141 entries, sorted for binary search)
+// ---------------------------------------------------------------------------
+
+/// Common REST resource plural-to-singular mappings, sorted alphabetically by plural form.
+static PLURAL_MAP: &[(&str, &str)] = &[
+    ("accounts", "account"),
+    ("actions", "action"),
+    ("addresses", "address"),
+    ("alerts", "alert"),
+    ("analyses", "analysis"),
+    ("annotations", "annotation"),
+    ("applications", "application"),
+    ("appointments", "appointment"),
+    ("approvals", "approval"),
+    ("artifacts", "artifact"),
+    ("assets", "asset"),
+    ("attributes", "attribute"),
+    ("audiences", "audience"),
+    ("branches", "branch"),
+    ("builds", "build"),
+    ("bundles", "bundle"),
+    ("buses", "bus"),
+    ("calendars", "calendar"),
+    ("campaigns", "campaign"),
+    ("categories", "category"),
+    ("certificates", "certificate"),
+    ("channels", "channel"),
+    ("clients", "client"),
+    ("clusters", "cluster"),
+    ("collections", "collection"),
+    ("columns", "column"),
+    ("comments", "comment"),
+    ("commits", "commit"),
+    ("companies", "company"),
+    ("configs", "config"),
+    ("connections", "connection"),
+    ("consumers", "consumer"),
+    ("contacts", "contact"),
+    ("containers", "container"),
+    ("conversions", "conversion"),
+    ("coupons", "coupon"),
+    ("customers", "customer"),
+    ("databases", "database"),
+    ("datasets", "dataset"),
+    ("departments", "department"),
+    ("deployments", "deployment"),
+    ("devices", "device"),
+    ("discounts", "discount"),
+    ("documents", "document"),
+    ("domains", "domain"),
+    ("employees", "employee"),
+    ("endpoints", "endpoint"),
+    ("entries", "entry"),
+    ("environments", "environment"),
+    ("events", "event"),
+    ("features", "feature"),
+    ("files", "file"),
+    ("filters", "filter"),
+    ("functions", "function"),
+    ("gateways", "gateway"),
+    ("groups", "group"),
+    ("images", "image"),
+    ("incidents", "incident"),
+    ("indexes", "index"),
+    ("integrations", "integration"),
+    ("invitations", "invitation"),
+    ("invoices", "invoice"),
+    ("items", "item"),
+    ("jobs", "job"),
+    ("keys", "key"),
+    ("labels", "label"),
+    ("listeners", "listener"),
+    ("logs", "log"),
+    ("memberships", "membership"),
+    ("messages", "message"),
+    ("metrics", "metric"),
+    ("models", "model"),
+    ("modules", "module"),
+    ("namespaces", "namespace"),
+    ("nodes", "node"),
+    ("notifications", "notification"),
+    ("operations", "operation"),
+    ("orders", "order"),
+    ("organizations", "organization"),
+    ("packages", "package"),
+    ("pages", "page"),
+    ("partitions", "partition"),
+    ("payments", "payment"),
+    ("permissions", "permission"),
+    ("pipelines", "pipeline"),
+    ("plugins", "plugin"),
+    ("pods", "pod"),
+    ("policies", "policy"),
+    ("posts", "post"),
+    ("producers", "producer"),
+    ("products", "product"),
+    ("profiles", "profile"),
+    ("projects", "project"),
+    ("promotions", "promotion"),
+    ("proxies", "proxy"),
+    ("publishers", "publisher"),
+    ("queries", "query"),
+    ("ratings", "rating"),
+    ("records", "record"),
+    ("releases", "release"),
+    ("reports", "report"),
+    ("repositories", "repository"),
+    ("requests", "request"),
+    ("reservations", "reservation"),
+    ("resources", "resource"),
+    ("responses", "response"),
+    ("results", "result"),
+    ("reviews", "review"),
+    ("roles", "role"),
+    ("routes", "route"),
+    ("rules", "rule"),
+    ("schedules", "schedule"),
+    ("schemas", "schema"),
+    ("scopes", "scope"),
+    ("secrets", "secret"),
+    ("segments", "segment"),
+    ("sensors", "sensor"),
+    ("services", "service"),
+    ("sessions", "session"),
+    ("settings", "setting"),
+    ("statuses", "status"),
+    ("subscribers", "subscriber"),
+    ("subscriptions", "subscription"),
+    ("tables", "table"),
+    ("tags", "tag"),
+    ("tasks", "task"),
+    ("teams", "team"),
+    ("templates", "template"),
+    ("tenants", "tenant"),
+    ("tickets", "ticket"),
+    ("tokens", "token"),
+    ("topics", "topic"),
+    ("transactions", "transaction"),
+    ("transfers", "transfer"),
+    ("triggers", "trigger"),
+    ("users", "user"),
+    ("versions", "version"),
+    ("views", "view"),
+    ("votes", "vote"),
+    ("webhooks", "webhook"),
+    ("workflows", "workflow"),
+];
+
+/// Convert a plural resource name to its singular form.
+///
+/// Uses a 137-entry lookup table for common REST resources, then falls back to
+/// English heuristic rules:
+/// - `-ies` → `-y` (e.g., `categories` → `category`)
+/// - `-ses` → `-s` but not `-sses` (e.g., `addresses` → `address`, but `processes` → `process`)
+/// - `-s` → strip but not `-ss` (e.g., `users` → `user`, but `class` stays `class`)
+fn singularize(word: &str) -> String {
+    let lower = word.to_lowercase();
+
+    // Lookup table (binary search on sorted array)
+    if let Ok(idx) = PLURAL_MAP.binary_search_by_key(&lower.as_str(), |(plural, _)| plural) {
+        return PLURAL_MAP[idx].1.to_string();
+    }
+
+    // Heuristic fallback for words not in the lookup table
+    if lower.ends_with("ies") && lower.len() > 3 {
+        let mut s = lower[..lower.len() - 3].to_string();
+        s.push('y');
+        return s;
+    }
+    if lower.ends_with("ses") && !lower.ends_with("sses") && lower.len() > 3 {
+        return lower[..lower.len() - 1].to_string();
+    }
+    if lower.ends_with('s') && !lower.ends_with("ss") && lower.len() > 3 {
+        return lower[..lower.len() - 1].to_string();
+    }
+
+    lower
+}
+
 /// Compiled regex patterns for parameter detection
 struct RegexPatterns {
-    /// UUID pattern (loose matching for v4 UUIDs)
+    /// UUID pattern (8-4-4-4-12 hex characters)
     uuid: Regex,
-    /// Numeric ID pattern (pure numbers)
+    /// Numeric ID pattern (pure digits)
     numeric_id: Regex,
-    /// Alphanumeric code pattern (mixed letters and numbers, at least 2 characters)
+    /// Alphanumeric code pattern (letters and digits only, at least 2 characters)
     alphanumeric_code: Regex,
     /// Date pattern (YYYY-MM-DD)
     date: Regex,
-    /// Unix timestamp (10+ digit number)
-    timestamp: Regex,
+    /// ISO 8601 DateTime pattern (YYYY-MM-DDTHH:MM...)
+    datetime: Regex,
 }
 
 /// Get compiled regex patterns (singleton)
@@ -171,62 +413,44 @@ struct RegexPatterns {
 /// 3. Failure indicates programmer error, not runtime issue
 fn get_patterns() -> &'static RegexPatterns {
     static PATTERNS: OnceLock<RegexPatterns> = OnceLock::new();
-    PATTERNS.get_or_init(|| {
-        RegexPatterns {
-            // UUID v4 pattern: 8-4-4-4-12 hex characters
-            uuid: Regex::new(
-                r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
-            )
-            .expect("BUG: UUID regex pattern is invalid - validated by tests"),
+    PATTERNS.get_or_init(|| RegexPatterns {
+        uuid: Regex::new(
+            r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+        )
+        .expect("BUG: UUID regex pattern is invalid - validated by tests"),
 
-            // Numeric ID: pure digits
-            numeric_id: Regex::new(r"^\d+$")
-                .expect("BUG: Numeric ID regex pattern is invalid - validated by tests"),
+        numeric_id: Regex::new(r"^\d+$")
+            .expect("BUG: Numeric ID regex pattern is invalid - validated by tests"),
 
-            // Alphanumeric code: mix of letters and numbers (at least one of each)
-            // Must have at least 2 characters total
-            // We'll validate this separately since regex crate doesn't support lookahead
-            alphanumeric_code: Regex::new(r"^[a-zA-Z0-9]{2,}$")
-                .expect("BUG: Alphanumeric code regex pattern is invalid - validated by tests"),
+        alphanumeric_code: Regex::new(r"^[a-zA-Z0-9]{2,}$")
+            .expect("BUG: Alphanumeric code regex pattern is invalid - validated by tests"),
 
-            // Date: YYYY-MM-DD
-            date: Regex::new(r"^\d{4}-\d{2}-\d{2}$")
-                .expect("BUG: Date regex pattern is invalid - validated by tests"),
+        date: Regex::new(r"^\d{4}-\d{2}-\d{2}$")
+            .expect("BUG: Date regex pattern is invalid - validated by tests"),
 
-            // Unix timestamp: 10+ digits (covers timestamps from 2001 onwards)
-            timestamp: Regex::new(r"^\d{10,}$")
-                .expect("BUG: Timestamp regex pattern is invalid - validated by tests"),
-        }
+        datetime: Regex::new(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}")
+            .expect("BUG: DateTime regex pattern is invalid - validated by tests"),
     })
 }
 
-/// Check if a segment looks like a common literal value that shouldn't be parameterized
-fn is_common_literal(segment: &str, config: &PathNormalizationConfig) -> bool {
-    // Version patterns: v1, v2, v1.0, v2.1, etc.
-    if segment.starts_with('v') && segment.len() <= 5 {
+/// Check if a segment is a literal (should not be parameterized)
+fn is_literal_segment(segment: &str, config: &PathNormalizationConfig) -> bool {
+    // Check user-configured literal keywords (case-insensitive)
+    let lower = segment.to_lowercase();
+    if config.literal_keywords.iter().any(|kw| kw.to_lowercase() == lower) {
+        return true;
+    }
+
+    // Version patterns not in keyword list: v1.0, v2.1, v10, etc.
+    if segment.starts_with('v') && segment.len() >= 2 && segment.len() <= 5 {
         let rest = &segment[1..];
-        // Check if rest is version-like (digits and dots)
-        if rest.chars().all(|c| c.is_numeric() || c == '.') {
+        if !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit() || c == '.') {
             return true;
         }
     }
 
-    // Short codes with hyphens (project identifiers like "team-1", "proj-2")
-    // BUT: Exclude date patterns (YYYY-MM-DD) which are 10 characters with 2 hyphens
-    if segment.contains('-') && segment.len() <= 10 {
-        // Check if it's a date pattern (YYYY-MM-DD)
-        let parts: Vec<&str> = segment.split('-').collect();
-        if parts.len() == 3 {
-            // If all parts are numeric, this might be a date (will be caught by date pattern)
-            if parts.iter().all(|p| p.chars().all(char::is_numeric)) {
-                return false; // Let date pattern handle it
-            }
-        }
-        return true;
-    }
-
-    // Check user-configured literal keywords
-    if config.literal_keywords.iter().any(|kw| kw == segment) {
+    // Pure letters (no digits, no special chars) = resource names, never dynamic
+    if !segment.is_empty() && segment.chars().all(|c| c.is_ascii_alphabetic()) {
         return true;
     }
 
@@ -240,87 +464,84 @@ fn detect_parameter_type(segment: &str, config: &PathNormalizationConfig) -> Opt
         return None;
     }
 
-    // Skip common literals
-    if is_common_literal(segment, config) {
+    // Literal segments are never dynamic
+    if is_literal_segment(segment, config) {
         return None;
     }
 
     let patterns = get_patterns();
 
     // Check in order of specificity (most specific first)
+
+    // UUID: 8-4-4-4-12 hex
     if patterns.uuid.is_match(segment) {
         return Some(ParameterType::Uuid);
     }
 
+    // ISO 8601 DateTime (before Date since it's more specific)
+    if patterns.datetime.is_match(segment) {
+        return Some(ParameterType::DateTime);
+    }
+
+    // Date: YYYY-MM-DD
     if patterns.date.is_match(segment) {
         return Some(ParameterType::Date);
     }
 
-    if patterns.timestamp.is_match(segment) {
-        return Some(ParameterType::Timestamp);
-    }
-
-    // Check alphanumeric code - must have both letters and numbers
-    // Exclude short patterns (length < 5) to avoid false positives
-    if segment.len() >= 5 && patterns.alphanumeric_code.is_match(segment) {
+    // Alphanumeric code: letters and digits mixed, no special chars
+    if patterns.alphanumeric_code.is_match(segment) {
         let has_letter = segment.chars().any(|c| c.is_alphabetic());
-        let has_digit = segment.chars().any(|c| c.is_numeric());
+        let has_digit = segment.chars().any(|c| c.is_ascii_digit());
         if has_letter && has_digit {
             return Some(ParameterType::AlphanumericCode);
         }
     }
 
+    // Pure numeric (any length — covers both short IDs and Unix timestamps)
     if patterns.numeric_id.is_match(segment) {
         return Some(ParameterType::NumericId);
+    }
+
+    // Hyphenated or underscored segments containing digits (e.g., "order-123", "item_456")
+    if (segment.contains('-') || segment.contains('_'))
+        && segment.chars().any(|c| c.is_ascii_digit())
+    {
+        return Some(ParameterType::HyphenatedId);
     }
 
     None
 }
 
-/// Generate a contextual parameter name based on the preceding segment
+/// Generate a contextual parameter name based on the preceding literal segment
 fn generate_parameter_name(
     param_type: ParameterType,
     previous_segment: Option<&str>,
     config: &PathNormalizationConfig,
 ) -> String {
-    // If there's a preceding segment (like "users"), use it for context
     if let Some(prev) = previous_segment {
-        // Optionally convert plural to singular (English REST convention)
-        let base = if config.enable_plural_conversion && prev.ends_with('s') && prev.len() > 1 {
-            &prev[..prev.len() - 1]
-        } else {
-            prev
-        };
+        let base =
+            if config.enable_plural_conversion { singularize(prev) } else { prev.to_string() };
 
-        // Combine with parameter type's default suffix
-        match param_type {
-            ParameterType::NumericId | ParameterType::Uuid => {
-                format!("{}Id", base)
-            }
-            ParameterType::AlphanumericCode => {
-                format!("{}Code", base)
-            }
-            ParameterType::Date => {
-                format!("{}Date", base)
-            }
-            ParameterType::Timestamp => {
-                format!("{}Timestamp", base)
-            }
-        }
+        format!("{}{}", base, param_type.contextual_suffix())
     } else {
-        // Fallback to default placeholder
         param_type.default_placeholder().to_string()
     }
 }
 
 /// Normalize a single API path by detecting and replacing parameter segments
 ///
+/// # Behavior
+///
+/// - Query strings are stripped before normalization
+/// - Already-parameterized segments (`{...}`) pass through unchanged
+/// - Consecutive dynamic segments: the second uses a generic placeholder (`{id}`)
+/// - The preceding *literal* segment (scanning backward) provides context for naming
+///
 /// # Examples
 ///
 /// ```
 /// use flowplane::services::path_normalizer::{normalize_path, PathNormalizationConfig};
 ///
-/// // Use REST defaults for common API normalization with plural conversion
 /// let config = PathNormalizationConfig::rest_defaults();
 ///
 /// assert_eq!(
@@ -343,28 +564,52 @@ pub fn normalize_path(path: &str, config: &PathNormalizationConfig) -> String {
         return path.to_string();
     }
 
-    // Split path into segments
+    // Strip query string before normalization
+    let path = match path.find('?') {
+        Some(idx) => &path[..idx],
+        None => path,
+    };
+
     let segments: Vec<&str> = path.split('/').collect();
 
-    let mut normalized_segments = Vec::with_capacity(segments.len());
-    let mut previous_segment: Option<&str> = None;
+    let mut normalized_segments: Vec<String> = Vec::with_capacity(segments.len());
+    let mut previous_was_dynamic = false;
 
     for segment in segments {
         if segment.is_empty() {
             // Preserve empty segments (leading/trailing slashes)
+            normalized_segments.push(String::new());
+            continue;
+        }
+
+        // Already parameterized segments pass through
+        if segment.starts_with('{') && segment.ends_with('}') {
             normalized_segments.push(segment.to_string());
+            previous_was_dynamic = true;
             continue;
         }
 
         // Try to detect if this segment is a parameter
         if let Some(param_type) = detect_parameter_type(segment, config) {
-            // Generate contextual parameter name
-            let param_name = generate_parameter_name(param_type, previous_segment, config);
-            normalized_segments.push(format!("{{{}}}", param_name));
+            if previous_was_dynamic {
+                // Consecutive dynamic segment → generic fallback
+                normalized_segments.push(format!("{{{}}}", param_type.default_placeholder()));
+            } else {
+                // Find the most recent literal segment by scanning backward
+                let preceding = normalized_segments
+                    .iter()
+                    .rev()
+                    .find(|s| !s.is_empty() && !s.starts_with('{'))
+                    .map(|s| s.as_str());
+
+                let param_name = generate_parameter_name(param_type, preceding, config);
+                normalized_segments.push(format!("{{{}}}", param_name));
+            }
+            previous_was_dynamic = true;
         } else {
             // Keep literal segment
             normalized_segments.push(segment.to_string());
-            previous_segment = Some(segment);
+            previous_was_dynamic = false;
         }
     }
 
@@ -379,15 +624,13 @@ mod tests {
     /// This test ensures the expect() calls in get_patterns() will never panic.
     #[test]
     fn test_regex_patterns_compile() {
-        // Force pattern initialization - will panic if any pattern is invalid
         let patterns = get_patterns();
 
-        // Verify patterns work by testing basic matching
         assert!(patterns.uuid.is_match("550e8400-e29b-41d4-a716-446655440000"));
         assert!(patterns.numeric_id.is_match("12345"));
         assert!(patterns.alphanumeric_code.is_match("ABC123"));
         assert!(patterns.date.is_match("2024-01-15"));
-        assert!(patterns.timestamp.is_match("1640000000"));
+        assert!(patterns.datetime.is_match("2024-01-15T10:30:00Z"));
     }
 
     fn default_config() -> PathNormalizationConfig {
@@ -398,12 +641,18 @@ mod tests {
         PathNormalizationConfig::rest_defaults()
     }
 
+    // -----------------------------------------------------------------------
+    // Parameter detection tests
+    // -----------------------------------------------------------------------
+
     #[test]
     fn test_detect_numeric_id() {
         let config = default_config();
         assert_eq!(detect_parameter_type("123", &config), Some(ParameterType::NumericId));
         assert_eq!(detect_parameter_type("0", &config), Some(ParameterType::NumericId));
         assert_eq!(detect_parameter_type("999999", &config), Some(ParameterType::NumericId));
+        // Long numbers (Unix timestamps) are also NumericId
+        assert_eq!(detect_parameter_type("1640000000", &config), Some(ParameterType::NumericId));
     }
 
     #[test]
@@ -424,7 +673,7 @@ mod tests {
         let config = default_config();
         assert_eq!(detect_parameter_type("ABC123", &config), Some(ParameterType::AlphanumericCode));
         assert_eq!(detect_parameter_type("prod1", &config), Some(ParameterType::AlphanumericCode));
-        // Pure letters should not match
+        // Pure letters should not match (literal resource names)
         assert_eq!(detect_parameter_type("ABC", &config), None);
         // Pure numbers covered by numeric_id
         assert_eq!(detect_parameter_type("123", &config), Some(ParameterType::NumericId));
@@ -438,13 +687,143 @@ mod tests {
     }
 
     #[test]
+    fn test_detect_datetime() {
+        let config = default_config();
+        assert_eq!(
+            detect_parameter_type("2024-01-15T10:30:00Z", &config),
+            Some(ParameterType::DateTime)
+        );
+        assert_eq!(
+            detect_parameter_type("2024-01-15T10:30:00.000+00:00", &config),
+            Some(ParameterType::DateTime)
+        );
+        assert_eq!(
+            detect_parameter_type("2024-01-15T10:30", &config),
+            Some(ParameterType::DateTime)
+        );
+    }
+
+    #[test]
+    fn test_detect_hyphenated_id() {
+        let config = default_config();
+        assert_eq!(detect_parameter_type("order-123", &config), Some(ParameterType::HyphenatedId));
+        assert_eq!(detect_parameter_type("item_456", &config), Some(ParameterType::HyphenatedId));
+        assert_eq!(detect_parameter_type("team-1", &config), Some(ParameterType::HyphenatedId));
+        // No digits → not a hyphenated ID (pure letters with hyphen is still literal-ish,
+        // but won't match because it has a hyphen — it falls through to None)
+        assert_eq!(detect_parameter_type("my-resource", &config), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Singularization tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_singularize_lookup() {
+        // Direct lookup hits
+        assert_eq!(singularize("users"), "user");
+        assert_eq!(singularize("categories"), "category");
+        assert_eq!(singularize("addresses"), "address");
+        assert_eq!(singularize("policies"), "policy");
+        assert_eq!(singularize("statuses"), "status");
+        assert_eq!(singularize("proxies"), "proxy");
+        assert_eq!(singularize("entries"), "entry");
+        assert_eq!(singularize("queries"), "query");
+    }
+
+    #[test]
+    fn test_singularize_case_insensitive() {
+        assert_eq!(singularize("Users"), "user");
+        assert_eq!(singularize("USERS"), "user");
+    }
+
+    #[test]
+    fn test_singularize_heuristic_fallback() {
+        // -ies → -y
+        assert_eq!(singularize("batteries"), "battery");
+        // -ses → -se (not in lookup, strip trailing s)
+        assert_eq!(singularize("impulses"), "impulse");
+        // -s → strip (not in lookup)
+        assert_eq!(singularize("widgets"), "widget");
+    }
+
+    #[test]
+    fn test_singularize_no_change() {
+        // Already singular or doesn't match patterns
+        assert_eq!(singularize("class"), "class"); // ends with ss, no strip
+        assert_eq!(singularize("bus"), "bus"); // too short after strip (len <= 2 → no strip)
+        assert_eq!(singularize("data"), "data"); // no matching rule
+    }
+
+    #[test]
+    fn test_plural_map_is_sorted() {
+        for window in PLURAL_MAP.windows(2) {
+            assert!(
+                window[0].0 < window[1].0,
+                "PLURAL_MAP is not sorted: {:?} should come before {:?}",
+                window[0].0,
+                window[1].0
+            );
+        }
+    }
+
+    #[test]
+    fn test_plural_map_count() {
+        assert_eq!(PLURAL_MAP.len(), 141, "PLURAL_MAP should have 141 entries");
+    }
+
+    // -----------------------------------------------------------------------
+    // Keyword / literal detection tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_all_rest_keywords_are_literals() {
+        let config = rest_config();
+        let keywords = &config.literal_keywords;
+        for kw in keywords {
+            assert!(
+                is_literal_segment(kw, &config),
+                "{:?} should be treated as a literal keyword",
+                kw
+            );
+        }
+    }
+
+    #[test]
+    fn test_keywords_case_insensitive() {
+        let config = rest_config();
+        assert!(is_literal_segment("API", &config));
+        assert!(is_literal_segment("Api", &config));
+        assert!(is_literal_segment("HEALTH", &config));
+    }
+
+    #[test]
+    fn test_version_patterns_literal() {
+        let config = default_config();
+        assert!(is_literal_segment("v1", &config));
+        assert!(is_literal_segment("v10", &config));
+        assert!(is_literal_segment("v1.0", &config));
+        assert!(is_literal_segment("v2.1", &config));
+    }
+
+    #[test]
+    fn test_pure_letters_literal() {
+        let config = default_config();
+        assert!(is_literal_segment("users", &config));
+        assert!(is_literal_segment("profile", &config));
+        assert!(is_literal_segment("anything", &config));
+    }
+
+    // -----------------------------------------------------------------------
+    // Path normalization tests
+    // -----------------------------------------------------------------------
+
+    #[test]
     fn test_normalize_simple_paths() {
         let config = rest_config();
 
         assert_eq!(normalize_path("/users/123", &config), "/users/{userId}");
-
         assert_eq!(normalize_path("/products/ABC123", &config), "/products/{productCode}");
-
         assert_eq!(normalize_path("/api/v1/users", &config), "/api/v1/users");
     }
 
@@ -459,6 +838,20 @@ mod tests {
     }
 
     #[test]
+    fn test_normalize_date_paths() {
+        let config = rest_config();
+
+        assert_eq!(normalize_path("/events/2024-01-15", &config), "/events/{eventDate}");
+    }
+
+    #[test]
+    fn test_normalize_datetime_paths() {
+        let config = rest_config();
+
+        assert_eq!(normalize_path("/logs/2024-01-15T10:30:00Z", &config), "/logs/{logTimestamp}");
+    }
+
+    #[test]
     fn test_normalize_composite_paths() {
         let config = rest_config();
 
@@ -467,11 +860,10 @@ mod tests {
             "/users/{userId}/orders/{orderId}"
         );
 
-        // Hyphenated identifiers are treated as literals to avoid false positives
-        // Pure numeric IDs are still parameterized
+        // Hyphenated identifiers with digits are now treated as dynamic
         assert_eq!(
             normalize_path("/teams/team-1/projects/proj-2/tasks/789", &config),
-            "/teams/team-1/projects/proj-2/tasks/{taskId}"
+            "/teams/{teamId}/projects/{projectId}/tasks/{taskId}"
         );
     }
 
@@ -479,7 +871,6 @@ mod tests {
     fn test_normalize_mixed_paths() {
         let config = rest_config();
 
-        // Path with both literals and parameters
         assert_eq!(
             normalize_path("/api/v1/users/123/profile", &config),
             "/api/v1/users/{userId}/profile"
@@ -501,6 +892,39 @@ mod tests {
 
         // Trailing slash
         assert_eq!(normalize_path("/users/123/", &config), "/users/{userId}/");
+    }
+
+    #[test]
+    fn test_normalize_query_string_stripped() {
+        let config = rest_config();
+
+        assert_eq!(normalize_path("/users/123?include=orders", &config), "/users/{userId}");
+        assert_eq!(normalize_path("/api/v1/users?page=1&limit=10", &config), "/api/v1/users");
+        assert_eq!(
+            normalize_path("/products/ABC123?format=json", &config),
+            "/products/{productCode}"
+        );
+    }
+
+    #[test]
+    fn test_normalize_consecutive_dynamics() {
+        let config = rest_config();
+
+        // Second consecutive dynamic segment gets generic placeholder
+        assert_eq!(normalize_path("/users/123/456", &config), "/users/{userId}/{id}");
+        // After v1 (literal), first dynamic uses v1 as context, rest are generic
+        assert_eq!(normalize_path("/api/v1/123/456/789", &config), "/api/v1/{v1Id}/{id}/{id}");
+    }
+
+    #[test]
+    fn test_normalize_already_parameterized() {
+        let config = rest_config();
+
+        assert_eq!(normalize_path("/users/{userId}/orders", &config), "/users/{userId}/orders");
+        assert_eq!(
+            normalize_path("/users/{userId}/orders/456", &config),
+            "/users/{userId}/orders/{orderId}"
+        );
     }
 
     #[test]
@@ -527,11 +951,8 @@ mod tests {
     fn test_actual_flowplane_paths() {
         let config = rest_config();
 
-        // Real paths from the database issue
         assert_eq!(normalize_path("/anything/users/101", &config), "/anything/users/{userId}");
-
         assert_eq!(normalize_path("/anything/users/102", &config), "/anything/users/{userId}");
-
         assert_eq!(normalize_path("/anything/users/103", &config), "/anything/users/{userId}");
 
         // All should normalize to the same pattern
@@ -545,7 +966,6 @@ mod tests {
 
         let normalized: Vec<String> = paths.iter().map(|p| normalize_path(p, &config)).collect();
 
-        // All should be identical
         assert_eq!(normalized.len(), 5);
         assert!(normalized.iter().all(|n| n == "/anything/users/{userId}"));
     }
@@ -564,7 +984,6 @@ mod tests {
         assert_eq!(normalize_path("/users/123", &config), "/users/{usersId}");
 
         // Version patterns (v1, v2) are still protected by default heuristics
-        // This is a reasonable default regardless of API type
         assert_eq!(normalize_path("/api/v1/users/123", &config), "/api/v1/users/{usersId}");
     }
 
@@ -587,7 +1006,6 @@ mod tests {
         };
 
         // Custom keywords are protected
-        // Parameter gets context from preceding segment
         assert_eq!(
             normalize_path("/custom/namespace/123", &config),
             "/custom/namespace/{namespaceId}"
@@ -595,5 +1013,93 @@ mod tests {
 
         // Test keyword at different positions
         assert_eq!(normalize_path("/custom/123", &config), "/custom/{customId}");
+    }
+
+    // -----------------------------------------------------------------------
+    // Contextual naming tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_contextual_naming_uuid() {
+        let config = rest_config();
+        assert_eq!(
+            normalize_path("/users/550e8400-e29b-41d4-a716-446655440000", &config),
+            "/users/{userId}"
+        );
+    }
+
+    #[test]
+    fn test_contextual_naming_date() {
+        let config = rest_config();
+        assert_eq!(normalize_path("/orders/2024-03-15", &config), "/orders/{orderDate}");
+    }
+
+    #[test]
+    fn test_contextual_naming_numeric() {
+        let config = rest_config();
+        assert_eq!(normalize_path("/customers/42", &config), "/customers/{customerId}");
+    }
+
+    #[test]
+    fn test_contextual_naming_alphanumeric_code() {
+        let config = rest_config();
+        assert_eq!(normalize_path("/products/SKU123", &config), "/products/{productCode}");
+    }
+
+    #[test]
+    fn test_contextual_naming_no_preceding() {
+        let config = rest_config();
+        // No preceding literal → generic fallback
+        assert_eq!(normalize_path("/123", &config), "/{id}");
+        assert_eq!(normalize_path("/550e8400-e29b-41d4-a716-446655440000", &config), "/{id}");
+    }
+
+    // -----------------------------------------------------------------------
+    // MockBank path normalization tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_mockbank_paths() {
+        let config = rest_config();
+
+        assert_eq!(
+            normalize_path("/v2/api/customers/1", &config),
+            "/v2/api/customers/{customerId}"
+        );
+        assert_eq!(normalize_path("/v2/api/accounts/3", &config), "/v2/api/accounts/{accountId}");
+        assert_eq!(
+            normalize_path("/v2/api/transactions/5", &config),
+            "/v2/api/transactions/{transactionId}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Backward scan for preceding literal tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_backward_scan_skips_params() {
+        let config = rest_config();
+
+        // /users/{userId}/456 — preceding literal for 456 is "users" (skips {userId})
+        // but {userId} is dynamic, so "456" is consecutive → generic {id}
+        assert_eq!(normalize_path("/users/123/456", &config), "/users/{userId}/{id}");
+
+        // /api/v1/123/orders/456 — "123" after "v1" keyword gets context from preceding non-keyword
+        // Actually, "v1" is in keywords but also a literal. The backward scan finds "v1".
+        // But "v1" is 2 chars. singularize("v1") → "v1" (no rule matches). So → "{v1Id}"
+        // Hmm, that's ugly. Let me check: v1 is in literal_keywords, so it's detected as literal.
+        // When we process "123", we scan backward. "v1" is a literal (not starting with {).
+        // So preceding = "v1" → singularize("v1") = "v1" → "v1Id"
+        // Actually we could get "api" instead... let me trace through:
+        // segments: ["", "api", "v1", "123", "orders", "456"]
+        // "" → empty, skip
+        // "api" → literal keyword, push "api"
+        // "v1" → literal keyword, push "v1"
+        // "123" → numeric, not consecutive (prev was literal "v1"), scan backward:
+        //   normalized = ["", "api", "v1"], rev: "v1" not empty and not starting with { → preceding = "v1"
+        //   → singularize("v1") = "v1" → "{v1Id}"
+        // Hmm, that doesn't feel great. But it's consistent with the algorithm.
+        // The specwatch code would do the same thing.
     }
 }

--- a/src/services/schema_aggregator.rs
+++ b/src/services/schema_aggregator.rs
@@ -52,7 +52,7 @@ impl SchemaAggregator {
     /// creating them in a single transaction.
     #[instrument(skip(self), fields(session_id = %session_id), name = "aggregate_session_schemas")]
     pub async fn aggregate_session(&self, session_id: &str) -> Result<Vec<i64>> {
-        self.aggregate_session_with_snapshot(session_id, None, None).await
+        self.aggregate_session_with_snapshot(session_id, Some(session_id.to_string()), None).await
     }
 
     /// Aggregate schemas for a session with optional snapshot metadata

--- a/src/services/schema_aggregator.rs
+++ b/src/services/schema_aggregator.rs
@@ -19,8 +19,13 @@ use crate::storage::repositories::{
     AggregatedSchemaRepository, CreateAggregatedSchemaRequest, InferredSchemaData,
     InferredSchemaRepository,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use tracing::{info, instrument, warn};
+
+/// Minimum number of samples before promoting observed values to enum
+const MIN_SAMPLES_FOR_ENUM: u64 = 10;
+/// Maximum cardinality for enum promotion (more distinct values = not an enum)
+const MAX_ENUM_CARDINALITY: usize = 10;
 
 /// Schema aggregation service
 pub struct SchemaAggregator {
@@ -47,6 +52,20 @@ impl SchemaAggregator {
     /// creating them in a single transaction.
     #[instrument(skip(self), fields(session_id = %session_id), name = "aggregate_session_schemas")]
     pub async fn aggregate_session(&self, session_id: &str) -> Result<Vec<i64>> {
+        self.aggregate_session_with_snapshot(session_id, None, None).await
+    }
+
+    /// Aggregate schemas for a session with optional snapshot metadata
+    ///
+    /// When `snapshot_session_id` and `snapshot_number` are provided, the aggregated
+    /// schemas are linked to the session and tagged with the snapshot number.
+    #[instrument(skip(self), fields(session_id = %session_id), name = "aggregate_session_schemas_snapshot")]
+    pub async fn aggregate_session_with_snapshot(
+        &self,
+        session_id: &str,
+        snapshot_session_id: Option<String>,
+        snapshot_number: Option<i64>,
+    ) -> Result<Vec<i64>> {
         info!(session_id = %session_id, "Starting schema aggregation for session");
 
         // Step 1: Fetch all inferred schemas for this session, grouped by endpoint
@@ -71,7 +90,7 @@ impl SchemaAggregator {
                 "Preparing endpoint aggregation"
             );
 
-            let request = self
+            let mut request = self
                 .prepare_aggregation(
                     &http_method,
                     &path_pattern,
@@ -79,6 +98,9 @@ impl SchemaAggregator {
                     observations,
                 )
                 .await?;
+
+            request.session_id = snapshot_session_id.clone();
+            request.snapshot_number = snapshot_number;
 
             create_requests.push(request);
         }
@@ -125,14 +147,16 @@ impl SchemaAggregator {
         // Use InferredSchema::merge() to properly combine observations
 
         // Aggregate request schemas by merging all observations
-        let request_schema = merge_schemas(&observations, |obs| obs.request_schema.as_ref())?;
+        let request_schema =
+            merge_schemas(&observations, |obs| obs.request_schema.as_ref(), Some(http_method))?;
 
         // Aggregate response schemas by status code.
         // Always insert the status code key so bodyless endpoints (DELETE 204,
         // GET collections) retain their status code in the aggregated record.
         let mut response_schemas_map = HashMap::new();
         if let Some(status) = response_status_code {
-            let response_schema = merge_schemas(&observations, |obs| obs.response_schema.as_ref())?;
+            let response_schema =
+                merge_schemas(&observations, |obs| obs.response_schema.as_ref(), None)?;
             response_schemas_map
                 .insert(status.to_string(), response_schema.unwrap_or(serde_json::Value::Null));
         }
@@ -214,6 +238,8 @@ impl SchemaAggregator {
             first_observed,
             last_observed,
             previous_version_id,
+            session_id: None,
+            snapshot_number: None,
         })
     }
 }
@@ -228,9 +254,12 @@ impl SchemaAggregator {
 ///
 /// After merging, the schema's `required` field is populated with fields
 /// that appear in 100% of observations.
+/// `http_method`: If `Some("PATCH")`, required fields are cleared on request schemas.
+/// Pass `None` for response schemas (they always get normal required analysis).
 fn merge_schemas<F>(
     observations: &[InferredSchemaData],
     schema_accessor: F,
+    http_method: Option<&str>,
 ) -> Result<Option<serde_json::Value>>
 where
     F: Fn(&InferredSchemaData) -> Option<&serde_json::Value> + Copy,
@@ -269,6 +298,14 @@ where
     // Calculate required fields based on 100% presence
     // For object schemas, determine which fields are required
     calculate_required_fields(&mut merged, total_observations);
+
+    // PATCH-aware: PATCH requests are partial updates, so no fields should be marked required
+    if http_method == Some("PATCH") {
+        clear_required_fields(&mut merged);
+    }
+
+    // Enum promotion: promote observed string values to enum when thresholds are met
+    promote_enums(&mut merged);
 
     // Convert merged schema to JSON value
     let result = serde_json::to_value(&merged).map_err(|e| {
@@ -448,6 +485,57 @@ fn calculate_required_fields(schema: &mut InferredSchema, total_observations: us
     }
 }
 
+/// Recursively clear all required fields from a schema.
+/// Used for PATCH requests where all fields are optional (partial update).
+fn clear_required_fields(schema: &mut InferredSchema) {
+    schema.required = None;
+
+    if let Some(ref mut properties) = schema.properties {
+        for field_schema in properties.values_mut() {
+            clear_required_fields(field_schema);
+        }
+    }
+
+    if let Some(ref mut items) = schema.items {
+        clear_required_fields(items);
+    }
+}
+
+/// Recursively promote observed string values to enum values when thresholds are met.
+///
+/// A string field is promoted to enum if:
+/// - It has `observed_values` (tracking was active)
+/// - `sample_count >= MIN_SAMPLES_FOR_ENUM` (enough data to be confident)
+/// - `unique observed values <= MAX_ENUM_CARDINALITY` (low cardinality = likely enum)
+///
+/// After promotion, `observed_values` is cleared (internal tracking only).
+fn promote_enums(schema: &mut InferredSchema) {
+    // Check if this field qualifies for enum promotion
+    if let Some(ref observed) = schema.observed_values {
+        if schema.stats.sample_count >= MIN_SAMPLES_FOR_ENUM {
+            let unique: BTreeSet<&str> = observed.iter().map(|s| s.as_str()).collect();
+            if unique.len() <= MAX_ENUM_CARDINALITY {
+                // Promote: set enum_values to sorted unique values
+                schema.enum_values = Some(unique.into_iter().map(String::from).collect());
+            }
+        }
+        // Always clear observed_values after aggregation (internal tracking only)
+        schema.observed_values = None;
+    }
+
+    // Recurse into object properties
+    if let Some(ref mut properties) = schema.properties {
+        for field_schema in properties.values_mut() {
+            promote_enums(field_schema);
+        }
+    }
+
+    // Recurse into array items
+    if let Some(ref mut items) = schema.items {
+        promote_enums(items);
+    }
+}
+
 /// Calculate comprehensive confidence score for aggregated schema
 ///
 /// Task 6.4: Confidence score based on multiple factors:
@@ -534,8 +622,8 @@ fn count_field_consistency(schema: &serde_json::Value, total: &mut usize, requir
                 }
             }
 
-            // Recursively check nested objects
-            if field_schema.get("type").and_then(|t| t.as_str()) == Some("object") {
+            // Recursively check nested objects (including oneOf with object variants)
+            if has_nested_object(field_schema) {
                 count_field_consistency(field_schema, total, required);
             }
         }
@@ -575,25 +663,37 @@ fn count_type_stability(schema: &serde_json::Value, total: &mut usize, stable: &
             *total += 1;
 
             // Check if type is stable (not a oneOf)
-            if let Some(type_val) = field_schema.get("type") {
-                let has_conflict = type_val.is_object() && type_val.get("oneof").is_some();
+            let has_conflict = field_schema
+                .get("type")
+                .map(|type_val| type_val.is_object() && type_val.get("oneof").is_some())
+                .unwrap_or(false);
 
-                if !has_conflict {
-                    *stable += 1;
-                }
-            } else {
-                // No type field means stable
+            if !has_conflict {
                 *stable += 1;
             }
 
             // Recursively check nested objects
-            if let Some(type_str) = field_schema.get("type").and_then(|t| t.as_str()) {
-                if type_str == "object" {
-                    count_type_stability(field_schema, total, stable);
-                }
+            // Handle both plain "object" type and oneOf containing "object"
+            if has_nested_object(field_schema) {
+                count_type_stability(field_schema, total, stable);
             }
         }
     }
+}
+
+/// Check if a field schema has nested object properties to recurse into.
+/// Handles both `"type": "object"` and `"type": {"oneof": [..., "object", ...]}`.
+fn has_nested_object(field_schema: &serde_json::Value) -> bool {
+    if let Some(type_val) = field_schema.get("type") {
+        if type_val.as_str() == Some("object") {
+            return true;
+        }
+        // oneOf containing "object" — field still has properties to recurse into
+        if let Some(oneof_arr) = type_val.get("oneof").and_then(|v| v.as_array()) {
+            return oneof_arr.iter().any(|t| t.as_str() == Some("object"));
+        }
+    }
+    false
 }
 
 /// Legacy simple confidence calculation (kept for backward compatibility in tests)
@@ -877,6 +977,185 @@ mod tests {
         // sample_score(10)=0.5, field=0.33, type=1.0
         // (0.5 * 0.4) + (0.33 * 0.4) + (1.0 * 0.2) = 0.2 + 0.132 + 0.2 = 0.532
         assert!(score > 0.50 && score < 0.56);
+    }
+
+    // === Enum promotion tests ===
+
+    #[test]
+    fn test_promote_enums_at_threshold() {
+        let mut schema = InferredSchema::new(crate::schema::SchemaType::String);
+        schema.stats.sample_count = MIN_SAMPLES_FOR_ENUM;
+        schema.observed_values = Some(vec!["active".into(), "inactive".into(), "pending".into()]);
+
+        promote_enums(&mut schema);
+
+        assert!(schema.observed_values.is_none(), "observed_values should be cleared");
+        assert_eq!(
+            schema.enum_values,
+            Some(vec!["active".into(), "inactive".into(), "pending".into()])
+        );
+    }
+
+    #[test]
+    fn test_promote_enums_below_threshold() {
+        let mut schema = InferredSchema::new(crate::schema::SchemaType::String);
+        schema.stats.sample_count = MIN_SAMPLES_FOR_ENUM - 1; // below threshold
+        schema.observed_values = Some(vec!["a".into(), "b".into()]);
+
+        promote_enums(&mut schema);
+
+        assert!(schema.observed_values.is_none(), "observed_values cleared regardless");
+        assert!(schema.enum_values.is_none(), "Should not promote below threshold");
+    }
+
+    #[test]
+    fn test_promote_enums_high_cardinality_rejected() {
+        let mut schema = InferredSchema::new(crate::schema::SchemaType::String);
+        schema.stats.sample_count = 20;
+        // 11 unique values > MAX_ENUM_CARDINALITY (10)
+        schema.observed_values = Some((0..11).map(|i| format!("val_{}", i)).collect());
+
+        promote_enums(&mut schema);
+
+        assert!(schema.enum_values.is_none(), "High cardinality should not promote");
+    }
+
+    #[test]
+    fn test_promote_enums_nested_objects() {
+        use crate::schema::SchemaType;
+
+        let mut inner = InferredSchema::new(SchemaType::String);
+        inner.stats.sample_count = 15;
+        inner.observed_values = Some(vec!["low".into(), "medium".into(), "high".into()]);
+
+        let mut props = HashMap::new();
+        props.insert("priority".to_string(), inner);
+
+        let mut schema = InferredSchema::new(SchemaType::Object);
+        schema.properties = Some(props);
+
+        promote_enums(&mut schema);
+
+        let priority = schema.properties.as_ref().and_then(|p| p.get("priority"));
+        assert_eq!(
+            priority.and_then(|s| s.enum_values.as_ref()),
+            Some(&vec!["high".to_string(), "low".to_string(), "medium".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_promote_enums_sorted_output() {
+        let mut schema = InferredSchema::new(crate::schema::SchemaType::String);
+        schema.stats.sample_count = 10;
+        schema.observed_values = Some(vec!["z".into(), "a".into(), "m".into()]);
+
+        promote_enums(&mut schema);
+
+        assert_eq!(
+            schema.enum_values,
+            Some(vec!["a".into(), "m".into(), "z".into()]),
+            "Enum values should be sorted"
+        );
+    }
+
+    // === PATCH-aware requirement tests ===
+
+    #[test]
+    fn test_clear_required_fields() {
+        use crate::schema::SchemaType;
+
+        let mut inner = InferredSchema::new(SchemaType::String);
+        inner.required = Some(vec!["nested_field".into()]);
+
+        let mut props = HashMap::new();
+        props.insert("name".to_string(), InferredSchema::new(SchemaType::String));
+        props.insert("address".to_string(), inner);
+
+        let mut schema = InferredSchema::new(SchemaType::Object);
+        schema.properties = Some(props);
+        schema.required = Some(vec!["name".into()]);
+
+        clear_required_fields(&mut schema);
+
+        assert!(schema.required.is_none(), "Top-level required should be cleared");
+        let address = schema.properties.as_ref().and_then(|p| p.get("address"));
+        assert!(
+            address.and_then(|s| s.required.as_ref()).is_none(),
+            "Nested required should also be cleared"
+        );
+    }
+
+    // === Confidence scoring edge case tests ===
+
+    #[test]
+    fn test_field_consistency_empty_schema_returns_1() {
+        // No properties at all — should return 1.0
+        let schema = serde_json::json!({"type": "object"});
+        let mut response_map = HashMap::new();
+        response_map.insert("200".to_string(), schema);
+        let score = calculate_field_consistency_score(&None, &response_map);
+        assert_eq!(score, 1.0, "Empty schema should return 1.0 for consistency");
+    }
+
+    #[test]
+    fn test_type_stability_empty_schema_returns_1() {
+        let schema = serde_json::json!({"type": "object"});
+        let mut response_map = HashMap::new();
+        response_map.insert("200".to_string(), schema);
+        let score = calculate_type_stability_score(&None, &response_map);
+        assert_eq!(score, 1.0, "Empty schema should return 1.0 for stability");
+    }
+
+    #[test]
+    fn test_type_stability_oneof_object_with_nested_props() {
+        // Field with oneOf containing object — should recurse into properties
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": {"oneof": ["object", "null"]},
+                    "properties": {
+                        "id": {"type": "integer"},
+                        "name": {"type": "string"}
+                    }
+                }
+            }
+        });
+
+        let mut response_map = HashMap::new();
+        response_map.insert("200".to_string(), schema);
+
+        let score = calculate_type_stability_score(&None, &response_map);
+        // 3 total fields: data (unstable, oneOf), id (stable), name (stable)
+        // 2 stable out of 3 = 0.667
+        assert!((score - 0.667).abs() < 0.01, "Expected ~0.667 but got {}", score);
+    }
+
+    #[test]
+    fn test_field_consistency_oneof_object_with_nested_props() {
+        // Field with oneOf containing object — should recurse into properties
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": {"oneof": ["object", "null"]},
+                    "properties": {
+                        "id": {"type": "integer"},
+                        "name": {"type": "string"}
+                    },
+                    "required": ["id"]
+                }
+            },
+            "required": ["data"]
+        });
+
+        let mut response_map = HashMap::new();
+        response_map.insert("200".to_string(), schema);
+
+        let score = calculate_field_consistency_score(&None, &response_map);
+        // 3 total fields: data (required), id (required), name (not required)
+        // 2 required out of 3 = 0.667
+        assert!((score - 0.667).abs() < 0.01, "Expected ~0.667 but got {}", score);
     }
 
     #[cfg(feature = "postgres_tests")]

--- a/src/services/webhook_service.rs
+++ b/src/services/webhook_service.rs
@@ -99,6 +99,39 @@ impl LearningSessionWebhookEvent {
         }
     }
 
+    /// Create a webhook event for snapshot completion (auto-aggregate mode)
+    pub fn snapshot_completed(
+        session_id: String,
+        team: String,
+        route_pattern: String,
+        target_sample_count: i64,
+        current_sample_count: i64,
+        snapshot_count: i64,
+    ) -> Self {
+        let progress_percentage = if target_sample_count > 0 {
+            (current_sample_count as f64 / target_sample_count as f64) * 100.0
+        } else {
+            0.0
+        };
+
+        Self {
+            event_type: "learning_session.snapshot_completed".to_string(),
+            timestamp: chrono::Utc::now(),
+            session_id,
+            team,
+            previous_status: None,
+            current_status: LearningSessionStatus::Active,
+            route_pattern,
+            target_sample_count,
+            current_sample_count,
+            progress_percentage,
+            error_message: None,
+            metadata: serde_json::json!({
+                "snapshot_count": snapshot_count,
+            }),
+        }
+    }
+
     /// Create a webhook event for session failure
     pub fn failed(
         session_id: String,

--- a/src/storage/repositories/aggregated_schema.rs
+++ b/src/storage/repositories/aggregated_schema.rs
@@ -29,6 +29,8 @@ struct AggregatedSchemaRow {
     pub last_observed: chrono::DateTime<chrono::Utc>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub session_id: Option<String>,
+    pub snapshot_number: Option<i64>,
 }
 
 /// Aggregated API schema data
@@ -51,6 +53,8 @@ pub struct AggregatedSchemaData {
     pub last_observed: chrono::DateTime<chrono::Utc>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub session_id: Option<String>,
+    pub snapshot_number: Option<i64>,
 }
 
 impl TryFrom<AggregatedSchemaRow> for AggregatedSchemaData {
@@ -100,6 +104,8 @@ impl TryFrom<AggregatedSchemaRow> for AggregatedSchemaData {
             last_observed: row.last_observed,
             created_at: row.created_at,
             updated_at: row.updated_at,
+            session_id: row.session_id,
+            snapshot_number: row.snapshot_number,
         })
     }
 }
@@ -142,6 +148,8 @@ pub struct CreateAggregatedSchemaRequest {
     pub first_observed: chrono::DateTime<chrono::Utc>,
     pub last_observed: chrono::DateTime<chrono::Utc>,
     pub previous_version_id: Option<i64>,
+    pub session_id: Option<String>,
+    pub snapshot_number: Option<i64>,
 }
 
 /// Repository for aggregated schema data access
@@ -222,8 +230,9 @@ impl AggregatedSchemaRepository {
                 team, path, http_method, version, previous_version_id,
                 request_schema, response_schemas, request_headers, response_headers,
                 sample_count, confidence_score,
-                breaking_changes, first_observed, last_observed, created_at, updated_at
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+                breaking_changes, first_observed, last_observed, created_at, updated_at,
+                session_id, snapshot_number
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
             RETURNING id",
         )
         .bind(&request.team)
@@ -242,6 +251,8 @@ impl AggregatedSchemaRepository {
         .bind(request.last_observed)
         .bind(now)
         .bind(now)
+        .bind(&request.session_id)
+        .bind(request.snapshot_number)
         .fetch_one(&mut *tx)
         .await
         .map_err(|e| {
@@ -344,7 +355,8 @@ impl AggregatedSchemaRepository {
                     team, path, http_method, version, previous_version_id,
                     request_schema, response_schemas, request_headers, response_headers,
                     sample_count, confidence_score,
-                    breaking_changes, first_observed, last_observed, created_at, updated_at
+                    breaking_changes, first_observed, last_observed, created_at, updated_at,
+                    session_id, snapshot_number
                 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
                 RETURNING id",
             )
@@ -364,6 +376,8 @@ impl AggregatedSchemaRepository {
             .bind(request.last_observed)
             .bind(now)
             .bind(now)
+            .bind(&request.session_id)
+            .bind(request.snapshot_number)
             .fetch_one(&mut *tx)
             .await
             .map_err(|e| {
@@ -411,7 +425,8 @@ impl AggregatedSchemaRepository {
             "SELECT id, team, path, http_method, version, previous_version_id,
                     request_schema, response_schemas, request_headers, response_headers,
                     sample_count, confidence_score,
-                    breaking_changes, first_observed, last_observed, created_at, updated_at
+                    breaking_changes, first_observed, last_observed, created_at, updated_at,
+                    session_id, snapshot_number
              FROM aggregated_api_schemas WHERE id = $1",
         )
         .bind(id)
@@ -456,7 +471,8 @@ impl AggregatedSchemaRepository {
             "SELECT id, team, path, http_method, version, previous_version_id,
                     request_schema, response_schemas, request_headers, response_headers,
                     sample_count, confidence_score,
-                    breaking_changes, first_observed, last_observed, created_at, updated_at
+                    breaking_changes, first_observed, last_observed, created_at, updated_at,
+                    session_id, snapshot_number
              FROM aggregated_api_schemas
              WHERE id IN ({})
              ORDER BY path, http_method",
@@ -491,7 +507,8 @@ impl AggregatedSchemaRepository {
             "SELECT id, team, path, http_method, version, previous_version_id,
                     request_schema, response_schemas, request_headers, response_headers,
                     sample_count, confidence_score,
-                    breaking_changes, first_observed, last_observed, created_at, updated_at
+                    breaking_changes, first_observed, last_observed, created_at, updated_at,
+                    session_id, snapshot_number
              FROM aggregated_api_schemas
              WHERE team = $1 AND path = $2 AND http_method = $3
              ORDER BY version DESC
@@ -520,7 +537,8 @@ impl AggregatedSchemaRepository {
             "SELECT id, team, path, http_method, version, previous_version_id,
                     request_schema, response_schemas, request_headers, response_headers,
                     sample_count, confidence_score,
-                    breaking_changes, first_observed, last_observed, created_at, updated_at
+                    breaking_changes, first_observed, last_observed, created_at, updated_at,
+                    session_id, snapshot_number
              FROM aggregated_api_schemas
              ORDER BY created_at DESC",
         )
@@ -544,7 +562,8 @@ impl AggregatedSchemaRepository {
             "SELECT id, team, path, http_method, version, previous_version_id,
                     request_schema, response_schemas, request_headers, response_headers,
                     sample_count, confidence_score,
-                    breaking_changes, first_observed, last_observed, created_at, updated_at
+                    breaking_changes, first_observed, last_observed, created_at, updated_at,
+                    session_id, snapshot_number
              FROM aggregated_api_schemas
              WHERE team = $1
              ORDER BY created_at DESC",
@@ -570,7 +589,8 @@ impl AggregatedSchemaRepository {
             "SELECT a.id, a.team, a.path, a.http_method, a.version, a.previous_version_id,
                     a.request_schema, a.response_schemas, a.request_headers, a.response_headers,
                     a.sample_count, a.confidence_score,
-                    a.breaking_changes, a.first_observed, a.last_observed, a.created_at, a.updated_at
+                    a.breaking_changes, a.first_observed, a.last_observed, a.created_at, a.updated_at,
+                    a.session_id, a.snapshot_number
              FROM aggregated_api_schemas a
              INNER JOIN (
                  SELECT team, path, http_method, MAX(version) as max_version
@@ -610,7 +630,8 @@ impl AggregatedSchemaRepository {
             "SELECT id, team, path, http_method, version, previous_version_id,
                     request_schema, response_schemas, request_headers, response_headers,
                     sample_count, confidence_score,
-                    breaking_changes, first_observed, last_observed, created_at, updated_at
+                    breaking_changes, first_observed, last_observed, created_at, updated_at,
+                    session_id, snapshot_number
              FROM aggregated_api_schemas
              WHERE team = $1 AND path = $2 AND http_method = $3
              ORDER BY version DESC",
@@ -644,7 +665,8 @@ impl AggregatedSchemaRepository {
             "SELECT id, team, path, http_method, version, previous_version_id,
                     request_schema, response_schemas, request_headers, response_headers,
                     sample_count, confidence_score,
-                    breaking_changes, first_observed, last_observed, created_at, updated_at
+                    breaking_changes, first_observed, last_observed, created_at, updated_at,
+                    session_id, snapshot_number
              FROM aggregated_api_schemas
              WHERE team = $1 AND path = $2 AND http_method = $3 AND version = $4",
         )
@@ -678,7 +700,8 @@ impl AggregatedSchemaRepository {
             "SELECT id, team, path, http_method, version, previous_version_id,
                     request_schema, response_schemas, request_headers, response_headers,
                     sample_count, confidence_score,
-                    breaking_changes, first_observed, last_observed, created_at, updated_at
+                    breaking_changes, first_observed, last_observed, created_at, updated_at,
+                    session_id, snapshot_number
              FROM aggregated_api_schemas
              WHERE team = $1",
         );
@@ -756,6 +779,8 @@ mod tests {
             first_observed: chrono::Utc::now(),
             last_observed: chrono::Utc::now(),
             previous_version_id: None,
+            session_id: None,
+            snapshot_number: None,
         };
 
         let created = repo.create(request).await.unwrap();
@@ -795,6 +820,8 @@ mod tests {
             first_observed: now,
             last_observed: now,
             previous_version_id: None,
+            session_id: None,
+            snapshot_number: None,
         };
 
         let v1 = repo.create(request1).await.unwrap();
@@ -815,6 +842,8 @@ mod tests {
             first_observed: now,
             last_observed: now,
             previous_version_id: Some(v1.id),
+            session_id: None,
+            snapshot_number: None,
         };
 
         let v2 = repo.create(request2).await.unwrap();
@@ -846,6 +875,8 @@ mod tests {
                 first_observed: now,
                 last_observed: now,
                 previous_version_id: None,
+                session_id: None,
+                snapshot_number: None,
             };
 
             repo.create(request).await.unwrap();
@@ -882,6 +913,8 @@ mod tests {
                     first_observed: now,
                     last_observed: now,
                     previous_version_id: None,
+                    session_id: None,
+                    snapshot_number: None,
                 };
 
                 repo.create(request).await.unwrap();
@@ -923,6 +956,8 @@ mod tests {
                 first_observed: now,
                 last_observed: now,
                 previous_version_id: None,
+                session_id: None,
+                snapshot_number: None,
             };
             let schema = repo.create(request).await.unwrap();
             ids.push(schema.id);
@@ -972,6 +1007,8 @@ mod tests {
                 first_observed: now,
                 last_observed: now,
                 previous_version_id: None,
+                session_id: None,
+                snapshot_number: None,
             };
             let schema = repo.create(request).await.unwrap();
             ids.push(schema.id);
@@ -1007,6 +1044,8 @@ mod tests {
             first_observed: now,
             last_observed: now,
             previous_version_id: None,
+            session_id: None,
+            snapshot_number: None,
         };
 
         let schema = repo.create(request).await.unwrap();

--- a/src/storage/repositories/aggregated_schema.rs
+++ b/src/storage/repositories/aggregated_schema.rs
@@ -695,6 +695,7 @@ impl AggregatedSchemaRepository {
         path_search: Option<&str>,
         http_method: Option<&str>,
         min_confidence: Option<f64>,
+        session_id: Option<&str>,
     ) -> Result<Vec<AggregatedSchemaData>> {
         let mut query = String::from(
             "SELECT id, team, path, http_method, version, previous_version_id,
@@ -723,6 +724,11 @@ impl AggregatedSchemaRepository {
             query.push_str(&format!(" AND confidence_score >= ${}", bind_count));
         }
 
+        if session_id.is_some() {
+            bind_count += 1;
+            query.push_str(&format!(" AND session_id = ${}", bind_count));
+        }
+
         query.push_str(" ORDER BY created_at DESC");
 
         let mut query_builder =
@@ -738,6 +744,10 @@ impl AggregatedSchemaRepository {
 
         if let Some(confidence) = min_confidence {
             query_builder = query_builder.bind(confidence);
+        }
+
+        if let Some(sid) = session_id {
+            query_builder = query_builder.bind(sid);
         }
 
         let rows = query_builder.fetch_all(&self.pool).await.map_err(|e| {

--- a/src/storage/repositories/aggregated_schema.rs
+++ b/src/storage/repositories/aggregated_schema.rs
@@ -357,7 +357,7 @@ impl AggregatedSchemaRepository {
                     sample_count, confidence_score,
                     breaking_changes, first_observed, last_observed, created_at, updated_at,
                     session_id, snapshot_number
-                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
                 RETURNING id",
             )
             .bind(&request.team)

--- a/src/storage/repositories/learning_session.rs
+++ b/src/storage/repositories/learning_session.rs
@@ -72,6 +72,7 @@ struct LearningSessionRow {
     pub updated_at: chrono::DateTime<chrono::Utc>,
     pub auto_aggregate: bool,
     pub snapshot_count: i64,
+    pub name: Option<String>,
 }
 
 /// Learning session data
@@ -96,6 +97,7 @@ pub struct LearningSessionData {
     pub updated_at: chrono::DateTime<chrono::Utc>,
     pub auto_aggregate: bool,
     pub snapshot_count: i64,
+    pub name: Option<String>,
 }
 
 impl TryFrom<LearningSessionRow> for LearningSessionData {
@@ -147,6 +149,7 @@ impl TryFrom<LearningSessionRow> for LearningSessionData {
             updated_at: row.updated_at,
             auto_aggregate: row.auto_aggregate,
             snapshot_count: row.snapshot_count,
+            name: row.name,
         })
     }
 }
@@ -186,6 +189,7 @@ pub struct CreateLearningSessionRequest {
     pub deployment_version: Option<String>,
     pub configuration_snapshot: Option<serde_json::Value>,
     pub auto_aggregate: bool,
+    pub name: Option<String>,
 }
 
 /// Update learning session request
@@ -244,8 +248,8 @@ impl LearningSessionRepository {
                 id, team, route_pattern, cluster_name, http_methods, status,
                 created_at, ends_at, target_sample_count, current_sample_count,
                 triggered_by, deployment_version, configuration_snapshot, updated_at,
-                auto_aggregate, snapshot_count
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)",
+                auto_aggregate, snapshot_count, name
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)",
         )
         .bind(&id)
         .bind(&request.team)
@@ -263,6 +267,7 @@ impl LearningSessionRepository {
         .bind(now)
         .bind(request.auto_aggregate)
         .bind(0i64) // snapshot_count starts at 0
+        .bind(&request.name)
         .execute(&self.pool)
         .await
         .map_err(|e| {
@@ -296,7 +301,7 @@ impl LearningSessionRepository {
                     target_sample_count, current_sample_count,
                     triggered_by, deployment_version, configuration_snapshot,
                     error_message, updated_at,
-                    auto_aggregate, snapshot_count
+                    auto_aggregate, snapshot_count, name
              FROM learning_sessions WHERE id = $1",
         )
         .bind(id)
@@ -328,7 +333,7 @@ impl LearningSessionRepository {
                     target_sample_count, current_sample_count,
                     triggered_by, deployment_version, configuration_snapshot,
                     error_message, updated_at,
-                    auto_aggregate, snapshot_count
+                    auto_aggregate, snapshot_count, name
              FROM learning_sessions WHERE id = $1 AND team = $2"
         )
         .bind(id)
@@ -352,6 +357,62 @@ impl LearningSessionRepository {
         }
     }
 
+    /// Get learning session by name and team
+    #[instrument(skip(self), fields(name = %name, team = %team), name = "db_get_learning_session_by_name")]
+    pub async fn get_by_name(&self, team: &str, name: &str) -> Result<LearningSessionData> {
+        let row = sqlx::query_as::<sqlx::Postgres, LearningSessionRow>(
+            "SELECT id, team, route_pattern, cluster_name, http_methods, status,
+                    created_at, started_at, ends_at, completed_at,
+                    target_sample_count, current_sample_count,
+                    triggered_by, deployment_version, configuration_snapshot,
+                    error_message, updated_at,
+                    auto_aggregate, snapshot_count, name
+             FROM learning_sessions WHERE team = $1 AND name = $2",
+        )
+        .bind(team)
+        .bind(name)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, name = %name, team = %team, "Failed to get learning session by name");
+            FlowplaneError::Database {
+                source: e,
+                context: format!("Failed to get learning session with name '{}' for team '{}'", name, team),
+            }
+        })?;
+
+        match row {
+            Some(row) => row.try_into(),
+            None => Err(FlowplaneError::not_found_msg(format!(
+                "Learning session with name '{}' not found for team '{}'",
+                name, team
+            ))),
+        }
+    }
+
+    /// Get learning session by name or ID
+    ///
+    /// Tries UUID parse first (lookup by ID), falls back to name lookup.
+    #[instrument(skip(self), fields(name_or_id = %name_or_id, team = %team), name = "db_get_learning_session_by_name_or_id")]
+    pub async fn get_by_name_or_id(
+        &self,
+        team: &str,
+        name_or_id: &str,
+    ) -> Result<LearningSessionData> {
+        // Try UUID parse first — if it's a valid UUID, look up by ID
+        if uuid::Uuid::parse_str(name_or_id).is_ok() {
+            match self.get_by_id(name_or_id).await {
+                Ok(session) => return Ok(session),
+                Err(_) => {
+                    // Fall through to name lookup
+                }
+            }
+        }
+
+        // Fall back to name lookup
+        self.get_by_name(team, name_or_id).await
+    }
+
     /// List learning sessions by team
     #[instrument(skip(self), fields(team = %team), name = "db_list_learning_sessions_by_team")]
     pub async fn list_by_team(
@@ -371,7 +432,7 @@ impl LearningSessionRepository {
                         target_sample_count, current_sample_count,
                         triggered_by, deployment_version, configuration_snapshot,
                         error_message, updated_at,
-                        auto_aggregate, snapshot_count
+                        auto_aggregate, snapshot_count, name
                  FROM learning_sessions
                  WHERE team = $1 AND status = $2
                  ORDER BY created_at DESC LIMIT $3 OFFSET $4",
@@ -383,7 +444,7 @@ impl LearningSessionRepository {
                         target_sample_count, current_sample_count,
                         triggered_by, deployment_version, configuration_snapshot,
                         error_message, updated_at,
-                        auto_aggregate, snapshot_count
+                        auto_aggregate, snapshot_count, name
                  FROM learning_sessions
                  WHERE team = $1
                  ORDER BY created_at DESC LIMIT $2 OFFSET $3",
@@ -439,7 +500,7 @@ impl LearningSessionRepository {
                         target_sample_count, current_sample_count,
                         triggered_by, deployment_version, configuration_snapshot,
                         error_message, updated_at,
-                        auto_aggregate, snapshot_count
+                        auto_aggregate, snapshot_count, name
                  FROM learning_sessions
                  WHERE status = $1
                  ORDER BY created_at DESC
@@ -452,7 +513,7 @@ impl LearningSessionRepository {
                         target_sample_count, current_sample_count,
                         triggered_by, deployment_version, configuration_snapshot,
                         error_message, updated_at,
-                        auto_aggregate, snapshot_count
+                        auto_aggregate, snapshot_count, name
                  FROM learning_sessions
                  ORDER BY created_at DESC
                  LIMIT $1 OFFSET $2",
@@ -494,7 +555,7 @@ impl LearningSessionRepository {
                     target_sample_count, current_sample_count,
                     triggered_by, deployment_version, configuration_snapshot,
                     error_message, updated_at,
-                    auto_aggregate, snapshot_count
+                    auto_aggregate, snapshot_count, name
              FROM learning_sessions
              WHERE status = $1
              ORDER BY created_at DESC",
@@ -832,6 +893,7 @@ mod tests {
                 deployment_version: Some("v1.0.0".to_string()),
                 configuration_snapshot: Some(serde_json::json!({"key": "value"})),
                 auto_aggregate: false,
+                name: None,
             };
 
             let created = repo.create(request).await.expect("create should succeed");
@@ -875,6 +937,7 @@ mod tests {
                     deployment_version: None,
                     configuration_snapshot: None,
                     auto_aggregate: false,
+                    name: None,
                 };
                 repo.create(request).await.expect("create should succeed");
             }
@@ -891,6 +954,7 @@ mod tests {
                 deployment_version: None,
                 configuration_snapshot: None,
                 auto_aggregate: false,
+                name: None,
             };
             repo.create(request).await.expect("create should succeed");
 
@@ -924,6 +988,7 @@ mod tests {
                 deployment_version: None,
                 configuration_snapshot: None,
                 auto_aggregate: false,
+                name: None,
             };
             let session = repo.create(request).await.expect("create should succeed");
             assert_eq!(session.status, LearningSessionStatus::Pending);
@@ -996,6 +1061,7 @@ mod tests {
                 deployment_version: None,
                 configuration_snapshot: None,
                 auto_aggregate: false,
+                name: None,
             };
             let session = repo.create(request).await.expect("create should succeed");
             assert_eq!(session.current_sample_count, 0);
@@ -1030,6 +1096,7 @@ mod tests {
                 deployment_version: None,
                 configuration_snapshot: None,
                 auto_aggregate: false,
+                name: None,
             };
             let session = repo.create(request).await.expect("create should succeed");
 

--- a/src/storage/repositories/learning_session.rs
+++ b/src/storage/repositories/learning_session.rs
@@ -70,6 +70,8 @@ struct LearningSessionRow {
     pub configuration_snapshot: Option<String>, // JSON
     pub error_message: Option<String>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub auto_aggregate: bool,
+    pub snapshot_count: i64,
 }
 
 /// Learning session data
@@ -92,6 +94,8 @@ pub struct LearningSessionData {
     pub configuration_snapshot: Option<serde_json::Value>,
     pub error_message: Option<String>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
+    pub auto_aggregate: bool,
+    pub snapshot_count: i64,
 }
 
 impl TryFrom<LearningSessionRow> for LearningSessionData {
@@ -141,6 +145,8 @@ impl TryFrom<LearningSessionRow> for LearningSessionData {
             configuration_snapshot,
             error_message: row.error_message,
             updated_at: row.updated_at,
+            auto_aggregate: row.auto_aggregate,
+            snapshot_count: row.snapshot_count,
         })
     }
 }
@@ -179,6 +185,7 @@ pub struct CreateLearningSessionRequest {
     pub triggered_by: Option<String>,
     pub deployment_version: Option<String>,
     pub configuration_snapshot: Option<serde_json::Value>,
+    pub auto_aggregate: bool,
 }
 
 /// Update learning session request
@@ -236,8 +243,9 @@ impl LearningSessionRepository {
             "INSERT INTO learning_sessions (
                 id, team, route_pattern, cluster_name, http_methods, status,
                 created_at, ends_at, target_sample_count, current_sample_count,
-                triggered_by, deployment_version, configuration_snapshot, updated_at
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
+                triggered_by, deployment_version, configuration_snapshot, updated_at,
+                auto_aggregate, snapshot_count
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)",
         )
         .bind(&id)
         .bind(&request.team)
@@ -253,6 +261,8 @@ impl LearningSessionRepository {
         .bind(&request.deployment_version)
         .bind(&config_snapshot_json)
         .bind(now)
+        .bind(request.auto_aggregate)
+        .bind(0i64) // snapshot_count starts at 0
         .execute(&self.pool)
         .await
         .map_err(|e| {
@@ -285,7 +295,8 @@ impl LearningSessionRepository {
                     created_at, started_at, ends_at, completed_at,
                     target_sample_count, current_sample_count,
                     triggered_by, deployment_version, configuration_snapshot,
-                    error_message, updated_at
+                    error_message, updated_at,
+                    auto_aggregate, snapshot_count
              FROM learning_sessions WHERE id = $1",
         )
         .bind(id)
@@ -316,7 +327,8 @@ impl LearningSessionRepository {
                     created_at, started_at, ends_at, completed_at,
                     target_sample_count, current_sample_count,
                     triggered_by, deployment_version, configuration_snapshot,
-                    error_message, updated_at
+                    error_message, updated_at,
+                    auto_aggregate, snapshot_count
              FROM learning_sessions WHERE id = $1 AND team = $2"
         )
         .bind(id)
@@ -358,7 +370,8 @@ impl LearningSessionRepository {
                         created_at, started_at, ends_at, completed_at,
                         target_sample_count, current_sample_count,
                         triggered_by, deployment_version, configuration_snapshot,
-                        error_message, updated_at
+                        error_message, updated_at,
+                        auto_aggregate, snapshot_count
                  FROM learning_sessions
                  WHERE team = $1 AND status = $2
                  ORDER BY created_at DESC LIMIT $3 OFFSET $4",
@@ -369,7 +382,8 @@ impl LearningSessionRepository {
                         created_at, started_at, ends_at, completed_at,
                         target_sample_count, current_sample_count,
                         triggered_by, deployment_version, configuration_snapshot,
-                        error_message, updated_at
+                        error_message, updated_at,
+                        auto_aggregate, snapshot_count
                  FROM learning_sessions
                  WHERE team = $1
                  ORDER BY created_at DESC LIMIT $2 OFFSET $3",
@@ -424,7 +438,8 @@ impl LearningSessionRepository {
                         created_at, started_at, ends_at, completed_at,
                         target_sample_count, current_sample_count,
                         triggered_by, deployment_version, configuration_snapshot,
-                        error_message, updated_at
+                        error_message, updated_at,
+                        auto_aggregate, snapshot_count
                  FROM learning_sessions
                  WHERE status = $1
                  ORDER BY created_at DESC
@@ -436,7 +451,8 @@ impl LearningSessionRepository {
                         created_at, started_at, ends_at, completed_at,
                         target_sample_count, current_sample_count,
                         triggered_by, deployment_version, configuration_snapshot,
-                        error_message, updated_at
+                        error_message, updated_at,
+                        auto_aggregate, snapshot_count
                  FROM learning_sessions
                  ORDER BY created_at DESC
                  LIMIT $1 OFFSET $2",
@@ -477,7 +493,8 @@ impl LearningSessionRepository {
                     created_at, started_at, ends_at, completed_at,
                     target_sample_count, current_sample_count,
                     triggered_by, deployment_version, configuration_snapshot,
-                    error_message, updated_at
+                    error_message, updated_at,
+                    auto_aggregate, snapshot_count
              FROM learning_sessions
              WHERE status = $1
              ORDER BY created_at DESC",
@@ -670,6 +687,46 @@ impl LearningSessionRepository {
         }
     }
 
+    /// Reset sample count and increment snapshot count (for auto-aggregate snapshot mode)
+    ///
+    /// Atomically resets current_sample_count to 0 and increments snapshot_count.
+    /// Used when a snapshot aggregation is triggered during auto-aggregate mode.
+    #[instrument(skip(self), fields(session_id = %id), name = "db_reset_sample_count_increment_snapshot")]
+    pub async fn reset_sample_count_and_increment_snapshot(&self, id: &str) -> Result<i64> {
+        let now = chrono::Utc::now();
+
+        let result = sqlx::query(
+            "UPDATE learning_sessions
+             SET current_sample_count = 0, snapshot_count = snapshot_count + 1, updated_at = $1
+             WHERE id = $2
+             RETURNING snapshot_count",
+        )
+        .bind(now)
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, session_id = %id, "Failed to reset sample count and increment snapshot");
+            FlowplaneError::Database {
+                source: e,
+                context: format!("Failed to reset sample count for session '{}'", id),
+            }
+        })?;
+
+        match result {
+            Some(row) => {
+                let count: i64 = row.try_get("snapshot_count").map_err(|e| {
+                    FlowplaneError::validation(format!("Failed to get snapshot_count: {}", e))
+                })?;
+                Ok(count)
+            }
+            None => Err(FlowplaneError::not_found_msg(format!(
+                "Learning session with ID '{}' not found",
+                id
+            ))),
+        }
+    }
+
     /// Delete learning session (cancel)
     #[instrument(skip(self), fields(session_id = %id), name = "db_delete_learning_session")]
     pub async fn delete(&self, id: &str, team: &str) -> Result<()> {
@@ -774,6 +831,7 @@ mod tests {
                 triggered_by: Some("test-user".to_string()),
                 deployment_version: Some("v1.0.0".to_string()),
                 configuration_snapshot: Some(serde_json::json!({"key": "value"})),
+                auto_aggregate: false,
             };
 
             let created = repo.create(request).await.expect("create should succeed");
@@ -816,6 +874,7 @@ mod tests {
                     triggered_by: None,
                     deployment_version: None,
                     configuration_snapshot: None,
+                    auto_aggregate: false,
                 };
                 repo.create(request).await.expect("create should succeed");
             }
@@ -831,6 +890,7 @@ mod tests {
                 triggered_by: None,
                 deployment_version: None,
                 configuration_snapshot: None,
+                auto_aggregate: false,
             };
             repo.create(request).await.expect("create should succeed");
 
@@ -863,6 +923,7 @@ mod tests {
                 triggered_by: None,
                 deployment_version: None,
                 configuration_snapshot: None,
+                auto_aggregate: false,
             };
             let session = repo.create(request).await.expect("create should succeed");
             assert_eq!(session.status, LearningSessionStatus::Pending);
@@ -934,6 +995,7 @@ mod tests {
                 triggered_by: None,
                 deployment_version: None,
                 configuration_snapshot: None,
+                auto_aggregate: false,
             };
             let session = repo.create(request).await.expect("create should succeed");
             assert_eq!(session.current_sample_count, 0);
@@ -967,6 +1029,7 @@ mod tests {
                 triggered_by: None,
                 deployment_version: None,
                 configuration_snapshot: None,
+                auto_aggregate: false,
             };
             let session = repo.create(request).await.expect("create should succeed");
 

--- a/ui/src/lib/api/client.ts
+++ b/ui/src/lib/api/client.ts
@@ -993,6 +993,17 @@ class ApiClient {
 	}
 
 	/**
+	 * Stop a learning session.
+	 * This triggers final aggregation and completes the session gracefully.
+	 */
+	async stopLearningSession(team: string, id: string): Promise<LearningSessionResponse> {
+		return this.post<LearningSessionResponse>(
+			`/api/v1/teams/${encodeURIComponent(team)}/learning-sessions/${encodeURIComponent(id)}/stop`,
+			{}
+		);
+	}
+
+	/**
 	 * Cancel a learning session.
 	 * This will stop traffic capture and mark the session as cancelled.
 	 */

--- a/ui/src/lib/api/types.ts
+++ b/ui/src/lib/api/types.ts
@@ -1630,6 +1630,7 @@ export type LearningSessionStatus =
 export interface LearningSessionResponse {
 	id: string;
 	team: string;
+	name: string | null;
 	routePattern: string;
 	clusterName: string | null;
 	httpMethods: string[] | null;
@@ -1650,6 +1651,7 @@ export interface LearningSessionResponse {
 
 /** Request to create a learning session */
 export interface CreateLearningSessionRequest {
+	name?: string;
 	routePattern: string;
 	clusterName?: string;
 	httpMethods?: string[];

--- a/ui/src/lib/api/types.ts
+++ b/ui/src/lib/api/types.ts
@@ -1644,6 +1644,8 @@ export interface LearningSessionResponse {
 	triggeredBy: string | null;
 	deploymentVersion: string | null;
 	errorMessage: string | null;
+	autoAggregate: boolean;
+	snapshotCount: number;
 }
 
 /** Request to create a learning session */
@@ -1656,6 +1658,7 @@ export interface CreateLearningSessionRequest {
 	triggeredBy?: string;
 	deploymentVersion?: string;
 	configurationSnapshot?: Record<string, unknown>;
+	autoAggregate?: boolean;
 }
 
 /** Query parameters for listing learning sessions */

--- a/ui/src/routes/(authenticated)/learning/+page.svelte
+++ b/ui/src/routes/(authenticated)/learning/+page.svelte
@@ -390,7 +390,14 @@
 								</div>
 							</td>
 							<td class="px-6 py-4 whitespace-nowrap">
+								<div class="flex items-center gap-2">
 								<SessionStatusBadge status={session.status} />
+								{#if session.autoAggregate}
+									<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+										Auto
+									</span>
+								{/if}
+							</div>
 							</td>
 							<td class="px-6 py-4">
 								<div class="w-48">

--- a/ui/src/routes/(authenticated)/learning/+page.svelte
+++ b/ui/src/routes/(authenticated)/learning/+page.svelte
@@ -132,6 +132,8 @@
 				!searchQuery ||
 				session.routePattern.toLowerCase().includes(searchQuery.toLowerCase()) ||
 				session.id.toLowerCase().includes(searchQuery.toLowerCase()) ||
+				(session.name &&
+					session.name.toLowerCase().includes(searchQuery.toLowerCase())) ||
 				(session.clusterName &&
 					session.clusterName.toLowerCase().includes(searchQuery.toLowerCase()))
 		)
@@ -357,6 +359,9 @@
 				<thead class="bg-gray-50">
 					<tr>
 						<th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+							Name
+						</th>
+						<th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
 							Route Pattern
 						</th>
 						<th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -376,6 +381,13 @@
 				<tbody class="bg-white divide-y divide-gray-200">
 					{#each filteredSessions as session}
 						<tr class="hover:bg-gray-50">
+							<td class="px-6 py-4 whitespace-nowrap">
+								{#if session.name}
+									<span class="text-sm font-medium text-gray-900">{session.name}</span>
+								{:else}
+									<span class="text-sm text-gray-400" title={session.id}>{session.id.slice(0, 8)}...</span>
+								{/if}
+							</td>
 							<td class="px-6 py-4">
 								<div class="flex flex-col">
 									<code class="text-sm font-mono text-gray-900">{session.routePattern}</code>

--- a/ui/src/routes/(authenticated)/learning/[id]/+page.svelte
+++ b/ui/src/routes/(authenticated)/learning/[id]/+page.svelte
@@ -14,7 +14,9 @@
 		AlertTriangle,
 		Calendar,
 		Target,
-		FileCode
+		FileCode,
+		StopCircle,
+		Camera
 	} from 'lucide-svelte';
 	import type { LearningSessionResponse } from '$lib/api/types';
 	import Button from '$lib/components/Button.svelte';
@@ -95,6 +97,25 @@
 		}
 	}
 
+	async function handleStop() {
+		if (!session) return;
+		if (
+			!confirm(
+				'Stop this session? This will trigger final aggregation and complete the session.'
+			)
+		) {
+			return;
+		}
+
+		actionError = null;
+		try {
+			await apiClient.stopLearningSession(session.team, session.id);
+			await loadSession();
+		} catch (err) {
+			actionError = err instanceof Error ? err.message : 'Failed to stop session';
+		}
+	}
+
 	async function handleCancel() {
 		if (!session) return;
 		if (
@@ -171,16 +192,30 @@
 				<div class="flex items-center gap-3">
 					<h1 class="text-3xl font-bold text-gray-900">Learning Session</h1>
 					<SessionStatusBadge status={session.status} size="md" />
+					{#if session.autoAggregate}
+						<span class="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+							<Camera class="h-3 w-3" />
+							Auto
+						</span>
+					{/if}
 				</div>
 				<p class="mt-2 text-sm text-gray-500 font-mono">{session.id}</p>
 			</div>
 
-			{#if session.status === 'active' || session.status === 'pending'}
-				<Button onclick={handleCancel} variant="danger">
-					<XCircle class="h-4 w-4 mr-2" />
-					Cancel Session
-				</Button>
-			{/if}
+			<div class="flex items-center gap-2">
+				{#if session.status === 'active'}
+					<Button onclick={handleStop} variant="primary">
+						<StopCircle class="h-4 w-4 mr-2" />
+						Stop Session
+					</Button>
+				{/if}
+				{#if session.status === 'active' || session.status === 'pending'}
+					<Button onclick={handleCancel} variant="danger">
+						<XCircle class="h-4 w-4 mr-2" />
+						Cancel Session
+					</Button>
+				{/if}
+			</div>
 		</div>
 
 		<!-- Action Error -->
@@ -210,6 +245,13 @@
 				size="lg"
 				animated={session.status === 'active'}
 			/>
+
+			{#if session.autoAggregate && session.snapshotCount > 0}
+				<div class="mt-4 flex items-center gap-2 text-sm text-gray-600">
+					<Camera class="h-4 w-4 text-purple-500" />
+					<span>Snapshots: {session.snapshotCount}</span>
+				</div>
+			{/if}
 
 			{#if session.errorMessage}
 				<div

--- a/ui/src/routes/(authenticated)/learning/[id]/+page.svelte
+++ b/ui/src/routes/(authenticated)/learning/[id]/+page.svelte
@@ -190,7 +190,7 @@
 		<div class="mb-8 flex items-start justify-between">
 			<div>
 				<div class="flex items-center gap-3">
-					<h1 class="text-3xl font-bold text-gray-900">Learning Session</h1>
+					<h1 class="text-3xl font-bold text-gray-900">{session.name ?? 'Learning Session'}</h1>
 					<SessionStatusBadge status={session.status} size="md" />
 					{#if session.autoAggregate}
 						<span class="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">

--- a/ui/src/routes/(authenticated)/learning/create/+page.svelte
+++ b/ui/src/routes/(authenticated)/learning/create/+page.svelte
@@ -16,6 +16,7 @@
 	let isLoadingPermissions = $state(true);
 
 	// Form state
+	let sessionName = $state('');
 	let routePattern = $state('^/api/.*');
 	let clusterName = $state('');
 	let httpMethods = $state<string[]>([]);
@@ -103,6 +104,10 @@
 				targetSampleCount
 			};
 
+			if (sessionName.trim()) {
+				request.name = sessionName.trim();
+			}
+
 			if (clusterName.trim()) {
 				request.clusterName = clusterName.trim();
 			}
@@ -178,6 +183,22 @@
 			<h2 class="text-lg font-semibold text-gray-900 mb-4">Traffic Matching</h2>
 
 			<div class="space-y-4">
+				<div>
+					<label for="sessionName" class="block text-sm font-medium text-gray-700 mb-1">
+						Session Name
+					</label>
+					<input
+						id="sessionName"
+						type="text"
+						bind:value={sessionName}
+						placeholder="e.g., mockbank-v1 (auto-generated if empty)"
+						class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+					/>
+					<p class="mt-1 text-sm text-gray-500">
+						A human-readable name for this session. Leave empty to auto-generate.
+					</p>
+				</div>
+
 				<div>
 					<label for="routePattern" class="block text-sm font-medium text-gray-700 mb-1">
 						Route Pattern (Regex) <span class="text-red-500">*</span>

--- a/ui/src/routes/(authenticated)/learning/create/+page.svelte
+++ b/ui/src/routes/(authenticated)/learning/create/+page.svelte
@@ -21,6 +21,7 @@
 	let httpMethods = $state<string[]>([]);
 	let targetSampleCount = $state(100);
 	let maxDurationSeconds = $state<number | null>(null);
+	let autoAggregate = $state(false);
 	let triggeredBy = $state('');
 	let deploymentVersion = $state('');
 
@@ -108,6 +109,10 @@
 
 			if (httpMethods.length > 0) {
 				request.httpMethods = httpMethods;
+			}
+
+			if (autoAggregate) {
+				request.autoAggregate = true;
 			}
 
 			if (maxDurationSeconds && maxDurationSeconds > 0) {
@@ -258,6 +263,25 @@
 					<p class="mt-1 text-sm text-gray-500">
 						Session completes after capturing this many samples (1 - 100,000)
 					</p>
+				</div>
+
+				<div class="flex items-start gap-3">
+					<div class="flex h-6 items-center">
+						<input
+							id="autoAggregate"
+							type="checkbox"
+							bind:checked={autoAggregate}
+							class="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+						/>
+					</div>
+					<div>
+						<label for="autoAggregate" class="text-sm font-medium text-gray-700">
+							Auto-aggregate
+						</label>
+						<p class="text-sm text-gray-500">
+							Periodically aggregate schemas while continuing to collect samples
+						</p>
+					</div>
 				</div>
 
 				<div>


### PR DESCRIPTION
## Summary

Ports key improvements from the [specwatch](https://github.com/rajeevramani/specwatch) schema learning engine into flowplane's Rust-based learning pipeline, plus new CLI commands and UX improvements.

### Schema Learning Engine
- **Enum detection** — low-cardinality strings auto-promoted to enums (≤10 unique, ≥10 samples)
- **Path normalization** — contextual parameter naming: `/users/123` → `/users/{userId}`, 47 keywords, 141 plural mappings
- **PATCH-aware requirements** — PATCH request bodies never mark fields as required
- **Confidence scoring** — improved oneOf field counting and edge case handling
- **Domain model dedup** — shared schemas as `$ref` in `components/schemas` for OpenAPI export
- **Auto-aggregate** — snapshot mode for continuous learning with periodic aggregation

### Named Learning Sessions
- `--name` flag on `learn start` (auto-generated from route pattern if omitted)
- All learn commands accept name or UUID
- Schema queries scoped by `--session`

### Schema CLI
- `flowplane schema list` / `get` / `export` — new top-level command
- `flowplane learn export` — convenience shortcut
- OpenAPI 3.1 export to stdout (YAML) or file (auto-detect format from extension)

### MCP Tools
- New `cp_stop_learning` tool
- `name` and `autoAggregate` params on `cp_create_learning_session`
- All learning tools accept name or UUID

### Documentation
- [Learning Quickstart](docs/learning-quickstart.md) — end-to-end guide
- CHANGELOG.md created
- Updated: README, cli-reference.md, mcp.md, getting-started.md, skills

### Quality
- 2429 lib tests + 20 doc tests passing
- 0 clippy warnings
- Live-tested against MockBank through Envoy

## Test plan

- [x] `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings` — 0 warnings
- [x] `cargo test` — 2429 passed, 0 failed
- [x] `npx svelte-check` — 9 errors (all pre-existing)
- [x] Live stack test: learning session → 34 schemas from 31 samples → OpenAPI export
- [ ] `make build` + `flowplane init --with-envoy` + full learning pipeline with MockBank
- [ ] Verify named sessions: `flowplane learn start --name test`, `flowplane learn get test`, `flowplane learn export --session test`
- [ ] Verify schema CLI: `flowplane schema list`, `flowplane schema export --all -o api.yaml`