### PR TITLE
Bump version to 0.2.2, add README badges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "flowplane"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowplane"
-version = "0.2.0"
+version = "0.2.2"
 edition = "2021"
 default-run = "flowplane"
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Flowplane
 
+[![CI](https://github.com/rajeevramani/flowplane/actions/workflows/ci.yml/badge.svg)](https://github.com/rajeevramani/flowplane/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/rajeevramani/flowplane)](https://github.com/rajeevramani/flowplane/releases/latest)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Rust](https://img.shields.io/badge/rust-1.92%2B-orange.svg)](https://www.rust-lang.org/)
+
 A control plane for [Envoy proxy](https://www.envoyproxy.io/) that manages gateway configuration through a CLI, REST API, or MCP server. Stores clusters, listeners, routes, and filters in PostgreSQL and pushes them to Envoy via xDS.
 
 ## Quick Start


### PR DESCRIPTION
## Summary

- Bump `Cargo.toml` version from 0.2.0 to 0.2.2 to match the release tag
- Add CI, release, license, and Rust version badges to README