### PR TITLE
Scrub hardcoded Auth0 identifiers from prod-local runbook

### DIFF
--- a/internal/prod-local-runbook.md
+++ b/internal/prod-local-runbook.md
@@ -108,9 +108,9 @@ auth0|6650f0...
 You now have:
 
 ```text
-Issuer:        https://dev-63kqv3bdirrh63bi.us.auth0.com/
-Client ID:     ehqZXjlVcosrCQcy0F3OySrXzfwlQwUQ
-Admin subject: auth0|6a34ba3d79da66ea439fc75d
+Issuer:        https://<tenant>.us.auth0.com/
+Client ID:     <auth0-native-app-client-id>
+Admin subject: auth0|<admin-user-id>
 ```
 
 Auth0-specific gotchas:


### PR DESCRIPTION
Replaces the concrete Auth0 tenant issuer, client id, and admin subject in `internal/prod-local-runbook.md` with placeholders so no tenant identifiers are checked in.

These are not credentials (no client secret/token) — public-by-design OAuth identifiers plus one opaque user id — but they should not be committed.

**Note:** the strings remain in prior history (this PR is a forward scrub, not a history rewrite). To fully neutralize, rotate the published Auth0 native-app for a new client id. A full `git filter-repo` history rewrite + force-push is the alternative if policy requires the strings gone entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)