### PR TITLE
fix(xds): verify materialized upstream TLS certs by default (fixes #125)

### DIFF
--- a/crates/fp-core/src/services/ai.rs
+++ b/crates/fp-core/src/services/ai.rs
@@ -1120,7 +1120,9 @@ fn provider_cluster_spec(provider: &AiProvider) -> DomainResult<ClusterSpec> {
         upstream_tls: use_tls.then_some(UpstreamTlsConfig {
             sni: Some(host),
             validation_context_sds_secret_name: None,
+            ca_cert_file: None,
             auto_sni_san_validation: true,
+            insecure_skip_verify: false,
         }),
         protocol: None,
         health_checks: None,

--- a/crates/fp-core/src/services/discovery.rs
+++ b/crates/fp-core/src/services/discovery.rs
@@ -337,7 +337,11 @@ fn cluster_spec(ip: &IpAddr, port: u16, spec: &DiscoverySessionSpec) -> ClusterS
         upstream_tls: spec.upstream_tls.then(|| UpstreamTlsConfig {
             sni: Some(spec.upstream_host.clone()),
             validation_context_sds_secret_name: None,
-            auto_sni_san_validation: false,
+            ca_cert_file: None,
+            // Validate the cert SAN against the SNI (upstream_host), not just the trust chain —
+            // otherwise any cert chaining to the CA bundle would be accepted (issue #125).
+            auto_sni_san_validation: true,
+            insecure_skip_verify: false,
         }),
         protocol: None,
         health_checks: None,

--- a/crates/fp-core/src/services/expose.rs
+++ b/crates/fp-core/src/services/expose.rs
@@ -94,7 +94,9 @@ pub async fn expose(
         upstream_tls: upstream.use_tls.then_some(UpstreamTlsConfig {
             sni: Some(upstream.sni),
             validation_context_sds_secret_name: None,
+            ca_cert_file: None,
             auto_sni_san_validation: true,
+            insecure_skip_verify: false,
         }),
         protocol: None,
         health_checks: None,

--- a/crates/fp-core/src/services/route_generation.rs
+++ b/crates/fp-core/src/services/route_generation.rs
@@ -284,7 +284,9 @@ fn build_plan(
         upstream_tls: upstream_tls.then_some(UpstreamTlsConfig {
             sni: Some(upstream_host.to_string()),
             validation_context_sds_secret_name: None,
+            ca_cert_file: None,
             auto_sni_san_validation: true,
+            insecure_skip_verify: false,
         }),
         protocol: None,
         health_checks: None,

--- a/crates/fp-domain/src/gateway/cluster.rs
+++ b/crates/fp-domain/src/gateway/cluster.rs
@@ -138,8 +138,19 @@ pub struct UpstreamTlsConfig {
     pub sni: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub validation_context_sds_secret_name: Option<String>,
+    /// Filesystem path (in the Envoy/dataplane container) to a PEM CA bundle used to verify the
+    /// upstream certificate. Alternative to `validation_context_sds_secret_name`. When neither is
+    /// set, the translator falls back to the default system CA bundle (verify-by-default); see
+    /// `upstream_tls_context`. Ignored when `insecure_skip_verify` is true.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ca_cert_file: Option<String>,
     #[serde(default)]
     pub auto_sni_san_validation: bool,
+    /// Explicit opt-out of upstream certificate verification. Default false: TLS upstreams verify
+    /// the server cert against a CA bundle. Set true only when the upstream cannot be verified and
+    /// the risk is accepted — this disables peer/SAN validation (issue #125).
+    #[serde(default)]
+    pub insecure_skip_verify: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
@@ -393,6 +404,23 @@ impl ClusterSpec {
             if let Some(secret) = &tls.validation_context_sds_secret_name {
                 crate::identity::validate_name(secret)?;
             }
+            if let Some(ca) = &tls.ca_cert_file {
+                if tls.validation_context_sds_secret_name.is_some() {
+                    return Err(DomainError::validation(
+                        "upstream_tls validation source must be either ca_cert_file or validation_context_sds_secret_name, not both",
+                    ));
+                }
+                if ca.trim().is_empty() {
+                    return Err(DomainError::validation(
+                        "upstream_tls ca_cert_file must not be empty",
+                    ));
+                }
+                if ca.chars().any(char::is_control) {
+                    return Err(DomainError::validation(
+                        "upstream_tls ca_cert_file must not contain control characters",
+                    ));
+                }
+            }
         }
         for hc in self.health_checks.iter().flatten() {
             validate_health_check(hc)?;
@@ -527,6 +555,37 @@ mod tests {
     #[test]
     fn minimal_spec_validates() {
         assert!(minimal().validate().is_ok());
+    }
+
+    #[test]
+    fn upstream_tls_ca_cert_file_validation() {
+        let with_ca = |ca: Option<&str>, secret: Option<&str>| ClusterSpec {
+            upstream_tls: Some(UpstreamTlsConfig {
+                sni: Some("api.example.com".into()),
+                validation_context_sds_secret_name: secret.map(Into::into),
+                ca_cert_file: ca.map(Into::into),
+                auto_sni_san_validation: true,
+                insecure_skip_verify: false,
+            }),
+            ..minimal()
+        };
+        assert!(with_ca(Some("/etc/ssl/upstream-ca.pem"), None)
+            .validate()
+            .is_ok());
+        assert!(
+            with_ca(Some(""), None).validate().is_err(),
+            "empty ca_cert_file"
+        );
+        assert!(
+            with_ca(Some("/etc/\nca.pem"), None).validate().is_err(),
+            "control char"
+        );
+        assert!(
+            with_ca(Some("/etc/ssl/ca.pem"), Some("upstream-ca"))
+                .validate()
+                .is_err(),
+            "ca_cert_file and SDS secret are mutually exclusive"
+        );
     }
 
     #[test]
@@ -726,7 +785,9 @@ mod tests {
             upstream_tls: Some(UpstreamTlsConfig {
                 sni: Some("api.example.com".into()),
                 validation_context_sds_secret_name: Some("upstream-ca".into()),
+                ca_cert_file: None,
                 auto_sni_san_validation: true,
+                insecure_skip_verify: false,
             }),
             protocol: Some(UpstreamProtocol::Grpc),
             health_checks: Some(vec![

--- a/crates/fp-xds/src/translate.rs
+++ b/crates/fp-xds/src/translate.rs
@@ -665,26 +665,60 @@ pub fn cluster_to_proto_with_ai(
     })
 }
 
+/// Default CA bundle path (in the Envoy/dataplane container) used to verify upstream TLS certs
+/// when a cluster's `UpstreamTlsConfig` names neither an SDS secret nor an explicit `ca_cert_file`.
+/// Override with `FLOWPLANE_UPSTREAM_CA_BUNDLE`. The path is resolved by Envoy, not the control
+/// plane, so it must exist on the dataplane host; the default matches Debian/Ubuntu containers.
+fn default_upstream_ca_bundle() -> String {
+    std::env::var("FLOWPLANE_UPSTREAM_CA_BUNDLE")
+        .unwrap_or_else(|_| "/etc/ssl/certs/ca-certificates.crt".to_string())
+}
+
 fn upstream_tls_context(spec: &ClusterSpec) -> tls::UpstreamTlsContext {
     let tls_spec = spec.upstream_tls.as_ref();
-    let validation_secret =
-        tls_spec.and_then(|tls| tls.validation_context_sds_secret_name.as_deref());
+    let insecure = tls_spec
+        .map(|tls| tls.insecure_skip_verify)
+        .unwrap_or(false);
+
+    // Verify-by-default (issue #125): TLS upstreams must authenticate the server cert. Pick a
+    // validation context source in priority order — explicit SDS secret, explicit CA file, then
+    // the default system CA bundle — unless the operator has explicitly opted out.
+    let validation_context_type = if insecure {
+        None
+    } else if let Some(secret) =
+        tls_spec.and_then(|tls| tls.validation_context_sds_secret_name.as_deref())
+    {
+        Some(
+            tls::common_tls_context::ValidationContextType::ValidationContextSdsSecretConfig(
+                sds_secret_config(secret),
+            ),
+        )
+    } else {
+        let ca_path = tls_spec
+            .and_then(|tls| tls.ca_cert_file.clone())
+            .unwrap_or_else(default_upstream_ca_bundle);
+        Some(
+            tls::common_tls_context::ValidationContextType::ValidationContext(
+                tls::CertificateValidationContext {
+                    trusted_ca: Some(filename(ca_path)),
+                    ..Default::default()
+                },
+            ),
+        )
+    };
+
+    let has_validation = validation_context_type.is_some();
     tls::UpstreamTlsContext {
         common_tls_context: Some(tls::CommonTlsContext {
-            validation_context_type: validation_secret.map(|secret| {
-                tls::common_tls_context::ValidationContextType::ValidationContextSdsSecretConfig(
-                    sds_secret_config(secret),
-                )
-            }),
+            validation_context_type,
             ..Default::default()
         }),
         sni: tls_spec.and_then(|tls| tls.sni.clone()).unwrap_or_default(),
         // Envoy rejects a cluster that sets `auto_sni_san_validation` without a validation
         // context ("'auto_sni_san_validation' was configured without a validation context"),
-        // which NACKs the whole CDS update. The AI/expose/route-generation materializers set
-        // the flag with `validation_context_sds_secret_name: None`, so only emit it when a
-        // validation context is actually present. See issue #123.
-        auto_sni_san_validation: validation_secret.is_some()
+        // which NACKs the whole CDS update (issue #123). With verify-by-default a context is
+        // normally present; only suppress the flag when verification is explicitly disabled.
+        auto_sni_san_validation: has_validation
             && tls_spec
                 .map(|tls| tls.auto_sni_san_validation)
                 .unwrap_or(false),
@@ -2464,18 +2498,57 @@ mod tests {
         tls::UpstreamTlsContext::decode(any.value.as_slice()).expect("upstream tls")
     }
 
-    // Issue #123: the AI/expose/route-generation materializers set `auto_sni_san_validation: true`
-    // with no validation context. Envoy NACKs that combination, rejecting the whole CDS update,
-    // so the translator must not emit `auto_sni_san_validation` unless a validation context exists.
+    // Issue #125: with no explicit trust source, a TLS upstream must still verify the server cert
+    // against the default system CA bundle (verify-by-default), and `auto_sni_san_validation` is
+    // then validly emitted (a validation context exists, so #123's NACK condition does not apply).
     #[test]
-    fn upstream_tls_without_validation_context_omits_auto_sni_san_validation() {
+    fn upstream_tls_without_explicit_trust_defaults_to_system_ca_bundle() {
         let mut spec = cluster_spec();
         spec.upstream_tls = Some(UpstreamTlsConfig {
             sni: Some("api.openai.com".into()),
             validation_context_sds_secret_name: None,
+            ca_cert_file: None,
             auto_sni_san_validation: true,
+            insecure_skip_verify: false,
         });
         let ctx = upstream_tls_context_of("ai-chat-route-b1", &spec);
+        assert!(
+            ctx.auto_sni_san_validation,
+            "verify-by-default emits a validation context, so the flag is preserved"
+        );
+        match ctx
+            .common_tls_context
+            .expect("common")
+            .validation_context_type
+            .expect("validation context (verify-by-default)")
+        {
+            tls::common_tls_context::ValidationContextType::ValidationContext(vc) => {
+                let path = match vc.trusted_ca.expect("trusted_ca").specifier.expect("spec") {
+                    core::data_source::Specifier::Filename(p) => p,
+                    other => panic!("expected filename data source: {other:?}"),
+                };
+                assert!(
+                    path.ends_with("ca-certificates.crt"),
+                    "default bundle path: {path}"
+                );
+            }
+            other => panic!("unexpected validation context: {other:?}"),
+        }
+    }
+
+    // Issue #125: explicit opt-out disables verification — no validation context, and the #123
+    // guard then suppresses `auto_sni_san_validation` so Envoy does not NACK the cluster.
+    #[test]
+    fn upstream_tls_insecure_skip_verify_omits_validation_context() {
+        let mut spec = cluster_spec();
+        spec.upstream_tls = Some(UpstreamTlsConfig {
+            sni: Some("api.openai.com".into()),
+            validation_context_sds_secret_name: None,
+            ca_cert_file: None,
+            auto_sni_san_validation: true,
+            insecure_skip_verify: true,
+        });
+        let ctx = upstream_tls_context_of("insecure", &spec);
         assert!(
             !ctx.auto_sni_san_validation,
             "no validation context => auto_sni_san_validation must be false (Envoy rejects it otherwise)"
@@ -2485,8 +2558,74 @@ mod tests {
                 .expect("common")
                 .validation_context_type
                 .is_none(),
-            "no validation context should be emitted"
+            "insecure_skip_verify should emit no validation context"
         );
+    }
+
+    // Issue #125: an explicit `ca_cert_file` is used verbatim (not the default bundle), and a
+    // validation context being present keeps `auto_sni_san_validation`.
+    #[test]
+    fn upstream_tls_explicit_ca_file_is_used_verbatim() {
+        let mut spec = cluster_spec();
+        spec.upstream_tls = Some(UpstreamTlsConfig {
+            sni: Some("api.example.com".into()),
+            validation_context_sds_secret_name: None,
+            ca_cert_file: Some("/etc/flowplane/upstream-ca.pem".into()),
+            auto_sni_san_validation: true,
+            insecure_skip_verify: false,
+        });
+        let ctx = upstream_tls_context_of("api", &spec);
+        assert!(ctx.auto_sni_san_validation);
+        match ctx
+            .common_tls_context
+            .expect("common")
+            .validation_context_type
+            .expect("validation context")
+        {
+            tls::common_tls_context::ValidationContextType::ValidationContext(vc) => {
+                match vc.trusted_ca.expect("trusted_ca").specifier.expect("spec") {
+                    core::data_source::Specifier::Filename(p) => {
+                        assert_eq!(p, "/etc/flowplane/upstream-ca.pem")
+                    }
+                    other => panic!("expected filename data source: {other:?}"),
+                }
+            }
+            other => panic!("unexpected validation context: {other:?}"),
+        }
+    }
+
+    // Issue #125: `insecure_skip_verify` overrides an explicit trust source — a configured SDS
+    // secret (or CA file) still yields no validation context.
+    #[test]
+    fn upstream_tls_insecure_overrides_explicit_trust_source() {
+        for tls in [
+            UpstreamTlsConfig {
+                sni: Some("api.example.com".into()),
+                validation_context_sds_secret_name: Some("upstream-ca".into()),
+                ca_cert_file: None,
+                auto_sni_san_validation: true,
+                insecure_skip_verify: true,
+            },
+            UpstreamTlsConfig {
+                sni: Some("api.example.com".into()),
+                validation_context_sds_secret_name: None,
+                ca_cert_file: Some("/etc/flowplane/upstream-ca.pem".into()),
+                auto_sni_san_validation: true,
+                insecure_skip_verify: true,
+            },
+        ] {
+            let mut spec = cluster_spec();
+            spec.upstream_tls = Some(tls);
+            let ctx = upstream_tls_context_of("api", &spec);
+            assert!(!ctx.auto_sni_san_validation);
+            assert!(
+                ctx.common_tls_context
+                    .expect("common")
+                    .validation_context_type
+                    .is_none(),
+                "insecure_skip_verify must override the explicit trust source"
+            );
+        }
     }
 
     #[test]
@@ -2495,7 +2634,9 @@ mod tests {
         spec.upstream_tls = Some(UpstreamTlsConfig {
             sni: Some("api.example.com".into()),
             validation_context_sds_secret_name: Some("upstream-ca".into()),
+            ca_cert_file: None,
             auto_sni_san_validation: true,
+            insecure_skip_verify: false,
         });
         let ctx = upstream_tls_context_of("api", &spec);
         assert!(
@@ -2620,7 +2761,9 @@ mod tests {
             upstream_tls: Some(UpstreamTlsConfig {
                 sni: Some("api.example.com".into()),
                 validation_context_sds_secret_name: Some("upstream-ca".into()),
+                ca_cert_file: None,
                 auto_sni_san_validation: true,
+                insecure_skip_verify: false,
             }),
             protocol: Some(UpstreamProtocol::Grpc),
             health_checks: Some(vec![HealthCheck::Http(HttpHealthCheck {

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -74,6 +74,9 @@ Server process:
 | MCP | `FLOWPLANE_MCP_ALLOWED_ORIGINS` |
 | Throttling/discovery | `FLOWPLANE_TENANT_WRITE_LIMIT_PER_MIN`, `FLOWPLANE_DISCOVERY_ALLOWED_DESTINATIONS` |
 | Dataplane cert issuer | `FLOWPLANE_CERT_ISSUER_CA_CERT_PATH`, `FLOWPLANE_CERT_ISSUER_CA_KEY_PATH`, `FLOWPLANE_CERT_ISSUER_TRUST_DOMAIN` |
+| Upstream TLS trust | `FLOWPLANE_UPSTREAM_CA_BUNDLE` (CA bundle path **in the Envoy/dataplane container** used to verify materialized TLS upstreams; default `/etc/ssl/certs/ca-certificates.crt`) |
+
+> **Upstream certificate verification (verify-by-default).** TLS upstreams that Flowplane materializes (AI providers, `flowplane expose https://…`, route-generation) verify the upstream server certificate against `FLOWPLANE_UPSTREAM_CA_BUNDLE`. A cluster may instead name an SDS validation secret (`validation_context_sds_secret_name`) or a per-cluster CA file (`ca_cert_file`). Verification can only be disabled per cluster by explicitly setting `insecure_skip_verify: true` — never the silent default (issue #125). The bundle path is resolved by **Envoy**, so the dataplane image must ship a CA bundle at that path (the default exists on Debian/Ubuntu via the `ca-certificates` package); otherwise Envoy rejects the cluster. The control plane cannot check the dataplane filesystem, so verify this when building/operating the dataplane image.
 
 CLI client:
 


### PR DESCRIPTION
## Summary

Fixes #125. Materialized TLS upstreams (AI providers, `flowplane expose https://…`, route-generation, discovery) were built with `validation_context_sds_secret_name: None`, so the emitted Envoy `UpstreamTlsContext` had **no validation context** — Envoy performed no peer/SAN verification. A request to e.g. `https://api.openai.com` was encrypted but **not authenticated**: any cert from an on-path attacker would be accepted.

## Change

**Verify-by-default** (issue's recommended posture). `upstream_tls_context` (`crates/fp-xds/src/translate.rs`) now picks a validation source in priority order:

1. explicit SDS secret (`validation_context_sds_secret_name`)
2. explicit `ca_cert_file` (new) — per-cluster CA path, mirrors the downstream-listener pattern
3. default system CA bundle — `FLOWPLANE_UPSTREAM_CA_BUNDLE`, default `/etc/ssl/certs/ca-certificates.crt`

Verification is skipped **only** when a cluster explicitly sets the new `insecure_skip_verify: true` — never the silent default. With a validation context now normally present, `auto_sni_san_validation` validly emits (the #123 NACK guard only suppresses it under the explicit opt-out).

- Discovery clusters now also enable `auto_sni_san_validation`, so upstream **identity** (SAN vs SNI) is checked, not just the trust chain.
- `ClusterSpec::validate` rejects an empty / control-character `ca_cert_file` and the mutually-exclusive `ca_cert_file` + SDS secret combination — a clean control-plane error instead of an Envoy NACK.

## API additions

`UpstreamTlsConfig` gains two optional fields (both default to the safe value):
- `ca_cert_file: Option<String>` — CA bundle path resolved in the Envoy/dataplane container.
- `insecure_skip_verify: bool` — explicit opt-out of verification.

## Tests

`fp-xds` translator: default-bundle path, explicit-CA verbatim, opt-out overriding SDS/CA, SDS-secret retention. `fp-domain`: `ca_cert_file` validation (empty / control-char / mutual-exclusion). All green; clippy clean.

## Deployment note

The CA bundle path is resolved by **Envoy**, so the dataplane image must ship a bundle at that path (Debian/Ubuntu `ca-certificates` provides the default). The control plane cannot check the dataplane filesystem. Documented in `docs/production-readiness.md`.

## Review

Passed an adversarial Codex (gpt-5.5) security/correctness review gate — `VERDICT: APPROVE` after one round of fixes (discovery SAN, ca_cert_file validation, added tests, deployment doc).
