### PR TITLE
docs: rustup prereq (#126) + organise scripts/ into ci/dev/release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Docs boundary self-test
-        run: python3 scripts/check-docs-boundary.py --self-test
+        run: python3 scripts/ci/check-docs-boundary.py --self-test
       - name: Docs boundary (user docs must stand alone, #116)
-        run: python3 scripts/check-docs-boundary.py
+        run: python3 scripts/ci/check-docs-boundary.py

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ a local Envoy dataplane, creating gateway resources, and checking stats/NACK dia
 
 ## Useful Commands
 
+> **Toolchain:** build through [rustup](https://rustup.rs) so the `rust-toolchain.toml`
+> pin (1.94.1) is applied automatically. A distro-packaged `cargo` (e.g. `apt-get install
+> cargo`) may be too old to read this repo's version-4 `Cargo.lock` and will fail before
+> building.
+
 Build:
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,5 +97,5 @@ existing operator docs have been reclassified (#116):
 | `docs/adversarial-surface-map.md` | `../internal/adversarial-surface-map.md` | internal (evidence) |
 | `docs/release-packaging.md` | `../internal/release/release-packaging.md` | internal |
 
-The boundary is enforced in CI by `scripts/check-docs-boundary.py` (see
+The boundary is enforced in CI by `scripts/ci/check-docs-boundary.py` (see
 [Enforcement (CI)](#enforcement-ci)).

--- a/docs/how-to/production-readiness.md
+++ b/docs/how-to/production-readiness.md
@@ -44,7 +44,7 @@ FLOWPLANE_PACKAGE_XDS_PORT=18000 \
 FLOWPLANE_PACKAGE_CERT_PATH=/etc/flowplane/tls/tls.crt \
 FLOWPLANE_PACKAGE_KEY_PATH=/etc/flowplane/tls/tls.key \
 FLOWPLANE_PACKAGE_CA_PATH=/etc/flowplane/tls/ca.crt \
-scripts/package-release.sh
+scripts/release/package-release.sh
 ```
 
 Run Envoy and `fp-agent` beside each other in the dataplane network. The dataplane dials the
@@ -183,8 +183,8 @@ flowplane mcp status --team <team>
 flowplane mcp connections --team <team>
 flowplane mcp enable --api api_get-catalog --team <team>
 
-scripts/package-release.sh
-FLOWPLANE_PACKAGE_IMAGE=1 scripts/package-release.sh
+scripts/release/package-release.sh
+FLOWPLANE_PACKAGE_IMAGE=1 scripts/release/package-release.sh
 ```
 
 The failure-mode matrix and adversarial surface map (in the internal engineering docs) are

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -27,7 +27,12 @@ You need:
   point `FLOWPLANE_DATABASE_URL` at your own superuser.
 - **Envoy installed** — a local `envoy` binary on your `PATH`. You use it in
   step 6 to actually route traffic. On macOS, prefer the local binary over Docker.
-- **The `flowplane` binary.** Build it from the repo:
+- **A Rust toolchain via [rustup](https://rustup.rs).** The repo pins its toolchain in
+  `rust-toolchain.toml`, which only takes effect when the build is driven through rustup —
+  it selects the pinned version automatically on first `cargo` invocation. Do **not** use a
+  distro-packaged `cargo` (e.g. `apt-get install cargo`): an older system cargo cannot read
+  this repo's version-4 `Cargo.lock` and fails before the build starts.
+- **The `flowplane` binary.** Build it from the repo (rustup picks the pinned toolchain):
 
   ```bash
   cargo build --bin flowplane

--- a/internal/prod-local-runbook.md
+++ b/internal/prod-local-runbook.md
@@ -47,7 +47,7 @@ postgres://<your-mac-user>@127.0.0.1:5432/flowplane_prod_local
 Run:
 
 ```bash
-scripts/setup-prod-local.sh
+scripts/dev/setup-prod-local.sh
 ```
 
 The script prompts for:
@@ -65,9 +65,9 @@ prints the exact `serve`, bootstrap, and login commands.
 Useful flags:
 
 ```bash
-scripts/setup-prod-local.sh --force
-scripts/setup-prod-local.sh --skip-build
-scripts/setup-prod-local.sh --skip-migrate
+scripts/dev/setup-prod-local.sh --force
+scripts/dev/setup-prod-local.sh --skip-build
+scripts/dev/setup-prod-local.sh --skip-migrate
 ```
 
 You can also pre-seed inputs non-interactively:
@@ -77,7 +77,7 @@ AUTH0_DOMAIN="<tenant>.us.auth0.com" \
 AUTH0_CLIENT_ID="<auth0-native-app-client-id>" \
 AUTH0_ADMIN_SUBJECT="auth0|6650f0..." \
 AUTH0_ADMIN_EMAIL="you@example.com" \
-scripts/setup-prod-local.sh --force
+scripts/dev/setup-prod-local.sh --force
 ```
 
 ## Step A - Set up Auth0

--- a/internal/release-walkthrough.md
+++ b/internal/release-walkthrough.md
@@ -32,8 +32,8 @@ bash scripts/e2e-envoy.sh
 Run release packaging:
 
 ```bash
-scripts/package-release.sh
-FLOWPLANE_PACKAGE_IMAGE=1 scripts/package-release.sh
+scripts/release/package-release.sh
+FLOWPLANE_PACKAGE_IMAGE=1 scripts/release/package-release.sh
 ```
 
 Verify release artifacts:
@@ -58,7 +58,7 @@ FLOWPLANE_PACKAGE_XDS_PORT=18000 \
 FLOWPLANE_PACKAGE_CERT_PATH=/etc/flowplane/tls/tls.crt \
 FLOWPLANE_PACKAGE_KEY_PATH=/etc/flowplane/tls/tls.key \
 FLOWPLANE_PACKAGE_CA_PATH=/etc/flowplane/tls/ca.crt \
-scripts/package-release.sh
+scripts/release/package-release.sh
 ```
 
 CLI first-contact flow is documented in `docs/how-to/production-readiness.md`; the release gate references
@@ -71,8 +71,8 @@ that workflow rather than duplicating every operator command here.
       cargo-deny.
 - [ ] `internal/adversarial-surface-map.md` is green or accepted.
 - [ ] `internal/failure-mode-matrix.md` is green, with live phases covered by the manual gate evidence.
-- [ ] Release artifacts reproducible with `scripts/package-release.sh`.
-- [ ] OCI image reproducible with `FLOWPLANE_PACKAGE_IMAGE=1 scripts/package-release.sh`.
+- [ ] Release artifacts reproducible with `scripts/release/package-release.sh`.
+- [ ] OCI image reproducible with `FLOWPLANE_PACKAGE_IMAGE=1 scripts/release/package-release.sh`.
 - [ ] Operator docs complete: `docs/how-to/production-readiness.md`.
 - [ ] `REWRITE-REPORT.md` committed.
 - [ ] Accepted risks below are signed off.

--- a/internal/release/release-packaging.md
+++ b/internal/release/release-packaging.md
@@ -17,7 +17,7 @@ unpublished (`publish = false`). Public distribution is no longer license-gated.
 ## Command
 
 ```bash
-scripts/package-release.sh
+scripts/release/package-release.sh
 ```
 
 For the musl release artifact:
@@ -26,7 +26,7 @@ For the musl release artifact:
 rustup target add x86_64-unknown-linux-musl
 brew install filosottile/musl-cross/musl-cross # macOS cross-linker
 FLOWPLANE_RELEASE_TARGET=x86_64-unknown-linux-musl \
-  scripts/package-release.sh
+  scripts/release/package-release.sh
 file target/x86_64-unknown-linux-musl/release/flowplane
 ```
 
@@ -48,7 +48,7 @@ distribution no longer license-gated.)
 Build and save the OCI image with:
 
 ```bash
-FLOWPLANE_PACKAGE_IMAGE=1 scripts/package-release.sh
+FLOWPLANE_PACKAGE_IMAGE=1 scripts/release/package-release.sh
 ```
 
 The image path requires Docker or Podman with enough free builder storage.
@@ -68,7 +68,7 @@ FLOWPLANE_PACKAGE_DATAPLANE_MODE=mtls \
 FLOWPLANE_PACKAGE_CERT_PATH=/etc/flowplane/tls/tls.crt \
 FLOWPLANE_PACKAGE_KEY_PATH=/etc/flowplane/tls/tls.key \
 FLOWPLANE_PACKAGE_CA_PATH=/etc/flowplane/tls/ca.crt \
-scripts/package-release.sh
+scripts/release/package-release.sh
 ```
 
 `mtls` is the release default. For local/dev bootstrap only, pass:

--- a/scripts/ci/check-docs-boundary.py
+++ b/scripts/ci/check-docs-boundary.py
@@ -13,8 +13,8 @@ that is NOT one of the allowed carve-outs (see docs/README.md "Enforcement (CI)"
 Everything else — any internal/ link from a task page, and required-reading spec/
 links in task steps — fails.
 
-Run:  scripts/check-docs-boundary.py            # check the tree
-      scripts/check-docs-boundary.py --self-test # run the parser self-checks
+Run:  scripts/ci/check-docs-boundary.py            # check the tree
+      scripts/ci/check-docs-boundary.py --self-test # run the parser self-checks
 """
 from __future__ import annotations
 
@@ -22,7 +22,8 @@ import os
 import re
 import sys
 
-REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# scripts/ci/check-docs-boundary.py -> repo root
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 # Inline links `[text](target)`.
 LINK_RE = re.compile(r"\[[^\]]*\]\(\s*<?([^)\s>]+)>?(?:\s+[^)]*)?\)")
 # Reference definition `[label]: target` -> (label, target).

--- a/scripts/dev/setup-prod-local.sh
+++ b/scripts/dev/setup-prod-local.sh
@@ -2,7 +2,8 @@
 # Prepare a local production-mode Flowplane control plane backed by Auth0 OIDC.
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+# scripts/dev/ -> repo root
+cd "$(dirname "$0")/../.."
 
 ENV_FILE=${FLOWPLANE_PROD_LOCAL_ENV_FILE:-internal/.env.prod-local}
 DB_NAME=${FLOWPLANE_PROD_LOCAL_DB_NAME:-flowplane_prod_local}
@@ -14,7 +15,7 @@ FORCE=0
 
 usage() {
   cat <<'EOF'
-Usage: scripts/setup-prod-local.sh [options]
+Usage: scripts/dev/setup-prod-local.sh [options]
 
 Creates internal/.env.prod-local for local production-mode Auth0 testing.
 

--- a/scripts/release/package-release.sh
+++ b/scripts/release/package-release.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+# scripts/release/ -> repo root
+cd "$(dirname "$0")/../.."
 
 VERSION=${FLOWPLANE_RELEASE_VERSION:-$(cargo pkgid -p flowplane | sed 's/.*#//')}
 TARGET=${FLOWPLANE_RELEASE_TARGET:-}


### PR DESCRIPTION
## Summary

Two changes:

**1. Fixes #126 — rustup prerequisite for build-from-source.** `Cargo.lock` is lockfile v4; a distro-packaged `cargo` (e.g. `apt-get install cargo`) is too old to read it and fails before building. `rust-toolchain.toml` pins 1.94.1 but only when the build runs through rustup. Added a clear rustup prerequisite to `docs/tutorials/getting-started.md` and `README.md`. Docs-only; no code change.

**2. Organise `scripts/` into `ci/ dev/ release/`.**
- `scripts/ci/check-docs-boundary.py`
- `scripts/dev/setup-prod-local.sh`
- `scripts/release/package-release.sh`

Fixed each moved script's internal paths (`cd "$(dirname "$0")/.."` → `/../..`; the checker's `REPO_ROOT` dirname depth) and every live reference (ci.yml, docs/README, production-readiness, internal release/prod-local runbooks) plus self-referencing usage strings.

Left at `scripts/` root **by design**: `ensure-postgres.sh` (shared by the `.codex` hook and `e2e-envoy.sh`) and the whole E2E cluster (`e2e-envoy.sh`, `aws-e2e-smoke.sh`, `agent-smoke.py`, `e2e/`) — **#71** owns restructuring those into `scripts/e2e/`.

## Review

Structure conferred with Codex up front; implementation passed a Codex review gate — `VERDICT: APPROVE`, no findings. Verified: checker resolves `REPO_ROOT` from the new location, `bash -n` clean, no stale references in living files.
