### PR TITLE
feat(bootstrap): operator-supplied bootstrap token, never logged (fixes #113)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
           FLOWPLANE_DATABASE_URL: postgres://postgres:postgres@localhost:5433/flowplane_test
           FLOWPLANE_API_INSECURE: "true"
           FLOWPLANE_API_ADDR: 127.0.0.1:8080
+          # Non-dev uninitialized instance fails closed without a bootstrap token (#113); supply one
+          # so the smoke can boot (also exercises the operator-seed path).
+          FLOWPLANE_BOOTSTRAP_TOKEN: ci-smoke-bootstrap-token-0123456789abcdef
         run: |
           # Persistent runner: make sure no spawned server leaks on failure.
           trap 'kill ${SERVER_PID:-} ${TLS_PID:-} 2>/dev/null || true' EXIT

--- a/crates/flowplane/src/serve.rs
+++ b/crates/flowplane/src/serve.rs
@@ -48,15 +48,7 @@ pub async fn run() -> anyhow::Result<()> {
         .context("failed to install Prometheus metrics recorder")?;
 
     if !config.dev_mode {
-        if let Some(token) =
-            fp_storage::repos::bootstrap::issue_token_if_uninitialized(&pool).await?
-        {
-            tracing::warn!(
-                bootstrap_token = %token,
-                "instance is uninitialized — POST /api/v1/bootstrap/initialize with this \
-                 one-shot token (valid 24h, logged only once)"
-            );
-        }
+        seed_bootstrap_token(&pool, &config).await?;
     }
 
     // xDS pipeline: snapshot cache primed from the DB (restart safety), then kept fresh by
@@ -359,6 +351,120 @@ async fn setup_dev_mode(
     ))
 }
 
+/// Minimum length of an operator-supplied bootstrap token after trimming (#113). First-platform-
+/// admin authority warrants more than "non-empty".
+const MIN_BOOTSTRAP_TOKEN_LEN: usize = 32;
+
+/// An operator-supplied bootstrap token. Wraps the secret so it never reaches logs: `Debug` and
+/// `Display` redact, and it is not `Serialize`. Only `as_str()` exposes the value, for hashing.
+struct BootstrapToken(String);
+
+impl BootstrapToken {
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for BootstrapToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("BootstrapToken(<redacted>)")
+    }
+}
+
+impl std::fmt::Display for BootstrapToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("<redacted>")
+    }
+}
+
+/// Resolve the operator-supplied bootstrap token from the environment, provider-agnostically.
+/// `FLOWPLANE_BOOTSTRAP_TOKEN_FILE` (a path) takes precedence over `FLOWPLANE_BOOTSTRAP_TOKEN`.
+/// Returns `Ok(None)` when neither is set. Errors never echo the token value or the file path.
+fn resolve_operator_bootstrap_token() -> anyhow::Result<Option<BootstrapToken>> {
+    let raw = if let Some(path) = std::env::var_os("FLOWPLANE_BOOTSTRAP_TOKEN_FILE") {
+        // Deliberately do not include the path or contents in the error.
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => contents,
+            Err(_) => {
+                anyhow::bail!(
+                    "could not read the file named by FLOWPLANE_BOOTSTRAP_TOKEN_FILE \
+                     (check the path exists and is readable)"
+                )
+            }
+        }
+    } else if let Some(value) = std::env::var_os("FLOWPLANE_BOOTSTRAP_TOKEN") {
+        value.to_string_lossy().into_owned()
+    } else {
+        return Ok(None);
+    };
+
+    validate_bootstrap_token(&raw).map(Some)
+}
+
+/// Trim and length-validate a bootstrap token from any source. The error never echoes the value.
+fn validate_bootstrap_token(raw: &str) -> anyhow::Result<BootstrapToken> {
+    let trimmed = raw.trim();
+    if trimmed.len() < MIN_BOOTSTRAP_TOKEN_LEN {
+        anyhow::bail!(
+            "the supplied bootstrap token is too short; it must be at least {MIN_BOOTSTRAP_TOKEN_LEN} \
+             characters after trimming whitespace"
+        );
+    }
+    Ok(BootstrapToken(trimmed.to_string()))
+}
+
+/// Bootstrap-token handling for an uninitialized, non-dev instance (#113). The operator supplies a
+/// token (env / file) that is seeded without ever being logged; with no token the instance fails
+/// closed unless the explicit local-only opt-in re-enables the legacy generate-and-log path.
+async fn seed_bootstrap_token(pool: &sqlx::PgPool, config: &ServerConfig) -> anyhow::Result<()> {
+    use fp_storage::repos::bootstrap::{
+        is_initialized, issue_token_if_uninitialized, seed_token_hash_if_uninitialized, SeedOutcome,
+    };
+
+    // Already-initialized instances ignore the bootstrap token entirely — do not even resolve it,
+    // so a stale/unreadable token file cannot block a restart. (The seed path rechecks under the
+    // advisory lock, so this early return is only an optimization, not the correctness boundary.)
+    if is_initialized(pool).await? {
+        return Ok(());
+    }
+
+    match resolve_operator_bootstrap_token()? {
+        Some(token) => match seed_token_hash_if_uninitialized(pool, token.as_str()).await? {
+            SeedOutcome::Seeded => tracing::info!(
+                "bootstrap token accepted from the operator; POST /api/v1/bootstrap/initialize to \
+                 complete setup (token not logged)"
+            ),
+            SeedOutcome::Idempotent => tracing::info!(
+                "bootstrap token already seeded for this instance; awaiting \
+                 POST /api/v1/bootstrap/initialize"
+            ),
+            SeedOutcome::AlreadyInitialized => {}
+            SeedOutcome::Conflict => anyhow::bail!(
+                "a different bootstrap token is already active for this uninitialized instance; \
+                 supply the same operator token across all replicas"
+            ),
+        },
+        None => {
+            if config.allow_logged_bootstrap_token {
+                if let Some(token) = issue_token_if_uninitialized(pool).await? {
+                    tracing::warn!(
+                        bootstrap_token = %token,
+                        "LOCAL-ONLY: FLOWPLANE_ALLOW_LOGGED_BOOTSTRAP_TOKEN is set — generated and \
+                         logged a one-shot bootstrap token (valid 24h). Do not use in production."
+                    );
+                }
+            } else if !is_initialized(pool).await? {
+                anyhow::bail!(
+                    "instance is uninitialized and no bootstrap token was supplied; set \
+                     FLOWPLANE_BOOTSTRAP_TOKEN or FLOWPLANE_BOOTSTRAP_TOKEN_FILE (or, for local use \
+                     only, FLOWPLANE_ALLOW_LOGGED_BOOTSTRAP_TOKEN=yes-this-is-local-only)"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
 fn load_config() -> anyhow::Result<ServerConfig> {
     ServerConfig::load().map_err(|e| {
         // Render the config error with its hint — the operator's first contact with our
@@ -464,4 +570,46 @@ async fn shutdown_signal() {
     }
     #[cfg(not(unix))]
     ctrl_c.await;
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod bootstrap_token_tests {
+    use super::*;
+
+    #[test]
+    fn rejects_short_or_blank_tokens() {
+        assert!(validate_bootstrap_token("").is_err(), "empty");
+        assert!(
+            validate_bootstrap_token("   \n").is_err(),
+            "whitespace only"
+        );
+        assert!(validate_bootstrap_token("short").is_err(), "too short");
+        assert!(
+            validate_bootstrap_token(&"x".repeat(31)).is_err(),
+            "31 chars"
+        );
+    }
+
+    #[test]
+    fn accepts_and_trims_valid_token() {
+        let t = validate_bootstrap_token("  abcdefghijklmnopqrstuvwxyz012345  ").expect("valid");
+        assert_eq!(t.as_str(), "abcdefghijklmnopqrstuvwxyz012345");
+        assert_eq!(t.as_str().len(), 32);
+    }
+
+    #[test]
+    fn token_never_renders_its_value() {
+        let secret = "abcdefghijklmnopqrstuvwxyz012345";
+        let t = validate_bootstrap_token(secret).expect("valid");
+        assert!(!format!("{t:?}").contains(secret), "Debug must redact");
+        assert!(!format!("{t}").contains(secret), "Display must redact");
+    }
+
+    #[test]
+    fn error_messages_do_not_echo_the_value() {
+        let secret = "supersecretbutslightlytooshort"; // 30 chars
+        let err = validate_bootstrap_token(secret).unwrap_err().to_string();
+        assert!(!err.contains(secret), "error must not echo the token");
+    }
 }

--- a/crates/fp-api/src/routes.rs
+++ b/crates/fp-api/src/routes.rs
@@ -439,7 +439,9 @@ async fn bootstrap_initialize(
                     fp_domain::ErrorCode::Unauthorized,
                     "missing bootstrap token",
                 )
-                .with_hint("pass the boot-logged token as: Authorization: Bearer fpboot_…"),
+                .with_hint(
+                    "pass the operator-supplied bootstrap token as: Authorization: Bearer <token>",
+                ),
                 rid,
             )
         })?;

--- a/crates/fp-core/src/config.rs
+++ b/crates/fp-core/src/config.rs
@@ -45,6 +45,10 @@ pub struct ServerConfig {
     pub oidc: Option<OidcSettings>,
     /// Per-tenant mutating-request budget per minute (spec/10 §4a).
     pub tenant_write_limit_per_minute: u32,
+    /// Local-only opt-in (#113): when true, an uninitialized non-dev instance with no
+    /// operator-supplied bootstrap token falls back to generating one and logging it. Enabled
+    /// only by the exact value `yes-this-is-local-only`; otherwise the instance fails closed.
+    pub allow_logged_bootstrap_token: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -298,6 +302,10 @@ impl ServerConfig {
             .with_hint("dev mode brings its own in-process issuer"));
         }
 
+        // Only the exact opt-in value re-enables the legacy generate-and-log path (#113).
+        let allow_logged_bootstrap_token =
+            get("FLOWPLANE_ALLOW_LOGGED_BOOTSTRAP_TOKEN") == Some("yes-this-is-local-only");
+
         Ok(Self {
             api_addr,
             xds_addr,
@@ -312,6 +320,7 @@ impl ServerConfig {
             dev_mode,
             oidc,
             tenant_write_limit_per_minute,
+            allow_logged_bootstrap_token,
         })
     }
 }

--- a/crates/fp-storage/migrations/0029_bootstrap_token_operator_seeded.sql
+++ b/crates/fp-storage/migrations/0029_bootstrap_token_operator_seeded.sql
@@ -1,0 +1,6 @@
+-- #113: distinguish operator-supplied (seeded) bootstrap tokens from legacy generate-and-log
+-- tokens. A successful operator seed invalidates prior unused *legacy* tokens, while a different
+-- live *operator-seeded* token across replicas must fail closed rather than be clobbered. The
+-- row data alone (hash/expiry/used) cannot tell the two apart, so we persist the provenance.
+ALTER TABLE bootstrap_tokens
+    ADD COLUMN operator_seeded BOOLEAN NOT NULL DEFAULT false;

--- a/crates/fp-storage/src/repos/bootstrap.rs
+++ b/crates/fp-storage/src/repos/bootstrap.rs
@@ -1,10 +1,15 @@
 //! One-shot bootstrap (spec/08a §2.2.10): first-boot token → platform org + first admin.
 //!
-//! Flow: an uninitialized server generates a token at boot, stores only its SHA-256 hash
-//! (24 h expiry), and logs the plaintext once. The operator calls
-//! `POST /api/v1/bootstrap/initialize` with it; in ONE transaction the platform org is
-//! created and marked, the admin user is provisioned for their OIDC subject, the owner
-//! membership lands, the token is consumed, and the audit row commits. Replays fail closed.
+//! Flow: the operator supplies a bootstrap token to an uninitialized server (env / file); the
+//! server stores only its SHA-256 hash (24 h expiry) and **never logs the plaintext** (#113).
+//! The operator calls `POST /api/v1/bootstrap/initialize` with it; in ONE transaction the
+//! platform org is created and marked, the admin user is provisioned for their OIDC subject, the
+//! owner membership lands, the token is consumed, and the audit row commits. Replays fail closed.
+//!
+//! A legacy generate-and-log path (`issue_token_if_uninitialized`) remains available only behind
+//! an explicit local-only opt-in; `operator_seeded` on `bootstrap_tokens` records which path a
+//! token came from so an operator seed can invalidate prior unused legacy tokens while a
+//! divergent live operator token across replicas fails closed.
 
 use crate::repos::audit::{ActorType, AuditEntry, Outcome, Surface};
 use fp_domain::{DomainError, DomainResult, ErrorCode, OrgId, RequestId, UserId};
@@ -31,9 +36,11 @@ pub async fn is_initialized(pool: &PgPool) -> DomainResult<bool> {
     Ok(marker.is_some())
 }
 
-/// Generate a fresh bootstrap token if (and only if) the instance is uninitialized.
-/// Called at boot; the plaintext is returned exactly once for logging. Prior unused tokens
-/// from earlier boots remain valid until expiry (their plaintext is in the earlier logs).
+/// LEGACY, local-only: generate a fresh bootstrap token if (and only if) the instance is
+/// uninitialized, returning the plaintext once for logging. This path leaks the token to logs and
+/// is gated behind an explicit opt-in (`FLOWPLANE_ALLOW_LOGGED_BOOTSTRAP_TOKEN`); production seeds
+/// the token with [`seed_token_hash_if_uninitialized`] instead. The generated row is marked
+/// `operator_seeded = false` so a later operator seed can invalidate it.
 pub async fn issue_token_if_uninitialized(pool: &PgPool) -> DomainResult<Option<String>> {
     if is_initialized(pool).await? {
         return Ok(None);
@@ -44,8 +51,8 @@ pub async fn issue_token_if_uninitialized(pool: &PgPool) -> DomainResult<Option<
         Uuid::new_v4().simple()
     );
     sqlx::query(
-        "INSERT INTO bootstrap_tokens (id, token_hash, expires_at) \
-         VALUES ($1, $2, now() + interval '24 hours')",
+        "INSERT INTO bootstrap_tokens (id, token_hash, expires_at, operator_seeded) \
+         VALUES ($1, $2, now() + interval '24 hours', false)",
     )
     .bind(Uuid::now_v7())
     .bind(hash_token(&token))
@@ -53,6 +60,120 @@ pub async fn issue_token_if_uninitialized(pool: &PgPool) -> DomainResult<Option<
     .await
     .map_err(|e| DomainError::internal(format!("issue bootstrap token: {e}")))?;
     Ok(Some(token))
+}
+
+/// Outcome of [`seed_token_hash_if_uninitialized`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeedOutcome {
+    /// The operator token's hash was newly seeded.
+    Seeded,
+    /// This exact token is already the live seed (same token across replicas / re-run). No-op.
+    Idempotent,
+    /// The instance is already initialized; nothing to seed.
+    AlreadyInitialized,
+    /// A *different* live operator-seeded token already exists — divergent replica configuration.
+    /// Fail closed; the existing token is left untouched.
+    Conflict,
+}
+
+/// Seed the SHA-256 hash of an **operator-supplied** bootstrap token when the instance is
+/// uninitialized — the plaintext is never logged (#113). Serialized with [`initialize`] via the
+/// same advisory lock so seeds and the consuming initialize cannot interleave across replicas.
+///
+/// Semantics (locked in #113):
+/// - already initialized → [`SeedOutcome::AlreadyInitialized`] (no row written);
+/// - same token already live → [`SeedOutcome::Idempotent`];
+/// - a *different* live operator-seeded token exists → [`SeedOutcome::Conflict`] (fail closed,
+///   never clobber a peer replica's token);
+/// - otherwise invalidate prior unused **legacy** tokens (`operator_seeded = false`) and seed ours
+///   → [`SeedOutcome::Seeded`].
+pub async fn seed_token_hash_if_uninitialized(
+    pool: &PgPool,
+    token: &str,
+) -> DomainResult<SeedOutcome> {
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| DomainError::internal(format!("bootstrap seed: begin: {e}")))?;
+
+    // Same advisory lock as `initialize`: seed and initialize mutate the same trust boundary, so
+    // they must serialize across all connections/replicas.
+    sqlx::query("SELECT pg_advisory_xact_lock($1)")
+        .bind(BOOTSTRAP_LOCK_KEY)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| DomainError::internal(format!("bootstrap seed: lock: {e}")))?;
+
+    let initialized: Option<String> =
+        sqlx::query_scalar("SELECT value FROM instance_meta WHERE key = 'platform_org_id'")
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| DomainError::internal(format!("bootstrap seed: check init: {e}")))?;
+    if initialized.is_some() {
+        return Ok(SeedOutcome::AlreadyInitialized);
+    }
+
+    let h = hash_token(token);
+
+    // This exact token is already live AND operator-seeded → idempotent (same operator token across
+    // replicas / re-run). A same-hash *legacy* row is intentionally excluded so it falls through to
+    // the invalidate-and-promote path below and becomes operator-seeded.
+    let mine_live: Option<i32> = sqlx::query_scalar(
+        "SELECT 1 FROM bootstrap_tokens \
+         WHERE token_hash = $1 AND used_at IS NULL AND expires_at > now() AND operator_seeded = true",
+    )
+    .bind(&h)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| DomainError::internal(format!("bootstrap seed: probe self: {e}")))?;
+    if mine_live.is_some() {
+        tx.commit()
+            .await
+            .map_err(|e| DomainError::internal(format!("bootstrap seed: commit: {e}")))?;
+        return Ok(SeedOutcome::Idempotent);
+    }
+
+    // A different live *operator-seeded* token → divergent replica config. Fail closed; do not
+    // invalidate it. (Legacy `operator_seeded = false` tokens do not trigger this.)
+    let peer: Option<i32> = sqlx::query_scalar(
+        "SELECT 1 FROM bootstrap_tokens \
+         WHERE token_hash <> $1 AND used_at IS NULL AND expires_at > now() \
+           AND operator_seeded = true LIMIT 1",
+    )
+    .bind(&h)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| DomainError::internal(format!("bootstrap seed: probe peers: {e}")))?;
+    if peer.is_some() {
+        return Ok(SeedOutcome::Conflict); // tx rolls back on drop
+    }
+
+    // Invalidate prior unused LEGACY tokens (generate-and-log boots), then seed ours.
+    sqlx::query(
+        "UPDATE bootstrap_tokens SET used_at = now() \
+         WHERE used_at IS NULL AND operator_seeded = false",
+    )
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| DomainError::internal(format!("bootstrap seed: invalidate legacy: {e}")))?;
+
+    // Insert (or refresh an expired same-hash row) as the live operator seed.
+    sqlx::query(
+        "INSERT INTO bootstrap_tokens (id, token_hash, expires_at, operator_seeded) \
+         VALUES ($1, $2, now() + interval '24 hours', true) \
+         ON CONFLICT (token_hash) DO UPDATE \
+            SET used_at = NULL, expires_at = now() + interval '24 hours', operator_seeded = true",
+    )
+    .bind(Uuid::now_v7())
+    .bind(&h)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| DomainError::internal(format!("bootstrap seed: insert: {e}")))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| DomainError::internal(format!("bootstrap seed: commit: {e}")))?;
+    Ok(SeedOutcome::Seeded)
 }
 
 /// Consume a bootstrap token and initialize the platform: platform org + first admin.
@@ -72,7 +193,7 @@ pub async fn initialize(
             ErrorCode::Unauthorized,
             "invalid, expired, or used bootstrap token",
         )
-        .with_hint("restart the server to issue a fresh token (logged once at boot)")
+        .with_hint("supply a valid bootstrap token to an uninitialized instance and retry")
     };
 
     let mut tx = pool
@@ -369,6 +490,161 @@ mod tests {
             .execute(&pool)
             .await
             .expect("clean");
+        sqlx::query("SELECT pg_advisory_unlock(420001)")
+            .execute(&pool)
+            .await
+            .expect("unlock");
+    }
+
+    #[tokio::test]
+    async fn operator_seed_semantics() {
+        let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+            eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+            return;
+        };
+        let pool = crate::connect(&url, 4).await.expect("connect");
+        crate::migrate(&pool).await.expect("migrate");
+
+        // Owns instance-level state; serialize against parallel siblings and start from a clean slate.
+        sqlx::query("SELECT pg_advisory_lock(420001)")
+            .execute(&pool)
+            .await
+            .expect("lock");
+        let clean = |pool: PgPool| async move {
+            sqlx::query("DELETE FROM instance_meta WHERE key = 'platform_org_id'")
+                .execute(&pool)
+                .await
+                .expect("clean meta");
+            sqlx::query("DELETE FROM bootstrap_tokens")
+                .execute(&pool)
+                .await
+                .expect("clean tokens");
+        };
+        clean(pool.clone()).await;
+
+        let live_count = |pool: PgPool, operator: bool| async move {
+            let n: i64 = sqlx::query_scalar(
+                "SELECT count(*) FROM bootstrap_tokens \
+                 WHERE used_at IS NULL AND expires_at > now() AND operator_seeded = $1",
+            )
+            .bind(operator)
+            .fetch_one(&pool)
+            .await
+            .expect("count");
+            n
+        };
+
+        let t1 = "operator-token-aaaaaaaaaaaaaaaaaaaaaaaa"; // >= 32 chars
+        let t2 = "operator-token-bbbbbbbbbbbbbbbbbbbbbbbb";
+
+        // Fresh seed.
+        assert_eq!(
+            seed_token_hash_if_uninitialized(&pool, t1)
+                .await
+                .expect("seed"),
+            SeedOutcome::Seeded
+        );
+        assert_eq!(
+            live_count(pool.clone(), true).await,
+            1,
+            "one live operator token"
+        );
+
+        // Same token again → idempotent, still exactly one live row.
+        assert_eq!(
+            seed_token_hash_if_uninitialized(&pool, t1)
+                .await
+                .expect("seed"),
+            SeedOutcome::Idempotent
+        );
+        assert_eq!(live_count(pool.clone(), true).await, 1);
+
+        // A different live operator token → fail closed; t1 untouched.
+        assert_eq!(
+            seed_token_hash_if_uninitialized(&pool, t2)
+                .await
+                .expect("seed"),
+            SeedOutcome::Conflict
+        );
+        assert_eq!(
+            live_count(pool.clone(), true).await,
+            1,
+            "conflict must not clobber t1"
+        );
+
+        // Invalidate prior unused LEGACY token on a successful operator seed.
+        clean(pool.clone()).await;
+        let legacy = issue_token_if_uninitialized(&pool)
+            .await
+            .expect("issue legacy")
+            .expect("uninitialized");
+        assert!(legacy.starts_with("fpboot_"));
+        assert_eq!(
+            live_count(pool.clone(), false).await,
+            1,
+            "legacy token live"
+        );
+        assert_eq!(
+            seed_token_hash_if_uninitialized(&pool, t1)
+                .await
+                .expect("seed"),
+            SeedOutcome::Seeded
+        );
+        assert_eq!(
+            live_count(pool.clone(), false).await,
+            0,
+            "legacy invalidated"
+        );
+        assert_eq!(
+            live_count(pool.clone(), true).await,
+            1,
+            "operator token live"
+        );
+
+        // Supplying the live LEGACY token itself as the operator token promotes it: Seeded, and the
+        // row becomes operator_seeded = true (so a later divergent peer fails closed, not clobbers).
+        clean(pool.clone()).await;
+        let legacy = issue_token_if_uninitialized(&pool)
+            .await
+            .expect("issue legacy")
+            .expect("uninitialized");
+        assert_eq!(
+            seed_token_hash_if_uninitialized(&pool, &legacy)
+                .await
+                .expect("seed"),
+            SeedOutcome::Seeded
+        );
+        assert_eq!(
+            live_count(pool.clone(), false).await,
+            0,
+            "no legacy row remains"
+        );
+        assert_eq!(
+            live_count(pool.clone(), true).await,
+            1,
+            "promoted to operator-seeded"
+        );
+
+        // Already initialized → no-op, no new token row.
+        clean(pool.clone()).await;
+        sqlx::query("INSERT INTO instance_meta (key, value) VALUES ('platform_org_id', $1)")
+            .bind(Uuid::now_v7().to_string())
+            .execute(&pool)
+            .await
+            .expect("mark initialized");
+        assert_eq!(
+            seed_token_hash_if_uninitialized(&pool, t1)
+                .await
+                .expect("seed"),
+            SeedOutcome::AlreadyInitialized
+        );
+        assert_eq!(
+            live_count(pool.clone(), true).await,
+            0,
+            "no token seeded once initialized"
+        );
+
+        clean(pool.clone()).await;
         sqlx::query("SELECT pg_advisory_unlock(420001)")
             .execute(&pool)
             .await

--- a/docs/concepts/tenancy-grants-xds.md
+++ b/docs/concepts/tenancy-grants-xds.md
@@ -2,10 +2,7 @@
 
 > Audience: operators, platform-engineers · Status: stable
 
-This page explains the three ideas you need to hold in your head to operate
-Flowplane confidently: how tenants are isolated, how access is decided, and why
-the Envoy configuration Flowplane produces is predictable. It is
-understanding-oriented — it argues *why* the system is shaped this way and links
+This page explains the three ideas you need to hold in your head to operate Flowplane confidently: how tenants are isolated, how access is decided, and why the Envoy configuration Flowplane produces is predictable. It is understanding-oriented — it argues *why* the system is shaped this way and links
 out for the exhaustive detail. For the authoritative decision tables and threat
 model see [spec/08a — Security & Tenancy](../../spec/08a-security-and-tenancy.md)
 and [spec/05 — Auth](../../spec/05-auth.md); for the xDS subsystem see

--- a/docs/how-to/bootstrap-platform.md
+++ b/docs/how-to/bootstrap-platform.md
@@ -1,0 +1,86 @@
+# How-to: bootstrap the first platform admin
+
+> Audience: operators · Status: stable
+
+A fresh, non-dev Flowplane control plane starts **uninitialized**: it has no platform
+organization and no admin. You initialize it once, with a one-shot **bootstrap token** that you
+supply — the control plane never generates or logs it.
+
+This page is self-contained: every value you need is here.
+
+## 1. Choose a bootstrap token
+
+Pick a high-entropy secret, **at least 32 characters**. For example:
+
+```bash
+openssl rand -hex 32        # 64 hex chars — fine
+```
+
+Keep it where only operators can read it. You will hand it to the control plane and then use it
+once against the API.
+
+## 2. Supply the token to the control plane
+
+Provide it by **either** of these, before `flowplane serve` starts. The control plane stores only
+its SHA-256 hash and never writes the token to logs.
+
+- A file (preferred — safer than env, which is visible via process inspection):
+
+  ```bash
+  printf '%s' "$BOOTSTRAP_TOKEN" > /run/flowplane/bootstrap-token   # tmpfs, mode 0600
+  export FLOWPLANE_BOOTSTRAP_TOKEN_FILE=/run/flowplane/bootstrap-token
+  ```
+
+- Or directly in the environment:
+
+  ```bash
+  export FLOWPLANE_BOOTSTRAP_TOKEN="<your-32+-char-token>"
+  ```
+
+`FLOWPLANE_BOOTSTRAP_TOKEN_FILE` takes precedence if both are set. Supply the **same** token to
+every replica; a different live token on another replica makes startup fail closed.
+
+Then start the server normally (`flowplane serve`). On an uninitialized instance it seeds the
+token's hash and logs a confirmation **without** the value. If the instance is already initialized,
+the token is ignored.
+
+> **Fail-closed:** an uninitialized, non-dev instance started with **no** token refuses to start.
+> This is deliberate — it prevents a misconfigured production instance from silently generating and
+> logging a token. (For local experimentation only, `FLOWPLANE_ALLOW_LOGGED_BOOTSTRAP_TOKEN=yes-this-is-local-only`
+> restores the old generate-and-log behavior; never use it in production.)
+
+## 3. Initialize the platform
+
+Call the public bootstrap endpoint once, passing the token as a bearer credential. `admin_subject`
+is the OIDC `sub` of your first admin (the identity your IdP will assert):
+
+```bash
+curl -fsS -X POST https://<control-plane>/api/v1/bootstrap/initialize \
+  -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "org_name": "platform",
+        "org_display_name": "Platform",
+        "admin_subject": "<oidc-sub-of-first-admin>",
+        "admin_email": "admin@example.com"
+      }'
+```
+
+A success response returns the new `org_id` and `admin_user_id`. The token is now consumed
+(single-use, 24-hour expiry); a replay returns `401`/`409`.
+
+## 4. Verify
+
+- Re-running the same `POST /api/v1/bootstrap/initialize` returns a conflict — the instance is
+  initialized.
+- Your admin can now authenticate through your OIDC issuer and reach authenticated endpoints.
+
+## Troubleshooting
+
+- **Server won't start, "no bootstrap token was supplied":** the instance is uninitialized and you
+  set neither `FLOWPLANE_BOOTSTRAP_TOKEN` nor `FLOWPLANE_BOOTSTRAP_TOKEN_FILE`. Set one and restart.
+- **Server won't start, "a different bootstrap token is already active":** another replica was
+  given a different token. Use one identical token across all replicas.
+- **"token is too short":** the token must be ≥ 32 characters after trimming whitespace.
+- **`401` on initialize:** the token is wrong, expired (24 h), or already used. Restart an
+  uninitialized instance with a fresh token, or confirm you are sending the exact value you seeded.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -33,6 +33,9 @@ Booleans accept `true`/`1`/`yes` and `false`/`0`/`no`. Invalid server values fai
 | `FLOWPLANE_OTLP_ENDPOINT` | server | — | no | OTLP trace export endpoint; unset disables export. |
 | `FLOWPLANE_DEV_MODE` | server | `false` | no ⁴ | In-process OIDC issuer + seeded resources; needs the `dev-oidc` build feature. |
 | `FLOWPLANE_DEV_MODE_ACK` | server | — | no ⁴ | In release builds, dev mode requires this to equal `yes-this-is-not-production`. |
+| `FLOWPLANE_BOOTSTRAP_TOKEN` | server | — | first boot ¹³ | Operator-supplied one-shot bootstrap token (≥ 32 chars after trimming). Seeds first-admin setup; the value is never logged. |
+| `FLOWPLANE_BOOTSTRAP_TOKEN_FILE` | server | — | first boot ¹³ | Path to read the bootstrap token from; **takes precedence** over `FLOWPLANE_BOOTSTRAP_TOKEN`. File delivery is safer than env. |
+| `FLOWPLANE_ALLOW_LOGGED_BOOTSTRAP_TOKEN` | server | — | no | Local-only escape hatch: the exact value `yes-this-is-local-only` re-enables generating and **logging** a token. Never set in production. |
 | `FLOWPLANE_OIDC_AUDIENCE` | server | — | no ⁵ | Expected JWT `aud` claim. |
 | `FLOWPLANE_OIDC_JWKS_URI` | server | — | no | JWKS endpoint override (optional even with OIDC set). |
 | `FLOWPLANE_TENANT_WRITE_LIMIT_PER_MIN` | server | `120` | no | Per-tenant mutating-request budget per minute; must be ≥ 1. |
@@ -85,6 +88,7 @@ encrypt/decrypt/snapshot paths run (not at server startup). A violation yields a
 | ¹⁰ | `FLOWPLANE_AGENT_CP_ENDPOINT` | Plaintext (`http`/non-`https`) allowed only for loopback hosts; non-loopback requires agent TLS (⁶). |
 | ¹¹ | `FLOWPLANE_AGENT_POLL_INTERVAL_SECS` | Coerced to a minimum of 1 second. |
 | ¹² | `FLOWPLANE_AGENT_QUEUE_CAP` | Clamped to `1..=16384`. |
+| ¹³ | `FLOWPLANE_BOOTSTRAP_TOKEN`, `FLOWPLANE_BOOTSTRAP_TOKEN_FILE` | Required on the **first** boot of an uninitialized, non-dev instance: with no token (and without the `yes-this-is-local-only` opt-in) the server **fails closed** and does not start. Already-initialized instances ignore these. Supply the **same** token to every replica. See [How-to: bootstrap the first admin](../how-to/bootstrap-platform.md). |
 
 ## TOML config file keys (server)
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -29,7 +29,7 @@ A missing or unparseable bearer token yields `401`. Authentication failures are 
 
 Two endpoints sit outside the secured surface and do **not** use the global Bearer scheme:
 
-- `POST /api/v1/bootstrap/initialize` is guarded by the one-shot bootstrap token (`Authorization: Bearer fpboot_…`).
+- `POST /api/v1/bootstrap/initialize` is guarded by the one-shot, operator-supplied bootstrap token (`Authorization: Bearer <token>`). See [How-to: bootstrap the first platform admin](../how-to/bootstrap-platform.md).
 - `GET /api/v1/bootstrap/status`, `/healthz`, `/readyz`, `/metrics`, and `/api-docs/openapi.json` are public.
 
 ### Active-org selector (`X-Flowplane-Org`)


### PR DESCRIPTION
## Summary

Fixes #113. The one-shot bootstrap token was generated on the production path and **logged in plaintext** (`serve.rs warn!(bootstrap_token = %token)`), readable by anyone with log access. This inverts the flow: the operator supplies the token and it is **never emitted**.

## Control plane (non-dev, uninitialized)

- Token from `FLOWPLANE_BOOTSTRAP_TOKEN` or `FLOWPLANE_BOOTSTRAP_TOKEN_FILE` (`_FILE` precedence; safer than env). Trimmed, **≥ 32 chars**; errors never echo the value or path. A redacting `BootstrapToken` newtype keeps it out of `Debug`/logs.
- `seed_token_hash_if_uninitialized` stores only the SHA-256 hash and logs nothing about the value. Under the existing advisory lock: same token → idempotent; a **different live operator-seeded token → fail closed** (never clobbers a peer); prior unused **legacy** tokens invalidated; a supplied legacy token is **promoted**.
- No token (and not the explicit opt-in) → **fail closed** (refuse to start). Already initialized → clean no-op (token not even resolved).
- Legacy generate-and-log path remains only behind `FLOWPLANE_ALLOW_LOGGED_BOOTSTRAP_TOKEN=yes-this-is-local-only` (exact value).

## Schema

Migration `0029` adds `bootstrap_tokens.operator_seeded` (provenance). A legacy log-leaked token and a peer replica's operator token are otherwise indistinguishable; the flag lets an operator seed invalidate legacy tokens while divergent operator tokens fail closed. Backward compatible (existing rows → `false` = legacy).

## Docs

`docs/reference/configuration.md` (the three env vars + fail-closed footnote) and a new `docs/how-to/bootstrap-platform.md` (supply token → start → `POST /bootstrap/initialize` → verify). Slotted by the #116 taxonomy.

## Tests

Seed semantics (seeded / idempotent / conflict / already-initialized / invalidate-legacy / promote-legacy) and token validation + redaction (Debug/Display/error never echo the value).

## Review

Codex reviewed the **design** (APPROVE — chose the `operator_seeded` column over no-schema options) and the **code** (APPROVE after one round: idempotent-probe legacy promotion, early already-initialized return, stale hint). No plaintext-leak path found on the operator path.
