### PR TITLE
Secure AWS ECS/RDS control plane with local mTLS dataplane (#98)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,10 @@ scripts/flowplane-dev.py
 internal/dev-workflow-automation.md
 internal/do-over-prompt.md
 internal/review-issue-prompt.md
+
+# local OpenTofu/Terraform state and inputs
+**/.terraform/
+**/*.tfstate
+**/*.tfstate.*
+**/*.tfvars
+**/*.tfvars.json

--- a/deploy/aws/.terraform.lock.hcl
+++ b/deploy/aws/.terraform.lock.hcl
@@ -1,0 +1,66 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:7/GgVlN+KplSVCuc8qb4ct2R7gotYooPNRd0cnj9GxE=",
+    "h1:BrNG7eFOdRrRRbHdvrTjMJ8X8Oh/tiegURiKf7J2db8=",
+    "h1:C6eM6fGJVktK2M5vH3Yhv5NnqmegcBDY0EuDHhiXoVY=",
+    "h1:C7yD4Be2zhVdjnilsKPfucYAYMG5UCJYuUSoY6FCtGQ=",
+    "h1:H8CH2vfXXP/WQgJw+Qrn72umKs9UlGYQvn+QdnwO8Nc=",
+    "h1:J7L5bgyYNRAbtwAFJl2Lj+IMI2DJTrbbL33PTK4OWVY=",
+    "h1:JJ+EJQ+sIN3XRmNmrSUnUQtR8i3P22z+AbtAf8O/cRE=",
+    "h1:Wm5Ofhc15lX1OMMCt7iDV0NY5FDIouQDjX7I1iab55s=",
+    "h1:crKvBCgX6RlMcE6Ewm8o8YVuIg6mkXqKNgt/kSFYTvQ=",
+    "h1:zef23ac/YWw9O2FepFWRs+my9iWWUkniL4dT4LnCKjU=",
+    "zh:1a41f3ee26720fee7a9a0a361890632a1701b5dc1cf5355dc651ddbe115682ff",
+    "zh:30457f36690c19307921885cc5e72b9dbeba369445815903acd5c39ac0e41e7a",
+    "zh:42c22674d5f23f6309eaf3ac3a4f1f8b66b566c1efe1dcb0dd2fb30c17ce1f78",
+    "zh:4cc271c795ff8ce6479ec2d11a8ba65a0a9ed6331def6693f4b9dccb6e662838",
+    "zh:60932aa376bb8c87cd1971240063d9d38ba6a55502c867fdbb9f5361dc93d003",
+    "zh:864e42784bde77b18393ebfcc0104cea9123da5f4392e8a059789e296952eefa",
+    "zh:9750423138bb01ecaa5cec1a6691664f7783d301fb1628d3b64a231b6b564e0e",
+    "zh:e5d30c4dec271ef9d6fe09f48237ec6cfea1036848f835b4e47f274b48bda5a7",
+    "zh:e62bd314ae97b43d782e0841b13e68a3f8ec85cc762004f973ce5ce7b6cdbfd0",
+    "zh:ea851a3c072528a4445ac6236ba2ce58ffc99ec466019b0bd0e4adde63a248e4",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:8EQU5KSxezcjo/phRSe69rDOI0lk4pSaggj7FsskYp8=",
+    "h1:Lw9im2VBBJQ3RyAbHPQ0rcvcmmcZWm3x+kIOpN+Tv9s=",
+    "h1:U8KXqGCoNI9/guYbTvzgdtVk3fRthoG0UXwm1JoEpIs=",
+    "h1:YXaVd4p6qXPPVaxIBaIDNXmBwT02ZqDn0qD+tYpw8sA=",
+    "h1:cOpc03fphEt/G9Rfc4jLL/fW0D7tgvlXqiDKPF4vuww=",
+    "h1:g09RR7T1xWkeGrZwWvWMT9ncJrFGr1k3CBD585UmO7w=",
+    "h1:gGDdPPibmw2EWROx+sh1RGLjR5+nPwZyrf6/N9jXfeM=",
+    "h1:haE7/nXCOhXKP4oXeEnER3t5CaVQWqujz4nBnpeTUv4=",
+    "h1:ieSVpfZS2lKuMr05ph0QsOVpCzg7uk3cgKBaXR+Ikug=",
+    "h1:ig2s1IS9IzehorRjvVAnKIsUUj8fkgyxct1L/kswcc4=",
+    "h1:j3lS+ZEERFnoab8t1ppDrScGVP/cgWbzlCrEYKTCXYw=",
+    "h1:lxezrKmOiQIySHAM+os8qLVq7hqufDr8h3Hpzvsk+78=",
+    "h1:lzRqBJAG+NETxHbEZUJ/YP3RMEjZBinTX7VmgH3lw60=",
+    "h1:tdSNWK5ApqUsgbdYieyeYLTu6nIZUV3hR1oFqUfAuGo=",
+    "h1:xedet8yH/zI2CfdxsGlK0nlFWc/Bp61yrWsEa3fHB8g=",
+    "zh:03f1114cc20b8913523735ab76e0f0a2b16ce13c92923a53304bf85f07fc0dbc",
+    "zh:105b678ee72322a3067f105d7e05e940f6143238f377f6e87ff4ec909246ac2a",
+    "zh:55f3bbf13ea18cbace61a706566a80f25f33fe2b1780b6f3d7b582af2a05b6d2",
+    "zh:63adf996db48f082f7a6351eb485e219cd88795fc71e6ec60a837263ab0d2cb1",
+    "zh:7e99550738a4e3cc68b8a467714b0d69371025fe95e3326d5323d026d55653e9",
+    "zh:8342b54af3a18a37e075eeae61be57f4de2ba71b35d95c5075d402dd2c1f289d",
+    "zh:83ee18e32ac9dd5fc91298554b7c4cfa4c3a1db50f4c797945637cc93c0844ae",
+    "zh:993ecc0adbf6bd535a59fbc9b735d8c33950e6f6eb5e621d750da9b71d65d80a",
+    "zh:ad722bc59d4edbf1415e827fc007c0efe6e0e9462d5568bae20b34be1058a261",
+    "zh:ae9448e1f87b2f9a6c5197a0e9862162ec6b137cb3a3835e11522995d8939e7c",
+    "zh:bc9cdd3aac784f759125c6627f6f6416e8726a1c184eb9cf3e55b9edbc94c627",
+    "zh:c8e35b89572ba1c40a9b20022e033a3395fb8d42e7604d50c900f193ba10382e",
+    "zh:e2deaa8a9975ef81d9f62baed12c41286918b0a10908e0e031f13f69a3b730a1",
+    "zh:ee39707557210a0ab1098aa357d2cdfe502e5a312d0dbdffb09d08facc4d3fc5",
+    "zh:f81afe4eb63e8aa9e0ea71be6c990f0dc69cb360e7191c0742a991f4a5081b64",
+  ]
+}

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -1,0 +1,142 @@
+# Flowplane AWS Secure Deployment
+
+This OpenTofu module provisions a strict-secure AWS smoke environment for the Flowplane control
+plane:
+
+- ECS/Fargate control plane in private subnets.
+- RDS PostgreSQL in private subnets.
+- Public API through an ALB on HTTPS 443, forwarding to the task over HTTPS 8080.
+- Public xDS through an NLB on TCP 18000, preserving mTLS through to the Flowplane process.
+- NAT egress for private ECS tasks to reach external OIDC/JWKS providers such as Auth0.
+- No `FLOWPLANE_API_INSECURE=true`.
+
+The module intentionally does not manage Cloudflare DNS. Use the outputs to create records under
+`getflowplane.io`.
+
+## Prerequisites
+
+- OpenTofu.
+- AWS credentials for the target account.
+- A Flowplane release image pushed to ECR in the selected region.
+- An ACM certificate for the API hostname.
+- Secrets Manager secrets containing:
+  - `FLOWPLANE_SECRET_ENCRYPTION_KEY`
+  - API backend TLS certificate PEM
+  - API backend TLS private key PEM
+  - xDS server certificate PEM
+  - xDS server private key PEM
+  - dataplane client CA certificate PEM
+  - dataplane certificate issuer CA certificate PEM
+  - dataplane certificate issuer CA private key PEM
+
+The control-plane container receives PEM values as ECS secrets, writes them to `/tmp/flowplane/tls`,
+and starts `flowplane serve` with file-path environment variables.
+
+The module creates NAT egress by default because prod OIDC needs outbound HTTPS to the configured
+issuer/JWKS provider. For the smoke environment it uses one NAT gateway by default; set
+`single_nat_gateway = false` for one NAT gateway per AZ.
+
+If the Secrets Manager secrets use a customer-managed KMS key, set `secret_kms_key_arns` so the ECS
+task execution role can decrypt them.
+
+## Variables
+
+Create an ignored tfvars file, for example `deploy/aws/local.auto.tfvars`:
+
+```hcl
+aws_region = "us-east-1"
+availability_zones = ["us-east-1a", "us-east-1b"]
+
+control_plane_image = "<account>.dkr.ecr.us-east-1.amazonaws.com/flowplane:<tag>"
+
+api_certificate_arn = "arn:aws:acm:us-east-1:<account>:certificate/..."
+
+oidc_issuer   = "https://<tenant>.us.auth0.com/"
+oidc_audience = "<auth0-native-app-client-id>"
+
+xds_ingress_cidrs = ["<your-public-ip>/32"]
+
+secret_encryption_key_secret_arn = "arn:aws:secretsmanager:..."
+api_tls_cert_secret_arn          = "arn:aws:secretsmanager:..."
+api_tls_key_secret_arn           = "arn:aws:secretsmanager:..."
+xds_tls_cert_secret_arn          = "arn:aws:secretsmanager:..."
+xds_tls_key_secret_arn           = "arn:aws:secretsmanager:..."
+xds_tls_client_ca_secret_arn     = "arn:aws:secretsmanager:..."
+cert_issuer_ca_cert_secret_arn   = "arn:aws:secretsmanager:..."
+cert_issuer_ca_key_secret_arn    = "arn:aws:secretsmanager:..."
+```
+
+You can source OIDC values from `internal/.env.prod-local`:
+
+```bash
+set -a; source internal/.env.prod-local; set +a
+export TF_VAR_oidc_issuer="$FLOWPLANE_OIDC_ISSUER"
+export TF_VAR_oidc_audience="$FLOWPLANE_OIDC_AUDIENCE"
+```
+
+If you change `aws_region`, also change `availability_zones` to AZ names in that region. The module
+keeps AZs explicit so planning does not require `ec2:DescribeAvailabilityZones`.
+
+## Commands
+
+```bash
+tofu -chdir=deploy/aws init
+tofu -chdir=deploy/aws validate
+tofu -chdir=deploy/aws plan
+tofu -chdir=deploy/aws apply
+```
+
+## DNS
+
+Create these records in Cloudflare:
+
+```text
+cp.getflowplane.io  -> api_alb_dns_name
+xds.getflowplane.io  -> xds_nlb_dns_name
+```
+
+Keep the xDS record DNS-only. Do not proxy xDS through Cloudflare for this test; it is raw TCP with
+mTLS terminated by Flowplane.
+
+## Bootstrap Token
+
+On first boot, the control plane logs a single-use bootstrap token. Retrieve it from CloudWatch:
+
+```bash
+aws logs filter-log-events \
+  --log-group-name "$(tofu -chdir=deploy/aws output -raw cloudwatch_log_group)" \
+  --filter-pattern "bootstrap_token"
+```
+
+Use the token to initialize the platform admin with the verified OIDC subject.
+
+## Local Dataplane Smoke Test
+
+After bootstrapping and logging in:
+
+```bash
+export FLOWPLANE_SERVER=https://cp.getflowplane.io
+flowplane auth login --device-code \
+  --issuer "$FLOWPLANE_OIDC_ISSUER" \
+  --client-id "$FLOWPLANE_OIDC_CLIENT_ID" \
+  --scope "openid email profile"
+
+flowplane dataplane create edge-local --team <team>
+flowplane --out .local/aws-dp-cert.json cert issue edge-local --team <team>
+
+jq -r '.certificate_pem' .local/aws-dp-cert.json > .local/aws-dp.crt
+jq -r '.private_key_pem' .local/aws-dp-cert.json > .local/aws-dp.key
+jq -r '.ca_certificate_pem' .local/aws-dp-cert.json > .local/aws-dp-ca.crt
+chmod 600 .local/aws-dp.key
+
+flowplane --out .local/aws-envoy.yaml dataplane bootstrap edge-local \
+  --team <team> \
+  --mode mtls \
+  --xds-host xds.getflowplane.io \
+  --xds-port 18000 \
+  --cert-path "$PWD/.local/aws-dp.crt" \
+  --key-path "$PWD/.local/aws-dp.key" \
+  --ca-path "$PWD/.local/aws-dp-ca.crt"
+```
+
+Then run Envoy locally with the generated bootstrap and apply a simple route to verify xDS delivery.

--- a/deploy/aws/alb.tf
+++ b/deploy/aws/alb.tf
@@ -1,0 +1,40 @@
+resource "aws_lb" "api" {
+  name               = "${local.name}-api"
+  load_balancer_type = "application"
+  internal           = false
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = values(aws_subnet.public)[*].id
+}
+
+resource "aws_lb_target_group" "api" {
+  name        = "${local.name}-api"
+  port        = 8080
+  protocol    = "HTTPS"
+  target_type = "ip"
+  vpc_id      = aws_vpc.this.id
+
+  health_check {
+    enabled             = true
+    path                = "/healthz"
+    protocol            = "HTTPS"
+    matcher             = "200"
+    interval            = 30
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+}
+
+resource "aws_lb_listener" "api_https" {
+  load_balancer_arn = aws_lb.api.arn
+  port              = 443
+  protocol          = "HTTPS"
+  certificate_arn   = var.api_certificate_arn
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api.arn
+  }
+}
+

--- a/deploy/aws/ecs.tf
+++ b/deploy/aws/ecs.tf
@@ -1,0 +1,188 @@
+resource "aws_cloudwatch_log_group" "control_plane" {
+  name              = "/flowplane/${var.environment}/control-plane"
+  retention_in_days = var.log_retention_days
+}
+
+resource "aws_ecs_cluster" "this" {
+  name = local.name
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}
+
+data "aws_iam_policy_document" "ecs_task_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_execution" {
+  name               = "${local.name}-task-execution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+data "aws_iam_policy_document" "task_execution_secrets" {
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+
+    resources = [
+      var.secret_encryption_key_secret_arn,
+      var.api_tls_cert_secret_arn,
+      var.api_tls_key_secret_arn,
+      var.xds_tls_cert_secret_arn,
+      var.xds_tls_key_secret_arn,
+      var.xds_tls_client_ca_secret_arn,
+      var.cert_issuer_ca_cert_secret_arn,
+      var.cert_issuer_ca_key_secret_arn,
+      aws_secretsmanager_secret.db_password.arn,
+    ]
+  }
+
+  dynamic "statement" {
+    for_each = length(var.secret_kms_key_arns) == 0 ? [] : [1]
+
+    content {
+      actions   = ["kms:Decrypt"]
+      resources = var.secret_kms_key_arns
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "task_execution_secrets" {
+  name   = "${local.name}-task-execution-secrets"
+  role   = aws_iam_role.task_execution.id
+  policy = data.aws_iam_policy_document.task_execution_secrets.json
+}
+
+resource "aws_iam_role" "task" {
+  name               = "${local.name}-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+}
+
+resource "aws_ecs_task_definition" "control_plane" {
+  family                   = "${local.name}-control-plane"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  # ponytail: ARM64/Graviton — the release image is built arm64 natively (x86 cross-build segfaults
+  # under QEMU on Apple Silicon). Switch to X86_64 if you build the image on an x86 host instead.
+  runtime_platform {
+    cpu_architecture        = "ARM64"
+    operating_system_family = "LINUX"
+  }
+
+  container_definitions = jsonencode([
+    {
+      name      = "control-plane"
+      image     = var.control_plane_image
+      essential = true
+
+      entryPoint = ["/bin/sh", "-ec"]
+      command    = [local.container_command]
+
+      portMappings = [
+        {
+          name          = "api"
+          containerPort = 8080
+          hostPort      = 8080
+          protocol      = "tcp"
+        },
+        {
+          name          = "xds"
+          containerPort = 18000
+          hostPort      = 18000
+          protocol      = "tcp"
+        },
+      ]
+
+      environment = concat(
+        [
+          { name = "FLOWPLANE_API_ADDR", value = "0.0.0.0:8080" },
+          { name = "FLOWPLANE_XDS_ADDR", value = "0.0.0.0:18000" },
+          { name = "FLOWPLANE_LOG_FORMAT", value = "json" },
+          { name = "FLOWPLANE_LOG", value = "info" },
+          { name = "FLOWPLANE_OIDC_ISSUER", value = var.oidc_issuer },
+          { name = "FLOWPLANE_OIDC_AUDIENCE", value = var.oidc_audience },
+          { name = "FLOWPLANE_CERT_ISSUER_TRUST_DOMAIN", value = var.cert_issuer_trust_domain },
+          { name = "FLOWPLANE_DB_HOST", value = aws_db_instance.this.address },
+        ],
+        var.oidc_jwks_uri == "" ? [] : [{ name = "FLOWPLANE_OIDC_JWKS_URI", value = var.oidc_jwks_uri }],
+      )
+
+      secrets = [
+        { name = "FLOWPLANE_SECRET_ENCRYPTION_KEY", valueFrom = var.secret_encryption_key_secret_arn },
+        { name = "FLOWPLANE_API_TLS_CERT_PEM", valueFrom = var.api_tls_cert_secret_arn },
+        { name = "FLOWPLANE_API_TLS_KEY_PEM", valueFrom = var.api_tls_key_secret_arn },
+        { name = "FLOWPLANE_XDS_TLS_CERT_PEM", valueFrom = var.xds_tls_cert_secret_arn },
+        { name = "FLOWPLANE_XDS_TLS_KEY_PEM", valueFrom = var.xds_tls_key_secret_arn },
+        { name = "FLOWPLANE_XDS_TLS_CLIENT_CA_PEM", valueFrom = var.xds_tls_client_ca_secret_arn },
+        { name = "FLOWPLANE_CERT_ISSUER_CA_CERT_PEM", valueFrom = var.cert_issuer_ca_cert_secret_arn },
+        { name = "FLOWPLANE_CERT_ISSUER_CA_KEY_PEM", valueFrom = var.cert_issuer_ca_key_secret_arn },
+        { name = "FLOWPLANE_DB_PASSWORD", valueFrom = aws_secretsmanager_secret.db_password.arn },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.control_plane.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "cp"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "control_plane" {
+  name            = "${local.name}-control-plane"
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.control_plane.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = values(aws_subnet.private)[*].id
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.api.arn
+    container_name   = "control-plane"
+    container_port   = 8080
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.xds.arn
+    container_name   = "control-plane"
+    container_port   = 18000
+  }
+
+  depends_on = [
+    aws_lb_listener.api_https,
+    aws_lb_listener.xds_tcp,
+    aws_vpc_endpoint.ecr_api,
+    aws_vpc_endpoint.ecr_dkr,
+    aws_vpc_endpoint.logs,
+    aws_vpc_endpoint.secretsmanager,
+    aws_vpc_endpoint.s3,
+  ]
+}

--- a/deploy/aws/local.auto.tfvars.example
+++ b/deploy/aws/local.auto.tfvars.example
@@ -1,0 +1,26 @@
+# Copy to local.auto.tfvars and fill with real values. local.auto.tfvars is ignored.
+
+aws_region = "us-east-1"
+availability_zones = ["us-east-1a", "us-east-1b"]
+
+control_plane_image = "<account>.dkr.ecr.us-east-1.amazonaws.com/flowplane:<tag>"
+
+api_certificate_arn = "arn:aws:acm:us-east-1:<account>:certificate/<id>"
+
+oidc_issuer   = "https://<tenant>.us.auth0.com/"
+oidc_audience = "<auth0-native-app-client-id>"
+
+api_ingress_cidrs = ["0.0.0.0/0"]
+xds_ingress_cidrs = ["<your-public-ip>/32"]
+
+secret_encryption_key_secret_arn = "arn:aws:secretsmanager:us-east-1:<account>:secret:flowplane/secret-encryption-key-..."
+api_tls_cert_secret_arn          = "arn:aws:secretsmanager:us-east-1:<account>:secret:flowplane/api-tls-cert-..."
+api_tls_key_secret_arn           = "arn:aws:secretsmanager:us-east-1:<account>:secret:flowplane/api-tls-key-..."
+xds_tls_cert_secret_arn          = "arn:aws:secretsmanager:us-east-1:<account>:secret:flowplane/xds-tls-cert-..."
+xds_tls_key_secret_arn           = "arn:aws:secretsmanager:us-east-1:<account>:secret:flowplane/xds-tls-key-..."
+xds_tls_client_ca_secret_arn     = "arn:aws:secretsmanager:us-east-1:<account>:secret:flowplane/dp-client-ca-..."
+cert_issuer_ca_cert_secret_arn   = "arn:aws:secretsmanager:us-east-1:<account>:secret:flowplane/cert-issuer-ca-cert-..."
+cert_issuer_ca_key_secret_arn    = "arn:aws:secretsmanager:us-east-1:<account>:secret:flowplane/cert-issuer-ca-key-..."
+
+# Only needed when those secrets use a customer-managed KMS key.
+secret_kms_key_arns = []

--- a/deploy/aws/locals.tf
+++ b/deploy/aws/locals.tf
@@ -1,0 +1,39 @@
+locals {
+  name = var.name
+  azs  = var.availability_zones
+
+  nat_gateway_azs = var.enable_nat_gateway ? (var.single_nat_gateway ? [local.azs[0]] : local.azs) : []
+
+  tags = merge(
+    {
+      Project     = "flowplane"
+      Environment = var.environment
+      ManagedBy   = "opentofu"
+    },
+    var.tags,
+  )
+
+  container_tls_dir = "/tmp/flowplane/tls"
+
+  container_command = <<-EOT
+    set -eu
+    mkdir -p ${local.container_tls_dir}
+    umask 077
+    printf '%s' "$FLOWPLANE_API_TLS_CERT_PEM" > ${local.container_tls_dir}/api.crt
+    printf '%s' "$FLOWPLANE_API_TLS_KEY_PEM" > ${local.container_tls_dir}/api.key
+    printf '%s' "$FLOWPLANE_XDS_TLS_CERT_PEM" > ${local.container_tls_dir}/xds.crt
+    printf '%s' "$FLOWPLANE_XDS_TLS_KEY_PEM" > ${local.container_tls_dir}/xds.key
+    printf '%s' "$FLOWPLANE_XDS_TLS_CLIENT_CA_PEM" > ${local.container_tls_dir}/dp-ca.crt
+    printf '%s' "$FLOWPLANE_CERT_ISSUER_CA_CERT_PEM" > ${local.container_tls_dir}/issuer-ca.crt
+    printf '%s' "$FLOWPLANE_CERT_ISSUER_CA_KEY_PEM" > ${local.container_tls_dir}/issuer-ca.key
+    export FLOWPLANE_API_TLS_CERT=${local.container_tls_dir}/api.crt
+    export FLOWPLANE_API_TLS_KEY=${local.container_tls_dir}/api.key
+    export FLOWPLANE_XDS_TLS_CERT=${local.container_tls_dir}/xds.crt
+    export FLOWPLANE_XDS_TLS_KEY=${local.container_tls_dir}/xds.key
+    export FLOWPLANE_XDS_TLS_CLIENT_CA=${local.container_tls_dir}/dp-ca.crt
+    export FLOWPLANE_CERT_ISSUER_CA_CERT_PATH=${local.container_tls_dir}/issuer-ca.crt
+    export FLOWPLANE_CERT_ISSUER_CA_KEY_PATH=${local.container_tls_dir}/issuer-ca.key
+    export FLOWPLANE_DATABASE_URL="postgres://${var.db_username}:$FLOWPLANE_DB_PASSWORD@$FLOWPLANE_DB_HOST:5432/${var.db_name}?sslmode=${var.database_sslmode}"
+    exec /usr/local/bin/flowplane serve
+  EOT
+}

--- a/deploy/aws/main.tf
+++ b/deploy/aws/main.tf
@@ -1,0 +1,3 @@
+# Resource groups are split by concern: networking, secrets, RDS, ECS, ALB, and NLB.
+# This file intentionally remains the module entrypoint without owning resources.
+

--- a/deploy/aws/networking.tf
+++ b/deploy/aws/networking.tf
@@ -1,0 +1,153 @@
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+}
+
+resource "aws_subnet" "public" {
+  for_each = { for idx, az in local.azs : az => idx }
+
+  vpc_id                  = aws_vpc.this.id
+  availability_zone       = each.key
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, each.value)
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${local.name}-public-${each.key}"
+  }
+}
+
+resource "aws_subnet" "private" {
+  for_each = { for idx, az in local.azs : az => idx }
+
+  vpc_id            = aws_vpc.this.id
+  availability_zone = each.key
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, each.value + 100)
+
+  tags = {
+    Name = "${local.name}-private-${each.key}"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+}
+
+resource "aws_route" "public_internet" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table_association" "public" {
+  for_each = aws_subnet.public
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  for_each = aws_subnet.private
+
+  vpc_id = aws_vpc.this.id
+}
+
+resource "aws_route_table_association" "private" {
+  for_each = aws_subnet.private
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.private[each.key].id
+}
+
+resource "aws_eip" "nat" {
+  for_each = toset(local.nat_gateway_azs)
+
+  domain = "vpc"
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+resource "aws_nat_gateway" "this" {
+  for_each = toset(local.nat_gateway_azs)
+
+  allocation_id = aws_eip.nat[each.key].id
+  subnet_id     = aws_subnet.public[each.key].id
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+resource "aws_route" "private_nat" {
+  for_each = var.enable_nat_gateway ? aws_route_table.private : {}
+
+  route_table_id         = each.value.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = var.single_nat_gateway ? aws_nat_gateway.this[local.azs[0]].id : aws_nat_gateway.this[each.key].id
+}
+
+resource "aws_security_group" "vpc_endpoints" {
+  name        = "${local.name}-vpce"
+  description = "VPC endpoint ingress from ECS tasks"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description     = "HTTPS from ECS tasks"
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs_tasks.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_vpc_endpoint" "ecr_api" {
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.${var.aws_region}.ecr.api"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = values(aws_subnet.private)[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  private_dns_enabled = true
+}
+
+resource "aws_vpc_endpoint" "ecr_dkr" {
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.${var.aws_region}.ecr.dkr"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = values(aws_subnet.private)[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  private_dns_enabled = true
+}
+
+resource "aws_vpc_endpoint" "logs" {
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.${var.aws_region}.logs"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = values(aws_subnet.private)[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  private_dns_enabled = true
+}
+
+resource "aws_vpc_endpoint" "secretsmanager" {
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.${var.aws_region}.secretsmanager"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = values(aws_subnet.private)[*].id
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  private_dns_enabled = true
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.this.id
+  service_name      = "com.amazonaws.${var.aws_region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = values(aws_route_table.private)[*].id
+}

--- a/deploy/aws/nlb.tf
+++ b/deploy/aws/nlb.tf
@@ -12,6 +12,10 @@ resource "aws_lb_target_group" "xds" {
   target_type = "ip"
   vpc_id      = aws_vpc.this.id
 
+  # Preserve the real client source IP so the operator-CIDR allowlist on the task SG is
+  # meaningful (off by default for IP targets — without this the task sees the NLB node IP).
+  preserve_client_ip = true
+
   health_check {
     enabled             = true
     protocol            = "TCP"

--- a/deploy/aws/nlb.tf
+++ b/deploy/aws/nlb.tf
@@ -1,0 +1,34 @@
+resource "aws_lb" "xds" {
+  name               = "${local.name}-xds"
+  load_balancer_type = "network"
+  internal           = false
+  subnets            = values(aws_subnet.public)[*].id
+}
+
+resource "aws_lb_target_group" "xds" {
+  name        = "${local.name}-xds"
+  port        = 18000
+  protocol    = "TCP"
+  target_type = "ip"
+  vpc_id      = aws_vpc.this.id
+
+  health_check {
+    enabled             = true
+    protocol            = "TCP"
+    interval            = 30
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+}
+
+resource "aws_lb_listener" "xds_tcp" {
+  load_balancer_arn = aws_lb.xds.arn
+  port              = 18000
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.xds.arn
+  }
+}
+

--- a/deploy/aws/outputs.tf
+++ b/deploy/aws/outputs.tf
@@ -1,0 +1,40 @@
+output "api_alb_dns_name" {
+  description = "DNS name for the public API ALB. Point the API hostname at this value."
+  value       = aws_lb.api.dns_name
+}
+
+output "api_alb_zone_id" {
+  description = "Hosted zone ID for the public API ALB."
+  value       = aws_lb.api.zone_id
+}
+
+output "xds_nlb_dns_name" {
+  description = "DNS name for the public xDS NLB. Point the xDS hostname at this value with DNS-only routing."
+  value       = aws_lb.xds.dns_name
+}
+
+output "xds_nlb_zone_id" {
+  description = "Hosted zone ID for the public xDS NLB."
+  value       = aws_lb.xds.zone_id
+}
+
+output "ecs_cluster_name" {
+  description = "ECS cluster name."
+  value       = aws_ecs_cluster.this.name
+}
+
+output "ecs_service_name" {
+  description = "ECS service name."
+  value       = aws_ecs_service.control_plane.name
+}
+
+output "cloudwatch_log_group" {
+  description = "CloudWatch log group containing control-plane logs and bootstrap token lines."
+  value       = aws_cloudwatch_log_group.control_plane.name
+}
+
+output "rds_endpoint" {
+  description = "RDS endpoint hostname."
+  value       = aws_db_instance.this.address
+}
+

--- a/deploy/aws/providers.tf
+++ b/deploy/aws/providers.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.tags
+  }
+}
+

--- a/deploy/aws/rds.tf
+++ b/deploy/aws/rds.tf
@@ -1,0 +1,31 @@
+resource "aws_db_subnet_group" "this" {
+  name       = "${local.name}-db"
+  subnet_ids = values(aws_subnet.private)[*].id
+}
+
+resource "aws_db_instance" "this" {
+  identifier = "${local.name}-${var.environment}"
+
+  engine         = "postgres"
+  engine_version = "16"
+  instance_class = var.db_instance_class
+
+  allocated_storage     = var.db_allocated_storage
+  max_allocated_storage = max(var.db_allocated_storage, 100)
+  storage_encrypted     = true
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = random_password.db.result
+
+  db_subnet_group_name   = aws_db_subnet_group.this.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  publicly_accessible    = false
+
+  backup_retention_period   = 7
+  deletion_protection       = var.deletion_protection
+  skip_final_snapshot       = !var.deletion_protection
+  final_snapshot_identifier = var.deletion_protection ? "${local.name}-${var.environment}-final" : null
+
+  apply_immediately = true
+}

--- a/deploy/aws/secrets.tf
+++ b/deploy/aws/secrets.tf
@@ -1,0 +1,15 @@
+resource "random_password" "db" {
+  length  = 32
+  special = false
+}
+
+resource "aws_secretsmanager_secret" "db_password" {
+  name                    = "${local.name}/${var.environment}/db-password"
+  recovery_window_in_days = 0
+}
+
+resource "aws_secretsmanager_secret_version" "db_password" {
+  secret_id     = aws_secretsmanager_secret.db_password.id
+  secret_string = random_password.db.result
+}
+

--- a/deploy/aws/security-groups.tf
+++ b/deploy/aws/security-groups.tf
@@ -56,6 +56,18 @@ resource "aws_vpc_security_group_egress_rule" "ecs_all" {
   cidr_ipv4         = "0.0.0.0/0"
 }
 
+# NLB health checks for the xDS target originate from the NLB nodes inside the VPC, not from
+# the operator CIDRs. Without this rule the TCP health check is dropped and the target is marked
+# unhealthy, so the NLB has no target to forward to (xDS connections time out).
+resource "aws_vpc_security_group_ingress_rule" "ecs_xds_healthcheck" {
+  security_group_id = aws_security_group.ecs_tasks.id
+  description       = "xDS NLB health checks from within the VPC"
+  from_port         = 18000
+  to_port           = 18000
+  ip_protocol       = "tcp"
+  cidr_ipv4         = var.vpc_cidr
+}
+
 resource "aws_security_group" "rds" {
   name        = "${local.name}-rds"
   description = "Flowplane RDS PostgreSQL"

--- a/deploy/aws/security-groups.tf
+++ b/deploy/aws/security-groups.tf
@@ -1,0 +1,78 @@
+resource "aws_security_group" "alb" {
+  name        = "${local.name}-api-alb"
+  description = "Public API ALB"
+  vpc_id      = aws_vpc.this.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "alb_https" {
+  for_each = toset(var.api_ingress_cidrs)
+
+  security_group_id = aws_security_group.alb.id
+  description       = "HTTPS API"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  cidr_ipv4         = each.value
+}
+
+resource "aws_security_group" "ecs_tasks" {
+  name        = "${local.name}-ecs-tasks"
+  description = "Flowplane control-plane ECS tasks"
+  vpc_id      = aws_vpc.this.id
+}
+
+resource "aws_vpc_security_group_egress_rule" "alb_to_ecs_api" {
+  security_group_id            = aws_security_group.alb.id
+  description                  = "HTTPS to ECS API target"
+  from_port                    = 8080
+  to_port                      = 8080
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.ecs_tasks.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ecs_api_from_alb" {
+  security_group_id            = aws_security_group.ecs_tasks.id
+  description                  = "HTTPS API from ALB"
+  from_port                    = 8080
+  to_port                      = 8080
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.alb.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ecs_xds" {
+  for_each = toset(var.xds_ingress_cidrs)
+
+  security_group_id = aws_security_group.ecs_tasks.id
+  description       = "xDS mTLS from approved dataplane/operator CIDRs through NLB"
+  from_port         = 18000
+  to_port           = 18000
+  ip_protocol       = "tcp"
+  cidr_ipv4         = each.value
+}
+
+resource "aws_vpc_security_group_egress_rule" "ecs_all" {
+  security_group_id = aws_security_group.ecs_tasks.id
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}
+
+resource "aws_security_group" "rds" {
+  name        = "${local.name}-rds"
+  description = "Flowplane RDS PostgreSQL"
+  vpc_id      = aws_vpc.this.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "rds_from_ecs" {
+  security_group_id            = aws_security_group.rds.id
+  description                  = "PostgreSQL from ECS tasks"
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.ecs_tasks.id
+}
+
+resource "aws_vpc_security_group_egress_rule" "rds_all" {
+  security_group_id = aws_security_group.rds.id
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+}

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -1,0 +1,201 @@
+variable "aws_region" {
+  description = "AWS region for the deployment. us-east-1 is the low-cost default for validation."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "name" {
+  description = "Name prefix for AWS resources."
+  type        = string
+  default     = "flowplane"
+}
+
+variable "environment" {
+  description = "Environment label used in tags and names."
+  type        = string
+  default     = "prod-smoke"
+}
+
+variable "tags" {
+  description = "Additional tags to apply to resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "vpc_cidr" {
+  description = "CIDR for the deployment VPC."
+  type        = string
+  default     = "10.42.0.0/16"
+}
+
+variable "availability_zones" {
+  description = "Availability zones to use. Keep these in aws_region; two is the minimum for ALB/RDS subnet groups."
+  type        = list(string)
+  default     = ["us-east-1a", "us-east-1b"]
+
+  validation {
+    condition     = length(var.availability_zones) >= 2
+    error_message = "availability_zones must contain at least two AZ names."
+  }
+}
+
+variable "enable_nat_gateway" {
+  description = "Create NAT egress for private ECS tasks. Required for external OIDC/JWKS providers such as Auth0 unless another egress path exists."
+  type        = bool
+  default     = true
+}
+
+variable "single_nat_gateway" {
+  description = "Use one NAT gateway for the smoke environment. Set false for one NAT gateway per AZ."
+  type        = bool
+  default     = true
+}
+
+variable "api_ingress_cidrs" {
+  description = "CIDRs allowed to reach the public API HTTPS listener."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "xds_ingress_cidrs" {
+  description = "CIDRs allowed to reach the public xDS TCP listener. Prefer your operator/dataplane public IP."
+  type        = list(string)
+}
+
+variable "control_plane_image" {
+  description = "Container image URI for the Flowplane release image. Prefer ECR in the same region."
+  type        = string
+}
+
+variable "cpu" {
+  description = "Fargate task CPU units."
+  type        = number
+  default     = 512
+}
+
+variable "memory" {
+  description = "Fargate task memory in MiB."
+  type        = number
+  default     = 1024
+}
+
+variable "desired_count" {
+  description = "ECS service desired task count."
+  type        = number
+  default     = 1
+}
+
+variable "api_certificate_arn" {
+  description = "ACM certificate ARN for the public API ALB listener."
+  type        = string
+}
+
+variable "oidc_issuer" {
+  description = "OIDC issuer URL. Auth0 is the verified provider, but this remains provider-agnostic."
+  type        = string
+}
+
+variable "oidc_audience" {
+  description = "OIDC audience expected by the Flowplane control plane."
+  type        = string
+}
+
+variable "oidc_jwks_uri" {
+  description = "Optional explicit OIDC JWKS URI."
+  type        = string
+  default     = ""
+}
+
+variable "db_name" {
+  description = "RDS database name."
+  type        = string
+  default     = "flowplane"
+}
+
+variable "db_username" {
+  description = "RDS master username."
+  type        = string
+  default     = "flowplane"
+}
+
+variable "db_instance_class" {
+  description = "RDS instance class."
+  type        = string
+  default     = "db.t4g.micro"
+}
+
+variable "db_allocated_storage" {
+  description = "RDS allocated storage in GiB."
+  type        = number
+  default     = 20
+}
+
+variable "database_sslmode" {
+  description = "sslmode query parameter for FLOWPLANE_DATABASE_URL."
+  type        = string
+  default     = "require"
+}
+
+variable "deletion_protection" {
+  description = "Enable deletion protection on stateful resources."
+  type        = bool
+  default     = false
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention for the control plane."
+  type        = number
+  default     = 14
+}
+
+variable "secret_encryption_key_secret_arn" {
+  description = "Secrets Manager ARN containing the Flowplane secret encryption key as SecretString."
+  type        = string
+}
+
+variable "secret_kms_key_arns" {
+  description = "Optional customer-managed KMS key ARNs used by the Secrets Manager secrets."
+  type        = list(string)
+  default     = []
+}
+
+variable "api_tls_cert_secret_arn" {
+  description = "Secrets Manager ARN containing the CP API backend TLS certificate PEM as SecretString."
+  type        = string
+}
+
+variable "api_tls_key_secret_arn" {
+  description = "Secrets Manager ARN containing the CP API backend TLS private key PEM as SecretString."
+  type        = string
+}
+
+variable "xds_tls_cert_secret_arn" {
+  description = "Secrets Manager ARN containing the xDS server certificate PEM as SecretString."
+  type        = string
+}
+
+variable "xds_tls_key_secret_arn" {
+  description = "Secrets Manager ARN containing the xDS server private key PEM as SecretString."
+  type        = string
+}
+
+variable "xds_tls_client_ca_secret_arn" {
+  description = "Secrets Manager ARN containing the dataplane client CA certificate PEM as SecretString."
+  type        = string
+}
+
+variable "cert_issuer_ca_cert_secret_arn" {
+  description = "Secrets Manager ARN containing the dataplane certificate issuer CA certificate PEM as SecretString."
+  type        = string
+}
+
+variable "cert_issuer_ca_key_secret_arn" {
+  description = "Secrets Manager ARN containing the dataplane certificate issuer CA private key PEM as SecretString."
+  type        = string
+}
+
+variable "cert_issuer_trust_domain" {
+  description = "SPIFFE trust domain used for issued dataplane certificates."
+  type        = string
+  default     = "getflowplane.io"
+}

--- a/deploy/aws/versions.tf
+++ b/deploy/aws/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}

--- a/docs/aws-secure-deployment.md
+++ b/docs/aws-secure-deployment.md
@@ -1,0 +1,164 @@
+# AWS Secure Deployment Runbook
+
+This runbook is the concrete AWS packaging for the provider-agnostic deployment invariants in
+`spec/14-architecture-integrity.md`.
+
+The target is a strict secure smoke environment:
+
+- API: client HTTPS -> AWS ALB HTTPS -> Flowplane CP HTTPS on port 8080.
+- xDS: dataplane mTLS -> AWS NLB TCP passthrough -> Flowplane CP xDS mTLS on port 18000.
+- ECS/Fargate tasks and RDS are private.
+- ECS tasks use NAT egress for external OIDC/JWKS access.
+- No `FLOWPLANE_API_INSECURE=true`.
+
+## Inputs
+
+Use `deploy/aws/local.auto.tfvars` for local operator values. This file is ignored.
+
+Required high-level values:
+
+- `aws_region` and matching `availability_zones`.
+- `control_plane_image`: Flowplane release image in ECR.
+- `api_certificate_arn`: ACM certificate for the public API hostname.
+- `oidc_issuer` and `oidc_audience`.
+- `xds_ingress_cidrs`: your local dataplane/operator public IP CIDR, for example `["1.2.3.4/32"]`.
+- Secrets Manager ARNs for Flowplane KEK and PEM material.
+
+OIDC values can come from the verified local prod env:
+
+```bash
+set -a; source internal/.env.prod-local; set +a
+export TF_VAR_oidc_issuer="$FLOWPLANE_OIDC_ISSUER"
+export TF_VAR_oidc_audience="$FLOWPLANE_OIDC_AUDIENCE"
+```
+
+The default region is `us-east-1` with `availability_zones = ["us-east-1a", "us-east-1b"]`. If you
+change regions, set AZs from the same region explicitly; this keeps planning usable with narrower
+IAM policies that do not allow availability-zone discovery.
+
+## Secret Setup
+
+Create Secrets Manager secrets for:
+
+- `FLOWPLANE_SECRET_ENCRYPTION_KEY`
+- API backend TLS certificate PEM
+- API backend TLS private key PEM
+- xDS server certificate PEM
+- xDS server private key PEM
+- dataplane client CA certificate PEM
+- dataplane certificate issuer CA certificate PEM
+- dataplane certificate issuer CA private key PEM
+
+The OpenTofu module passes secret ARNs into ECS. The container writes PEM values to files under
+`/tmp/flowplane/tls` before running `flowplane serve`.
+
+The module generates the RDS password and stores it in Secrets Manager. Protect the OpenTofu state
+backend because generated secret material is present in state.
+
+## Network Egress
+
+Auth0/OIDC discovery and JWKS fetches require outbound HTTPS from the private ECS task. The module
+creates NAT egress by default. For the smoke environment it defaults to one NAT gateway to control
+cost; set `single_nat_gateway = false` if you want per-AZ NAT gateways.
+
+## OpenTofu
+
+```bash
+tofu -chdir=deploy/aws init
+tofu -chdir=deploy/aws validate
+tofu -chdir=deploy/aws plan
+tofu -chdir=deploy/aws apply
+```
+
+## Cloudflare DNS
+
+Create records in `getflowplane.io` from module outputs:
+
+```text
+cp.getflowplane.io  -> api_alb_dns_name
+xds.getflowplane.io  -> xds_nlb_dns_name
+```
+
+Keep `xds.getflowplane.io` DNS-only. Do not proxy xDS through Cloudflare for this smoke path;
+Flowplane must terminate the dataplane mTLS connection itself.
+
+## Bootstrap
+
+The first CP task logs a single-use bootstrap token. It expires after 24 hours.
+
+```bash
+aws logs filter-log-events \
+  --log-group-name "$(tofu -chdir=deploy/aws output -raw cloudwatch_log_group)" \
+  --filter-pattern "bootstrap_token"
+```
+
+Use it with your verified Auth0/OIDC subject:
+
+```bash
+curl -fsS -X POST https://cp.getflowplane.io/api/v1/bootstrap/initialize \
+  -H "Authorization: Bearer fpboot_xxxxxxxx" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "org_name": "platform",
+        "org_display_name": "Platform",
+        "admin_subject": "auth0|...",
+        "admin_email": "you@example.com"
+      }'
+```
+
+## CLI Login
+
+Auth0 must have Device Code grant enabled.
+
+```bash
+export FLOWPLANE_SERVER=https://cp.getflowplane.io
+
+flowplane auth login --device-code \
+  --issuer "$FLOWPLANE_OIDC_ISSUER" \
+  --client-id "$FLOWPLANE_OIDC_CLIENT_ID" \
+  --scope "openid email profile"
+
+flowplane auth whoami
+```
+
+## Local Dataplane Smoke
+
+Create the dataplane and issue a one-time cert response:
+
+```bash
+flowplane dataplane create edge-local --team <team>
+flowplane --out .local/aws-dp-cert.json cert issue edge-local --team <team>
+```
+
+Write the PEM values to files:
+
+```bash
+jq -r '.certificate_pem' .local/aws-dp-cert.json > .local/aws-dp.crt
+jq -r '.private_key_pem' .local/aws-dp-cert.json > .local/aws-dp.key
+jq -r '.ca_certificate_pem' .local/aws-dp-cert.json > .local/aws-dp-ca.crt
+chmod 600 .local/aws-dp.key
+```
+
+Generate the local Envoy bootstrap:
+
+```bash
+flowplane --out .local/aws-envoy.yaml dataplane bootstrap edge-local \
+  --team <team> \
+  --mode mtls \
+  --xds-host xds.getflowplane.io \
+  --xds-port 18000 \
+  --cert-path "$PWD/.local/aws-dp.crt" \
+  --key-path "$PWD/.local/aws-dp.key" \
+  --ca-path "$PWD/.local/aws-dp-ca.crt"
+```
+
+Run Envoy locally with `.local/aws-envoy.yaml`, then apply a simple route/listener and confirm the
+dataplane receives xDS without NACKs.
+
+## Teardown
+
+```bash
+tofu -chdir=deploy/aws destroy
+```
+
+If `deletion_protection=true`, disable it before destroy or keep the RDS instance intentionally.

--- a/internal/prod-local-runbook.md
+++ b/internal/prod-local-runbook.md
@@ -108,9 +108,9 @@ auth0|6650f0...
 You now have:
 
 ```text
-Issuer:        https://dev-63kqv3bdirrh63bi.us.auth0.com/
-Client ID:     ehqZXjlVcosrCQcy0F3OySrXzfwlQwUQ
-Admin subject: auth0|6a34ba3d79da66ea439fc75d
+Issuer:        https://<tenant>.us.auth0.com/
+Client ID:     <auth0-native-app-client-id>
+Admin subject: auth0|<admin-user-id>
 ```
 
 Auth0-specific gotchas:

--- a/internal/user-onboarding.md
+++ b/internal/user-onboarding.md
@@ -1,0 +1,107 @@
+# User Onboarding (internal)
+
+How a human user goes from "exists in the IdP" to "can operate Flowplane resources".
+Derived from the auth code paths (`crates/fp-api/src/auth.rs`, `crates/fp-core/src/services/orgs.rs`,
+`crates/fp-domain/src/identity.rs`) and the CLI (`crates/flowplane/src/cli`).
+
+## Identity model (read this first)
+
+- **Identity = OIDC `sub`.** Flowplane trusts any compliant IdP (Q-004); we run Auth0. A user is
+  keyed by their `sub` (e.g. `auth0|6a34…`), not their email.
+- **The Flowplane user row is created lazily (JIT).** `flowplane auth login` only talks to the IdP —
+  it does **not** create anything in Flowplane. The row is created on the user's **first
+  authenticated request to the control plane** (`auth.rs` → `upsert_user_by_subject`). In practice:
+  one `flowplane auth whoami` after login.
+- **Authorization is org/team scoped (D-014).** Being a platform admin lets you run platform
+  operations (create orgs/teams, add members) but does **not** grant context to read or write
+  org/team-scoped resources. For those you must hold an actual membership.
+
+## Roles
+
+**Org roles** (`OrgRole`, hierarchical — each includes the powers below it):
+
+| role     | notes |
+|----------|-------|
+| `viewer` | read-only |
+| `member` | standard |
+| `admin`  | org admin — **implicit access to every team in the org** (spec/05 §3.1) |
+| `owner`  | org admin + ownership |
+
+**Teams** have flat membership (no per-member role at the CLI). Capabilities beyond membership are
+assigned with `flowplane team grant …`. Org `admin`/`owner` already reach every team in their org.
+
+## Onboarding a new user — steps
+
+Assume the operator is the platform admin with a valid session
+(`flowplane auth whoami` shows `PLATFORM ADMIN true`), and `FLOWPLANE_SERVER` points at the CP.
+
+### 1. Create the user in Auth0 (with verified email)
+- Auth0 Dashboard → User Management → Users → Create User (Database connection), or via the
+  Management API.
+- The dashboard "Create User" form does **not** set `email_verified` → it defaults to `false`.
+  Verify it one of two ways:
+  - User → `…` → **Send Verification Email** (user clicks the link), or
+  - Management API: `PATCH /api/v2/users/{id}` body `{"email_verified": true}`
+    (URL-encode the `|` in the id as `%7C`).
+- Flowplane itself does **not** require `email_verified` (the validator checks `iss/aud/exp/sub`
+  only), but verify it anyway for hygiene and to avoid IdP-side prompts during login.
+
+### 2. User signs in once (creates the Flowplane row)
+The new user, on their own machine:
+```bash
+export FLOWPLANE_SERVER=https://<cp-host>
+flowplane auth login --device \
+  --issuer https://<tenant>.us.auth0.com/ \
+  --client-id <auth0-app-client-id>
+flowplane auth whoami     # <-- this authenticated call creates their user row
+```
+After this, `whoami` prints their `USER ID` and subject. (Concrete demo values live in the
+gitignored `internal/.env.prod-local`.)
+
+### 3. Platform admin adds the user to an org
+```bash
+flowplane org member add <org> --role <viewer|member|admin|owner> \
+  --subject "auth0|…"        # or --email <addr>, or --user-id <flowplane-uuid>
+```
+- Pick **one** identifier. `--subject` = OIDC sub, `--email` = email, `--user-id` = Flowplane
+  internal **UUID** (from `whoami`/`org member list`). Passing an `auth0|…` value to `--user-id`
+  fails with HTTP 422 (UUID parse error).
+- The target user row must already exist (step 2), else `not_found: must sign in once`.
+
+### 4. (If they need resource access) add to a team
+Resources (clusters, listeners, routes, …) are team-scoped.
+```bash
+flowplane team create <team> --display-name "…"      # if the team doesn't exist
+flowplane team member add --team <team> <email>      # flat membership, no role arg
+flowplane team grant …                               # optional extra capabilities
+```
+Org `admin`/`owner` members implicitly reach every team and can skip explicit team membership.
+
+### 5. User selects their context
+Org/team-scoped commands need a selector. Either pass flags per call or set a context:
+```bash
+flowplane cluster list --org <org> --team <team>
+# or persist it:
+flowplane config set-context <name> --server https://<cp-host> --org <org> --team <team>
+flowplane config use-context <name>
+```
+
+## Common errors → fixes
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `not_found: … must sign in once before being added` | target user has no row | user runs `auth login` **+** `whoami` (step 2) first |
+| HTTP 422 `UUID parsing failed … found 'u'` | `auth0|…` passed to `--user-id` | use `--subject` for the OIDC sub |
+| `org_selector_required` (even with `--org`) | caller is not a **member** of that org; platform-admin alone is not org context (D-014); the platform org doesn't count | add the caller to the org (`org member add`), then retry |
+| `team_selector_required` | resource is team-scoped, no team in context | pass `--team <team>` (or be org admin/owner) |
+| `whoami` shows the wrong identity / `PLATFORM ADMIN false` | `auth login` **clobbers** the stored token | use separate CLI contexts per identity (`config set-context` / `use-context`), or re-login as the needed identity |
+| `Could not resolve host` for the CP hostname | local resolver serving a stale/blocked record | `/etc/hosts` entry to the ALB/NLB IP, or `curl --resolve` (CLI uses the OS resolver) |
+
+## Quick reference: the moving parts
+
+- **Platform admin** is created once by bootstrap (`POST /api/v1/bootstrap/initialize`) bound to an
+  OIDC subject.
+- **One IdP user ⇒ one Flowplane user row**, created JIT on first authenticated CP call.
+- **Org membership** grants org context + (admin/owner) all teams.
+- **Team membership/grants** scope resource access.
+- **Selectors** (`--org`, `--team`, or a saved context) put the request in the right tenant.

--- a/scripts/aws-e2e-smoke.sh
+++ b/scripts/aws-e2e-smoke.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# AWS end-to-end smoke test, one step at a time.
+#
+#   scripts/aws-e2e-smoke.sh <step>
+#
+# Runs the full live flow against the AWS-hosted control plane and a LOCAL Envoy
+# dataplane, ending with a routed API call through Envoy. Each step is independent
+# and re-runnable; the flowplane CLI persists your login between steps.
+#
+# Run `scripts/aws-e2e-smoke.sh` with no arg to list steps.
+#
+# ponytail: a smoke runbook, not product code — hardcodes the demo account/zone and
+# single-CA trust on purpose. Generalize only if this becomes a real test harness.
+set -euo pipefail
+
+# ---- config (override via env) ---------------------------------------------
+FP="${FP:-./target/release/flowplane}"
+AWS_PROFILE="${AWS_PROFILE:-rajeev-flowplane-demo}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+
+export FLOWPLANE_SERVER="${FLOWPLANE_SERVER:-https://cp.getflowplane.io}"
+
+# Auth0 / OIDC + admin identity — provide via env; do NOT hardcode tenant identifiers here.
+# Export these before running (or source a gitignored local env file of your own):
+#   export FLOWPLANE_OIDC_ISSUER=https://<tenant>.us.auth0.com/
+#   export FLOWPLANE_OIDC_CLIENT_ID=<auth0-native-app-client-id>
+#   export ADMIN_EMAIL=<platform-admin email>
+#   export ADMIN_SUBJECT='<auth0|... admin OIDC subject>'
+export FLOWPLANE_OIDC_ISSUER="${FLOWPLANE_OIDC_ISSUER:-}"
+export FLOWPLANE_OIDC_CLIENT_ID="${FLOWPLANE_OIDC_CLIENT_ID:-}"
+export FLOWPLANE_OIDC_SCOPE="${FLOWPLANE_OIDC_SCOPE:-openid email profile}"
+ADMIN_SUBJECT="${ADMIN_SUBJECT:-}"
+ADMIN_EMAIL="${ADMIN_EMAIL:-}"
+
+# tenant context (created by this script)
+export FLOWPLANE_ORG="${FLOWPLANE_ORG:-acme}"
+export FLOWPLANE_TEAM="${FLOWPLANE_TEAM:-payments}"
+
+need_oidc() { # fail with guidance if required identifiers are not provided
+  [ -n "$FLOWPLANE_OIDC_ISSUER" ]    || die "set FLOWPLANE_OIDC_ISSUER (e.g. https://<tenant>.us.auth0.com/)"
+  [ -n "$FLOWPLANE_OIDC_CLIENT_ID" ] || die "set FLOWPLANE_OIDC_CLIENT_ID (Auth0 native-app client id)"
+}
+
+DP_NAME="${DP_NAME:-dp-local}"
+UPSTREAM_PORT="${UPSTREAM_PORT:-3001}"
+LISTEN_PORT="${LISTEN_PORT:-10001}"
+
+CP_HOST="cp.getflowplane.io"
+XDS_HOST="xds.getflowplane.io"
+WORK="${WORK:-/tmp/fp-e2e}"
+mkdir -p "$WORK"
+
+say() { printf '\n\033[1;36m== %s\033[0m\n' "$*"; }
+ok()  { printf '\033[1;32m   ok: %s\033[0m\n' "$*"; }
+die() { printf '\033[1;31m   FAIL: %s\033[0m\n' "$*" >&2; exit 1; }
+
+case "${1:-help}" in
+
+# ---------------------------------------------------------------------------
+0-preflight)
+  say "Preflight: tooling + reachability"
+  command -v "$FP" >/dev/null 2>&1 || [ -x "$FP" ] || die "flowplane binary not at $FP (cargo build --release --bin flowplane)"
+  command -v envoy >/dev/null 2>&1 || die "envoy not installed (brew install envoy)"
+  command -v python3 >/dev/null 2>&1 || die "python3 missing"
+  command -v jq >/dev/null 2>&1 || echo "   note: jq not found, will use python3 for JSON"
+  echo "   flowplane: $($FP --version 2>/dev/null || echo "$FP")"
+  echo "   envoy:     $(envoy --version 2>&1 | head -1)"
+  echo "   server:    $FLOWPLANE_SERVER"
+  getent_host() { python3 -c "import socket,sys;print(socket.gethostbyname(sys.argv[1]))" "$1" 2>/dev/null || echo "UNRESOLVED"; }
+  echo "   $CP_HOST  -> $(getent_host $CP_HOST)"
+  echo "   $XDS_HOST -> $(getent_host $XDS_HOST)"
+  echo "   (if UNRESOLVED or pointing at an old ELB, run step 1-hosts)"
+  ;;
+
+# ---------------------------------------------------------------------------
+1-hosts)
+  say "Fetch current ALB/NLB IPs and print /etc/hosts lines"
+  ALB_IP=$(aws ec2 describe-network-interfaces --region "$AWS_REGION" --profile "$AWS_PROFILE" \
+    --filters "Name=description,Values=ELB app/flowplane-api/*" \
+    --query 'NetworkInterfaces[0].Association.PublicIp' --output text)
+  NLB_IP=$(aws ec2 describe-network-interfaces --region "$AWS_REGION" --profile "$AWS_PROFILE" \
+    --filters "Name=description,Values=ELB net/flowplane-xds/*" \
+    --query 'NetworkInterfaces[0].Association.PublicIp' --output text)
+  [ "$ALB_IP" != "None" ] && [ -n "$ALB_IP" ] || die "no ALB IP — is the deployment up?"
+  printf '%s\n' "$ALB_IP $CP_HOST" "$NLB_IP $XDS_HOST" > "$WORK/hosts.add"
+  echo "   Add these to /etc/hosts (CLI + Envoy use the OS resolver):"
+  echo
+  sed 's/^/      /' "$WORK/hosts.add"
+  echo
+  echo "   Run:"
+  echo "      sudo sh -c 'grep -v getflowplane.io /etc/hosts > /tmp/h && cat /tmp/h $WORK/hosts.add > /etc/hosts'"
+  echo "   (the grep drops any stale getflowplane.io lines first)"
+  ;;
+
+# ---------------------------------------------------------------------------
+2-login-admin)
+  say "Device-code login as ADMIN (Auth0 user 1)"
+  need_oidc
+  "$FP" auth login --device-code \
+    --issuer "$FLOWPLANE_OIDC_ISSUER" \
+    --client-id "$FLOWPLANE_OIDC_CLIENT_ID" \
+    --scope "$FLOWPLANE_OIDC_SCOPE"
+  ok "approve in the browser as the admin identity ($ADMIN_EMAIL)"
+  ;;
+
+3-whoami)
+  say "Verify admin identity + JIT row"
+  "$FP" auth whoami
+  echo "   expect PLATFORM ADMIN = true"
+  ;;
+
+# ---------------------------------------------------------------------------
+4-org-team)
+  say "Create tenant org + team, make admin a member (D-014 context)"
+  [ -n "$ADMIN_EMAIL" ] || die "set ADMIN_EMAIL to the platform-admin email"
+  "$FP" org create "$FLOWPLANE_ORG" --display-name "Acme" || echo "   (org may already exist)"
+  "$FP" org member add "$FLOWPLANE_ORG" --email "$ADMIN_EMAIL" --role admin || echo "   (admin may already be a member)"
+  "$FP" team create "$FLOWPLANE_TEAM" --display-name "Payments" || echo "   (team may already exist)"
+  echo "   org=$FLOWPLANE_ORG team=$FLOWPLANE_TEAM (org admin reaches all teams implicitly)"
+  "$FP" org list
+  ;;
+
+# ---------------------------------------------------------------------------
+5-dataplane)
+  say "Register a dataplane record"
+  "$FP" dataplane create "$DP_NAME" --description "local Envoy smoke" || echo "   (may already exist)"
+  "$FP" dataplane list
+  ;;
+
+# ---------------------------------------------------------------------------
+6-cert)
+  say "Issue the dataplane mTLS client cert (CP cert-issuer CA)"
+  "$FP" -o json dataplane cert issue "$DP_NAME" --ttl-hours 24 > "$WORK/cert.json"
+  python3 - "$WORK" <<'PY'
+import json,sys,os
+w=sys.argv[1]
+d=json.load(open(f"{w}/cert.json"))
+for k,f in [("certificate_pem","client.crt"),("private_key_pem","client.key"),("ca_certificate_pem","ca.crt")]:
+    open(f"{w}/{f}","w").write(d[k]);
+os.chmod(f"{w}/client.key",0o600)
+print("   wrote client.crt, client.key, ca.crt to",w)
+PY
+  ok "cert/key/ca staged in $WORK"
+  ;;
+
+# ---------------------------------------------------------------------------
+7-upstream)
+  say "Start a local upstream on :$UPSTREAM_PORT"
+  mkdir -p "$WORK/upstream"
+  printf 'hello-flowplane\n' > "$WORK/upstream/index.html"
+  ( cd "$WORK/upstream" && nohup python3 -m http.server "$UPSTREAM_PORT" >"$WORK/upstream.log" 2>&1 & echo $! > "$WORK/upstream.pid" )
+  sleep 1
+  curl -fsS "http://127.0.0.1:$UPSTREAM_PORT/" && ok "upstream up (pid $(cat $WORK/upstream.pid))" || die "upstream not responding"
+  ;;
+
+# ---------------------------------------------------------------------------
+8-expose)
+  say "Expose the upstream -> cluster + route + listener (:$LISTEN_PORT)"
+  "$FP" expose "http://127.0.0.1:$UPSTREAM_PORT" \
+    --name local --path / --port "$LISTEN_PORT" \
+    --public-base-url "http://127.0.0.1:$LISTEN_PORT"
+  ;;
+
+# ---------------------------------------------------------------------------
+9-bootstrap)
+  say "Generate the Envoy mTLS bootstrap (xDS -> $XDS_HOST:18000)"
+  "$FP" --out "$WORK/envoy.yaml" dataplane bootstrap "$DP_NAME" \
+    --mode mtls \
+    --xds-host "$XDS_HOST" --xds-port 18000 --admin-port 9901 \
+    --cert-path "$WORK/client.crt" \
+    --key-path  "$WORK/client.key" \
+    --ca-path   "$WORK/ca.crt"
+  ok "wrote $WORK/envoy.yaml"
+  echo "   (xds-host = $XDS_HOST matches the xDS server cert SAN; /etc/hosts maps it to the NLB)"
+  ;;
+
+# ---------------------------------------------------------------------------
+10-envoy)
+  say "Run local Envoy (foreground — watch for xDS connect, Ctrl-C to stop)"
+  echo "   expect: cluster/listener warmed, no NACKs"
+  exec envoy -c "$WORK/envoy.yaml" --log-level info
+  ;;
+
+# ---------------------------------------------------------------------------
+11-curl)
+  say "THE TEST: call through Envoy"
+  curl -i "http://127.0.0.1:$LISTEN_PORT/" || die "no response — check Envoy logs + step 12-diag"
+  echo
+  ok "expect body: hello-flowplane"
+  ;;
+
+# ---------------------------------------------------------------------------
+12-diag)
+  say "Diagnostics (CP-side, the operator path)"
+  "$FP" stats overview || true
+  "$FP" ops xds status || true
+  "$FP" ops xds nacks || true
+  ;;
+
+# ---- optional: onboard the SECOND Auth0 user ------------------------------
+u2-login)
+  say "Login as Auth0 user 2 (separate context to avoid clobbering admin)"
+  need_oidc
+  echo "   NOTE: this overwrites the stored CLI token. Re-run 2-login-admin to switch back."
+  "$FP" auth login --device-code --issuer "$FLOWPLANE_OIDC_ISSUER" \
+    --client-id "$FLOWPLANE_OIDC_CLIENT_ID" --scope "$FLOWPLANE_OIDC_SCOPE"
+  "$FP" auth whoami   # JIT-creates the user 2 row; copy its USER ID / subject
+  ;;
+
+u2-add)
+  say "As ADMIN, add user 2 to the org (re-login as admin first!)"
+  echo "   usage: U2_SUBJECT='auth0|...' scripts/aws-e2e-smoke.sh u2-add"
+  : "${U2_SUBJECT:?set U2_SUBJECT to the user-2 OIDC subject from u2-login whoami}"
+  "$FP" org member add "$FLOWPLANE_ORG" --subject "$U2_SUBJECT" --role member
+  "$FP" org member list "$FLOWPLANE_ORG"
+  ;;
+
+# ---------------------------------------------------------------------------
+cleanup)
+  say "Tear down local bits (leaves AWS infra alone)"
+  [ -f "$WORK/upstream.pid" ] && kill "$(cat $WORK/upstream.pid)" 2>/dev/null && echo "   stopped upstream" || true
+  "$FP" unexpose local 2>/dev/null && echo "   unexposed listener" || true
+  echo "   (stop Envoy with Ctrl-C in its terminal; AWS teardown: tofu -chdir=deploy/aws destroy)"
+  ;;
+
+*)
+  cat <<EOF
+AWS end-to-end smoke — run one step at a time:
+
+  0-preflight   tooling + DNS check
+  1-hosts       fetch live ALB/NLB IPs, print /etc/hosts lines  (run the sudo cmd it prints)
+  2-login-admin device login as Auth0 user 1 (admin)
+  3-whoami      verify PLATFORM ADMIN true
+  4-org-team    create org '$FLOWPLANE_ORG' + team '$FLOWPLANE_TEAM', add admin
+  5-dataplane   register dataplane '$DP_NAME'
+  6-cert        issue mTLS client cert -> $WORK/{client.crt,client.key,ca.crt}
+  7-upstream    start local upstream on :$UPSTREAM_PORT
+  8-expose      create cluster+route+listener on :$LISTEN_PORT
+  9-bootstrap   generate Envoy mTLS bootstrap -> $WORK/envoy.yaml
+  10-envoy      run local Envoy (foreground)
+  11-curl       >>> curl through Envoy, expect 'hello-flowplane'   (new terminal)
+  12-diag       CP-side xDS diagnostics
+
+  optional:
+  u2-login      login as Auth0 user 2 (clobbers admin token)
+  u2-add        admin adds user 2 to the org (U2_SUBJECT=...)
+  cleanup       stop upstream + unexpose
+
+Typical order: 0 1 (sudo) 2 3 4 5 6 7 8 9 10(keep running) then 11 in a new terminal.
+EOF
+  ;;
+esac

--- a/spec/14-architecture-integrity.md
+++ b/spec/14-architecture-integrity.md
@@ -48,17 +48,26 @@ mutation path before editing code.
    Production xDS is mTLS-or-off; partial TLS config fails boot; dev plaintext is explicit and
    gated; secret values are write-only over HTTP.
 
-10. **Envoy admin is not an operator/product API.**
+10. **Deployment packaging preserves security boundaries.**
+    Provider-specific packaging must not weaken product security invariants. Public operator/API
+    traffic is TLS-protected to the CP service; production deployments do not use plaintext API
+    opt-in. Dataplane control traffic reaches the CP over mTLS terminated by Flowplane so client
+    certificates are validated by the CP. Control-plane workloads and databases are not directly
+    internet-addressable; DNS, load balancers, schedulers, and secret stores are deployment
+    mechanisms, not architecture. OIDC remains provider-agnostic, and runtime secrets/certs are
+    supplied through deployment secret mechanisms, never committed config.
+
+11. **Envoy admin is not an operator/product API.**
    Envoy admin endpoints stay loopback-local to the dataplane unit. Product diagnostics and
    operator workflows must use CP surfaces backed by persisted diagnostics, audit, outbox, and
    xDS state. Only `fp-agent` may scrape Envoy admin, and only to relay curated telemetry to the
    CP over the outbound diagnostics channel.
 
-11. **Contracts must not drift.**
+12. **Contracts must not drift.**
    REST, OpenAPI, CLI, and MCP declarations should come from the same source where possible, with
    parity tests pinning the surface.
 
-12. **The V2 UX must improve V1.**
+13. **The V2 UX must improve V1.**
     V1 defines the user outcome; V2 defines the architecture and experience.
 
 ## 2. Domain Ownership


### PR DESCRIPTION
Implements the secure AWS deployment epic (#98): control plane on ECS/Fargate + RDS, API over HTTPS via ALB, xDS over mTLS via NLB (TCP passthrough), Auth0 OIDC, secrets via Secrets Manager. Validated end-to-end (admin login → org/team → dataplane mTLS cert → local Envoy → routed API call).

## Commits
- **AWS ECS/RDS deployment module** (`deploy/aws`, OpenTofu): VPC/subnets/SGs, RDS Postgres (private), ECS/Fargate CP (ARM64/Graviton — x86 cross-build segfaults under QEMU on Apple Silicon), ALB HTTPS, NLB TCP passthrough, Secrets Manager wiring, no `FLOWPLANE_API_INSECURE`. `spec/14` invariant #10 records provider-agnostic deployment boundaries.
- **xDS NLB health-check fix**: NLB IP-target health checks come from the VPC, not the operator CIDRs — added a VPC-CIDR ingress rule (target was always unhealthy → xDS connection timeouts) and enabled `preserve_client_ip` so the operator allowlist is meaningful.
- **`scripts/aws-e2e-smoke.sh`**: step-at-a-time runbook for the full live flow (login, org/team, dataplane + mTLS cert, expose, Envoy mTLS bootstrap, local Envoy, routed curl). No hardcoded tenant identifiers — supplied via env.
- **`internal/user-onboarding.md`**: IdP → JIT row → org role → team → context, with the common errors and fixes.
- **Auth0 identifier scrub** of `internal/prod-local-runbook.md` (placeholders). No credentials were ever committed; real values stay in gitignored `internal/.env.prod-local` + Secrets Manager.

## Notes
- `deploy/aws/local.auto.tfvars` is gitignored (real ARNs/IPs/audience never committed).
- Overlaps PR #114 (same runbook scrub off `main`) — close #114 once this merges, or merge #114 first.
- Verified acceptance criteria from #98: HTTPS API healthy, OIDC enabled, xDS mTLS up, RDS migrated, bootstrap + device login + dataplane mTLS + route mutation all working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)