### PR TITLE
docs: unwrap hard-wrapped prose so it renders as flowing text

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,17 +2,13 @@
 
 > Audience: end users (operators, platform engineers, API teams) · Status: stable
 
-This directory is **user-facing product documentation only**. Everything here is
-written for people *using* Flowplane, and every page **stands alone** — you never
-need to read `spec/` or `internal/` to follow a doc here.
+This directory is **user-facing product documentation only**. Everything here is written for people *using* Flowplane, and every page **stands alone** — you never need to read `spec/` or `internal/` to follow a doc here.
 
-For engineering design records, decisions, progress, and release evidence, see
-[`../internal/README.md`](../internal/README.md) and `../spec/`.
+For engineering design records, decisions, progress, and release evidence, see [`../internal/README.md`](../internal/README.md) and `../spec/`.
 
 ## Structure (Diátaxis)
 
-The primary axis is **Diátaxis mode**, not audience. Audience and status are
-per-document metadata (a header banner), not directories.
+The primary axis is **Diátaxis mode**, not audience. Audience and status are per-document metadata (a header banner), not directories.
 
 | Directory | Mode | What it holds |
 |-----------|------|---------------|
@@ -23,38 +19,25 @@ per-document metadata (a header banner), not directories.
 
 ## Cardinal rule
 
-**User docs must stand alone.** The test is *completability*: a reader must be able
-to finish a tutorial, how-to, or reference page — every step, every required value —
-**without opening `spec/` or `internal/`**. A page may be *derived* from `spec/`, but
-the spec must never be required reading to succeed.
+**User docs must stand alone.** The test is *completability*: a reader must be able to finish a tutorial, how-to, or reference page — every step, every required value — **without opening `spec/` or `internal/`**. A page may be *derived* from `spec/`, but the spec must never be required reading to succeed.
 
 What this allows and forbids:
 
 - ✅ Internal docs may link *into* `docs/`.
-- ✅ **Optional** "Further reading" / design-reference links into `spec/` are fine,
-  as long as they are clearly marked optional and the task is complete without them.
-  Put them under a `## Further reading` (or "Design references") heading, or label
-  them inline as optional background.
-- ✅ `concepts/` (explanation) pages may cite `spec/` freely — by design they are a
-  bridge into the design records (see #112). They still must not pull in `internal/`.
-- ❌ No page may make a `spec/` or `internal/` link **required reading** — i.e. a step
-  the reader must follow to complete the task.
-- ❌ No page may depend on an `internal/` artifact in a task step (e.g.
-  `source internal/.env...`); inline a self-contained example instead.
+- ✅ **Optional** "Further reading" / design-reference links into `spec/` are fine, as long as they are clearly marked optional and the task is complete without them. Put them under a `## Further reading` (or "Design references") heading, or label them inline as optional background.
+- ✅ `concepts/` (explanation) pages may cite `spec/` freely — by design they are a bridge into the design records (see #112). They still must not pull in `internal/`.
+- ❌ No page may make a `spec/` or `internal/` link **required reading** — i.e. a step the reader must follow to complete the task.
+- ❌ No page may depend on an `internal/` artifact in a task step (e.g. `source internal/.env...`); inline a self-contained example instead.
 
 ### Enforcement (CI)
 
-A CI check lists every `docs/**/*.md` link into `../internal/` or `../spec/` and
-fails on the ones that are **not** allowed. Allowed:
+A CI check lists every `docs/**/*.md` link into `../internal/` or `../spec/` and fails on the ones that are **not** allowed. Allowed:
 
-1. `docs/README.md` (this index) and links to a *bucket index*
-   (`../internal/README.md`, `../spec/README.md`).
+1. `docs/README.md` (this index) and links to a *bucket index* (`../internal/README.md`, `../spec/README.md`).
 2. Any link from a `docs/concepts/` page into `../spec/` (explanation bridge).
-3. Links into `../spec/` that sit under a `## Further reading` / "Design references"
-   heading (optional background).
+3. Links into `../spec/` that sit under a `## Further reading` / "Design references" heading (optional background).
 
-Everything else — required-reading spec links in task steps, and **any** link into
-`../internal/` from a task page — fails the check.
+Everything else — required-reading spec links in task steps, and **any** link into `../internal/` from a task page — fails the check.
 
 Tracked in #116, #118.
 
@@ -66,26 +49,20 @@ Every page starts with one metadata line:
 > Audience: operators · Status: stable
 ```
 
-Use `Audience:` (operators / platform-engineers / api-teams / newcomers) and
-`Status:` (stable / draft).
+Use `Audience:` (operators / platform-engineers / api-teams / newcomers) and `Status:` (stable / draft).
 
 ## Source-of-truth policy
 
 - **Implementation truth** → code + tests.
-- **User/operator truth** → the single canonical page for that task (e.g. one
-  bootstrap how-to, one configuration reference). Do not restate it elsewhere.
-- **Deployment examples** (AWS, later k8s/systemd) → platform-specific *delivery*
-  only; they **link** to the canonical how-to/reference instead of duplicating it.
+- **User/operator truth** → the single canonical page for that task (e.g. one bootstrap how-to, one configuration reference). Do not restate it elsewhere.
+- **Deployment examples** (AWS, later k8s/systemd) → platform-specific *delivery* only; they **link** to the canonical how-to/reference instead of duplicating it.
 - **Design rationale** → `spec/` + issues (linked, not inlined).
 
-When behavior changes: update the one canonical user page plus any deployment
-example whose exact commands would otherwise be wrong. Do not sprinkle the change
-across every file.
+When behavior changes: update the one canonical user page plus any deployment example whose exact commands would otherwise be wrong. Do not sprinkle the change across every file.
 
 ## Migration status
 
-The Diátaxis directories are populated by epic #100 (sub-issues #101–#112). The
-existing operator docs have been reclassified (#116):
+The Diátaxis directories are populated by epic #100 (sub-issues #101–#112). The existing operator docs have been reclassified (#116):
 
 | Old path | New location | Class |
 |----------|--------------|-------|
@@ -97,5 +74,4 @@ existing operator docs have been reclassified (#116):
 | `docs/adversarial-surface-map.md` | `../internal/adversarial-surface-map.md` | internal (evidence) |
 | `docs/release-packaging.md` | `../internal/release/release-packaging.md` | internal |
 
-The boundary is enforced in CI by `scripts/ci/check-docs-boundary.py` (see
-[Enforcement (CI)](#enforcement-ci)).
+The boundary is enforced in CI by `scripts/ci/check-docs-boundary.py` (see [Enforcement (CI)](#enforcement-ci)).

--- a/docs/concepts/tenancy-grants-xds.md
+++ b/docs/concepts/tenancy-grants-xds.md
@@ -2,150 +2,41 @@
 
 > Audience: operators, platform-engineers · Status: stable
 
-This page explains the three ideas you need to hold in your head to operate Flowplane confidently: how tenants are isolated, how access is decided, and why the Envoy configuration Flowplane produces is predictable. It is understanding-oriented — it argues *why* the system is shaped this way and links
-out for the exhaustive detail. For the authoritative decision tables and threat
-model see [spec/08a — Security & Tenancy](../../spec/08a-security-and-tenancy.md)
-and [spec/05 — Auth](../../spec/05-auth.md); for the xDS subsystem see
-[spec/04 — xDS](../../spec/04-xds.md). Error shapes referenced below are catalogued
-in [reference/errors.md](../reference/errors.md).
+This page explains the three ideas you need to hold in your head to operate Flowplane confidently: how tenants are isolated, how access is decided, and why the Envoy configuration Flowplane produces is predictable. It is understanding-oriented — it argues *why* the system is shaped this way and links out for the exhaustive detail. For the authoritative decision tables and threat model see [spec/08a — Security & Tenancy](../../spec/08a-security-and-tenancy.md) and [spec/05 — Auth](../../spec/05-auth.md); for the xDS subsystem see [spec/04 — xDS](../../spec/04-xds.md). Error shapes referenced below are catalogued in [reference/errors.md](../reference/errors.md).
 
 ## 1. Multi-tenancy: every query names whose data it touches
 
-Flowplane is multi-tenant by construction. Tenancy has two levels:
-**organizations** own **teams**, and teams own the gateway resources (clusters,
-routes, listeners, secrets, and the rest). A team is the unit of isolation — it
-is what a dataplane's configuration is built from, and what almost every access
-check is scoped to.
+Flowplane is multi-tenant by construction. Tenancy has two levels: **organizations** own **teams**, and teams own the gateway resources (clusters, routes, listeners, secrets, and the rest). A team is the unit of isolation — it is what a dataplane's configuration is built from, and what almost every access check is scoped to.
 
-The load-bearing idea is that **a tenant query always says which team's data you
-mean.** Many repository methods take a team id directly; where a query could span
-tenants it instead takes a `TeamScope`, a type with exactly two shapes:
-`TeamScope::Team(team_id)`, which pushes the team predicate into the SQL itself,
-and `TeamScope::PlatformAdmin { reason }`, an explicit, greppable, audit-carrying
-admission that a query deliberately crosses tenants. There is no "just give me the
-rows regardless of tenant" variant. This matters because
-the classic multi-tenant failure mode is a handler that forgets to add the tenant
-filter; here that handler simply cannot be written — an unscoped tenant query is
-not representable. The cross-tenant escape hatch carries a human-readable reason
-precisely because "because admin" is not a good enough explanation at 2am.
+The load-bearing idea is that **a tenant query always says which team's data you mean.** Many repository methods take a team id directly; where a query could span tenants it instead takes a `TeamScope`, a type with exactly two shapes: `TeamScope::Team(team_id)`, which pushes the team predicate into the SQL itself, and `TeamScope::PlatformAdmin { reason }`, an explicit, greppable, audit-carrying admission that a query deliberately crosses tenants. There is no "just give me the rows regardless of tenant" variant. This matters because the classic multi-tenant failure mode is a handler that forgets to add the tenant filter; here that handler simply cannot be written — an unscoped tenant query is not representable. The cross-tenant escape hatch carries a human-readable reason precisely because "because admin" is not a good enough explanation at 2am.
 
-A consequence worth internalising: **cross-tenant existence is hidden.** When a
-principal in org A asks about a team that belongs to org B, Flowplane does not
-say "you are not allowed to see this" — it behaves as though the team does not
-exist. The authorization engine settles the org boundary *before* it ever
-consults grants, and the API layer renders that denial as `404 not_found` rather
-than `403 forbidden`. The distinction is deliberate anti-enumeration: a
-`forbidden` answer confirms the resource is real, which leaks one tenant's
-inventory to another. So `not_found` here means "does not exist *within your
-visibility*," which is indistinguishable from genuine absence (see the
-`not_found` vs `forbidden` rows in [reference/errors.md](../reference/errors.md)).
-`forbidden` is reserved for the case where you *can* see the resource but lack the
-specific grant.
+A consequence worth internalising: **cross-tenant existence is hidden.** When a principal in org A asks about a team that belongs to org B, Flowplane does not say "you are not allowed to see this" — it behaves as though the team does not exist. The authorization engine settles the org boundary *before* it ever consults grants, and the API layer renders that denial as `404 not_found` rather than `403 forbidden`. The distinction is deliberate anti-enumeration: a `forbidden` answer confirms the resource is real, which leaks one tenant's inventory to another. So `not_found` here means "does not exist *within your visibility*," which is indistinguishable from genuine absence (see the `not_found` vs `forbidden` rows in [reference/errors.md](../reference/errors.md)). `forbidden` is reserved for the case where you *can* see the resource but lack the specific grant.
 
-One refinement to keep in mind: a human can belong to more than one org. When the
-caller has a single non-platform membership, Flowplane uses it implicitly — no
-selector needed. But when the caller has several memberships and sent no selector,
-it fails closed by asking for one (`org_selector_required`) rather than silently
-guessing an org or leaking a `not_found`. So the active org is inferred only when
-it is unambiguous; as soon as there is a choice to make, the caller must make it
-explicitly (via `X-Flowplane-Org` / `--org`).
+One refinement to keep in mind: a human can belong to more than one org. When the caller has a single non-platform membership, Flowplane uses it implicitly — no selector needed. But when the caller has several memberships and sent no selector, it fails closed by asking for one (`org_selector_required`) rather than silently guessing an org or leaking a `not_found`. So the active org is inferred only when it is unambiguous; as soon as there is a choice to make, the caller must make it explicitly (via `X-Flowplane-Org` / `--org`).
 
 ## 2. Grants and authorization: one pure decision over a grant set
 
-Access in Flowplane is **grant-based**. A grant is a row keyed by the triple
-`(resource, action, team)` — for example "read clusters in team T." `Resource`
-and `Action` are a small, closed vocabulary: every surface (REST route, MCP tool,
-CLI command) declares the `(resource, action)` pair it requires, and the grant
-table stores the same pairs, so there is one shared vocabulary and no phantom
-permissions that nothing can ever satisfy.
+Access in Flowplane is **grant-based**. A grant is a row keyed by the triple `(resource, action, team)` — for example "read clusters in team T." `Resource` and `Action` are a small, closed vocabulary: every surface (REST route, MCP tool, CLI command) declares the `(resource, action)` pair it requires, and the grant table stores the same pairs, so there is one shared vocabulary and no phantom permissions that nothing can ever satisfy.
 
 Two things make this tractable to reason about:
 
-**Authorization is a pure function.** A single gate decides every access on every
-surface. Its inputs are a snapshot of *who is asking* (the principal context,
-loaded once per request from the database) and *what is being attempted* (the
-resource, action, and optionally the target team). It performs no IO, reads no
-clock, and touches no globals — the answer depends only on its arguments. That is
-why the engine can be exhaustively property-tested, and why you can predict a
-decision from the principal's grant set without tracing through handler code.
-Every decision also returns a *reason* (a stable string like `grant_match`,
-`cross_org`, or `platform_governance`) so that audit records can say not just
-that access was denied but *why*.
+**Authorization is a pure function.** A single gate decides every access on every surface. Its inputs are a snapshot of *who is asking* (the principal context, loaded once per request from the database) and *what is being attempted* (the resource, action, and optionally the target team). It performs no IO, reads no clock, and touches no globals — the answer depends only on its arguments. That is why the engine can be exhaustively property-tested, and why you can predict a decision from the principal's grant set without tracing through handler code. Every decision also returns a *reason* (a stable string like `grant_match`, `cross_org`, or `platform_governance`) so that audit records can say not just that access was denied but *why*.
 
-**Resources split into governance and tenant.** A handful of resources —
-organizations, users, teams, audit, platform — are *governance* resources: they
-describe the platform itself, are never team-scoped, and writing them is reserved
-for the platform admin. Everything else is a *tenant* resource, owned by a team.
-This split drives the two big invariants you should hold:
+**Resources split into governance and tenant.** A handful of resources — organizations, users, teams, audit, platform — are *governance* resources: they describe the platform itself, are never team-scoped, and writing them is reserved for the platform admin. Everything else is a *tenant* resource, owned by a team. This split drives the two big invariants you should hold:
 
-- The **platform admin** is a governance role, not a superuser. Platform-admin
-  rights apply to governance resources only; a pure platform-admin context is
-  *denied* tenant resources outright — it cannot read another tenant's clusters
-  by virtue of being admin. Cross-tenant access goes through the explicit
-  `TeamScope::PlatformAdmin` hatch described above, not through the authorization
-  bypass.
-- Inside an org, access is the union of explicit grants and a few sensible
-  defaults: an exact grant matches; an org admin gets implicit access to teams in
-  *its own* org; an "any-team" grant lets list endpoints through (the rows are
-  then filtered down to the caller's teams by `TeamScope`); and org-scoped callers
-  can read governance resources but not write them.
+- The **platform admin** is a governance role, not a superuser. Platform-admin rights apply to governance resources only; a pure platform-admin context is *denied* tenant resources outright — it cannot read another tenant's clusters by virtue of being admin. Cross-tenant access goes through the explicit `TeamScope::PlatformAdmin` hatch described above, not through the authorization bypass.
+- Inside an org, access is the union of explicit grants and a few sensible defaults: an exact grant matches; an org admin gets implicit access to teams in *its own* org; an "any-team" grant lets list endpoints through (the rows are then filtered down to the caller's teams by `TeamScope`); and org-scoped callers can read governance resources but not write them.
 
-**Principals come in two kinds, and they are not symmetric.** A `User` is a human
-with org memberships and a grant set. An `Agent` is a machine identity, and agents
-are *structurally* constrained before grants are even consulted — the kind of
-agent fixes what it can ever touch. A gateway tool agent, for instance, can only
-ever reach MCP tools and is denied every other resource by structure; an
-API-consumer agent is denied everything at this layer; a control-plane tool agent
-is grants-only, with no governance arm and no org-admin shortcut. The point is
-that an agent's blast radius is bounded by *what it is*, independent of what
-grants happen to exist. The exhaustive decision table lives in
-[spec/05 §3.1](../../spec/05-auth.md) and the threat model in
-[spec/08a](../../spec/08a-security-and-tenancy.md); this page is only the mental
-model.
+**Principals come in two kinds, and they are not symmetric.** A `User` is a human with org memberships and a grant set. An `Agent` is a machine identity, and agents are *structurally* constrained before grants are even consulted — the kind of agent fixes what it can ever touch. A gateway tool agent, for instance, can only ever reach MCP tools and is denied every other resource by structure; an API-consumer agent is denied everything at this layer; a control-plane tool agent is grants-only, with no governance arm and no org-admin shortcut. The point is that an agent's blast radius is bounded by *what it is*, independent of what grants happen to exist. The exhaustive decision table lives in [spec/05 §3.1](../../spec/05-auth.md) and the threat model in [spec/08a](../../spec/08a-security-and-tenancy.md); this page is only the mental model.
 
 ## 3. The deterministic xDS pipeline: same inputs, same Envoy bytes
 
-Flowplane translates each team's stored gateway resources into the protobuf
-Envoy speaks (CDS, RDS, LDS, EDS, SDS) and serves it over an ADS stream. The
-property that makes this safe to operate is **determinism**: the same database
-state always produces the same configuration bytes.
+Flowplane translates each team's stored gateway resources into the protobuf Envoy speaks (CDS, RDS, LDS, EDS, SDS) and serves it over an ADS stream. The property that makes this safe to operate is **determinism**: the same database state always produces the same configuration bytes.
 
-**Stable encoding.** Resources are sorted by name and assembled through stable,
-ordered structures, so translation has no run-to-run variation — no map iteration
-order leaking into the wire, no spurious diffs. This is what lets the next two
-properties exist.
+**Stable encoding.** Resources are sorted by name and assembled through stable, ordered structures, so translation has no run-to-run variation — no map iteration order leaking into the wire, no spurious diffs. This is what lets the next two properties exist.
 
-**Per-type versions that bump only on real change.** Each team's snapshot carries
-an independent version *per resource type* (clusters, routes, listeners,
-endpoints, secrets). A version is incremented only when that type's *encoded bytes
-actually change*. A rebuild that produces identical bytes does not bump anything,
-so Envoy is never told to re-apply configuration it already has. The split by type
-is what keeps unrelated churn from rippling: endpoint changes for an EDS cluster
-bump only the endpoints version, leaving the cluster and route versions —
-and therefore Envoy's view of them — untouched. Rebuilds are driven by outbox
-events from writes, not by polling, and the serving snapshots are held in memory,
-so reconnecting dataplanes are answered from cache rather than re-querying the
-database per request.
+**Per-type versions that bump only on real change.** Each team's snapshot carries an independent version *per resource type* (clusters, routes, listeners, endpoints, secrets). A version is incremented only when that type's *encoded bytes actually change*. A rebuild that produces identical bytes does not bump anything, so Envoy is never told to re-apply configuration it already has. The split by type is what keeps unrelated churn from rippling: endpoint changes for an EDS cluster bump only the endpoints version, leaving the cluster and route versions — and therefore Envoy's view of them — untouched. Rebuilds are driven by outbox events from writes, not by polling, and the serving snapshots are held in memory, so reconnecting dataplanes are answered from cache rather than re-querying the database per request.
 
-**NACK quarantine that serves last-good.** Envoy can reject a configuration it
-considers invalid (a NACK). Flowplane's response is surgical: it quarantines only
-the *specific resources that changed* since the last accepted generation and
-falls back to their last-known-good bytes, rather than rolling back or blanking
-the whole resource type. A single bad cluster does not take a team's working
-listeners offline; the rest of the snapshot keeps serving. The quarantine clears
-itself when the offending bytes change again — that is, when an operator pushes a
-fix — and quarantined resources are surfaced as "degraded" so the failure is
-visible rather than silent. The same wait-for-fix posture applies to resources
-that fail translation inside the control plane before Envoy ever sees them: they
-are skipped and reported, never allowed to poison the snapshot.
+**NACK quarantine that serves last-good.** Envoy can reject a configuration it considers invalid (a NACK). Flowplane's response is surgical: it quarantines only the *specific resources that changed* since the last accepted generation and falls back to their last-known-good bytes, rather than rolling back or blanking the whole resource type. A single bad cluster does not take a team's working listeners offline; the rest of the snapshot keeps serving. The quarantine clears itself when the offending bytes change again — that is, when an operator pushes a fix — and quarantined resources are surfaced as "degraded" so the failure is visible rather than silent. The same wait-for-fix posture applies to resources that fail translation inside the control plane before Envoy ever sees them: they are skipped and reported, never allowed to poison the snapshot.
 
-Two operational corollaries follow from this design. First, a control-plane
-restart is safe: the cache is primed from the database at startup so a freshly
-started process serves a database-built snapshot instead of an empty one — it
-never hands a reconnecting dataplane an empty snapshot that would wipe its config.
-(The in-memory quarantine/last-good state is not carried across a restart; the
-snapshot is simply rebuilt from persisted resources.) Second,
-because identical inputs yield identical bytes and versions only move on genuine
-change, "nothing happened" is a meaningful, observable state. For the wire-level
-contract — stream loops, mTLS and SPIFFE identity, per-dataplane scoping, and NACK
-persistence — see [spec/04 — xDS](../../spec/04-xds.md).
+Two operational corollaries follow from this design. First, a control-plane restart is safe: the cache is primed from the database at startup so a freshly started process serves a database-built snapshot instead of an empty one — it never hands a reconnecting dataplane an empty snapshot that would wipe its config. (The in-memory quarantine/last-good state is not carried across a restart; the snapshot is simply rebuilt from persisted resources.) Second, because identical inputs yield identical bytes and versions only move on genuine change, "nothing happened" is a meaningful, observable state. For the wire-level contract — stream loops, mTLS and SPIFFE identity, per-dataplane scoping, and NACK persistence — see [spec/04 — xDS](../../spec/04-xds.md).

--- a/docs/how-to/ai-gateway-route-budget.md
+++ b/docs/how-to/ai-gateway-route-budget.md
@@ -2,36 +2,21 @@
 
 > Audience: api-teams · Status: stable
 
-This guide stands up a working AI gateway path: register an upstream LLM provider,
-publish an AI route that points a listener at it, and cap token spend with a budget —
-first in `shadow` (observe-only), then `enforcing`. It uses the `flowplane` CLI, whose
-AI resources (`ai providers`, `ai routes`, `ai budgets`) all take a JSON spec file and
-POST it to the team's `ai/*` endpoints.
+This guide stands up a working AI gateway path: register an upstream LLM provider, publish an AI route that points a listener at it, and cap token spend with a budget — first in `shadow` (observe-only), then `enforcing`. It uses the `flowplane` CLI, whose AI resources (`ai providers`, `ai routes`, `ai budgets`) all take a JSON spec file and POST it to the team's `ai/*` endpoints.
 
 For the full command surface and flags, see [`../reference/cli.md`](../reference/cli.md).
 
 ## Prereqs
 
-The CLI is authenticated and scoped to your team (see
-[`cli-auth-and-contexts.md`](./cli-auth-and-contexts.md)).
+The CLI is authenticated and scoped to your team (see [`cli-auth-and-contexts.md`](./cli-auth-and-contexts.md)).
 
-The control plane must be running with `FLOWPLANE_SECRET_ENCRYPTION_KEY` set (a 32-byte
-raw or base64 key). Secrets are encrypted at rest, so `flowplane secret create` fails with
-`error (unavailable): secret encryption key is not configured` if the server was started
-without it — the dev getting-started setup omits this key, so set it before this step (see
-[`../reference/configuration.md`](../reference/configuration.md), constraint ⁷).
+The control plane must be running with `FLOWPLANE_SECRET_ENCRYPTION_KEY` set (a 32-byte raw or base64 key). Secrets are encrypted at rest, so `flowplane secret create` fails with `error (unavailable): secret encryption key is not configured` if the server was started without it — the dev getting-started setup omits this key, so set it before this step (see [`../reference/configuration.md`](../reference/configuration.md), constraint ⁷).
 
-With that key set, create a secret holding the provider API key —
-`flowplane secret create --file secret.json` — and note its UUID for `credential_secret_id`
-below.
+With that key set, create a secret holding the provider API key — `flowplane secret create --file secret.json` — and note its UUID for `credential_secret_id` below.
 
 ## 1. Create a provider
 
-The provider body is `{ "name", "spec" }`, where `spec` is the `AiProviderSpec`: a
-`kind` (`openai` or `openai-compatible`), an **origin-only** `base_url` (scheme + host,
-no path — use `path_prefix` for upstream paths), the `credential_secret_id` of your
-secret, the `models` the provider serves, and the `auth_header` the key is sent in
-(defaults to `authorization`).
+The provider body is `{ "name", "spec" }`, where `spec` is the `AiProviderSpec`: a `kind` (`openai` or `openai-compatible`), an **origin-only** `base_url` (scheme + host, no path — use `path_prefix` for upstream paths), the `credential_secret_id` of your secret, the `models` the provider serves, and the `auth_header` the key is sent in (defaults to `authorization`).
 
 `provider.json`:
 
@@ -52,17 +37,11 @@ secret, the `models` the provider serves, and the `auth_header` the key is sent 
 flowplane ai providers create --file provider.json
 ```
 
-This POSTs to `/api/v1/teams/{team}/ai/providers` and returns the provider view,
-including its `id` — note it for the route backend.
+This POSTs to `/api/v1/teams/{team}/ai/providers` and returns the provider view, including its `id` — note it for the route backend.
 
 ## 2. Create a route to the provider
 
-The route body is `{ "name", "spec" }`, where `spec` is the `AiRouteSpec`: a
-`listener_port`, a `path` (defaults to `/v1/chat/completions`, the only supported path
-in S10), and one or more `backends`. Each `AiRouteBackend` references a `provider_id`,
-optionally restricts which `models` it serves (empty = catch-all), and carries a
-`weight` (1–1000, default 1) and `priority` (default 0). Use `model_override` to rewrite
-the client's `model` to a specific upstream model.
+The route body is `{ "name", "spec" }`, where `spec` is the `AiRouteSpec`: a `listener_port`, a `path` (defaults to `/v1/chat/completions`, the only supported path in S10), and one or more `backends`. Each `AiRouteBackend` references a `provider_id`, optionally restricts which `models` it serves (empty = catch-all), and carries a `weight` (1–1000, default 1) and `priority` (default 0). Use `model_override` to rewrite the client's `model` to a specific upstream model.
 
 `route.json`:
 
@@ -88,21 +67,11 @@ the client's `model` to a specific upstream model.
 flowplane ai routes create --file route.json
 ```
 
-This POSTs to `/api/v1/teams/{team}/ai/routes`. The returned view's `materialized`
-field shows the cluster/route-config/listener names Flowplane generated, and `status`
-should be `active`.
+This POSTs to `/api/v1/teams/{team}/ai/routes`. The returned view's `materialized` field shows the cluster/route-config/listener names Flowplane generated, and `status` should be `active`.
 
 ## 3. Attach a budget (shadow first)
 
-The budget body is `{ "name", "spec" }`, where `spec` is the `AiBudgetSpec`. Start in
-`shadow` mode so the budget records usage without blocking traffic. `limit_units` is the
-cap, `window_seconds` is the rolling window (defaults to ~30 days), and the per-token
-weights convert token counts into budget units. Note the defaults differ:
-`prompt_token_weight` defaults to **0** (prompt tokens are not counted unless you set
-it), while `completion_token_weight` defaults to **1**. The example below sets
-`prompt_token_weight` to `1` explicitly so prompt tokens also count toward the budget.
-Scope the budget to this provider with `provider_id` (or to a route config with
-`route_config_id`).
+The budget body is `{ "name", "spec" }`, where `spec` is the `AiBudgetSpec`. Start in `shadow` mode so the budget records usage without blocking traffic. `limit_units` is the cap, `window_seconds` is the rolling window (defaults to ~30 days), and the per-token weights convert token counts into budget units. Note the defaults differ: `prompt_token_weight` defaults to **0** (prompt tokens are not counted unless you set it), while `completion_token_weight` defaults to **1**. The example below sets `prompt_token_weight` to `1` explicitly so prompt tokens also count toward the budget. Scope the budget to this provider with `provider_id` (or to a route config with `route_config_id`).
 
 `budget-shadow.json`:
 
@@ -126,11 +95,7 @@ flowplane ai budgets create --file budget-shadow.json
 
 ### Flip to enforcing
 
-Once the shadow run looks right, switch the same budget to `enforcing` so requests are
-rejected when the limit is exceeded. Updates are a PATCH carrying only the `spec`
-(no `name`), and require the current revision via `If-Match` — the CLI sends it from the
-global `--revision` flag. Read the current revision first (e.g. with
-`flowplane ai budgets get chat-budget`, whose `revision` field you pass below).
+Once the shadow run looks right, switch the same budget to `enforcing` so requests are rejected when the limit is exceeded. Updates are a PATCH carrying only the `spec` (no `name`), and require the current revision via `If-Match` — the CLI sends it from the global `--revision` flag. Read the current revision first (e.g. with `flowplane ai budgets get chat-budget`, whose `revision` field you pass below).
 
 `budget-enforce.json`:
 
@@ -153,9 +118,7 @@ flowplane ai budgets update chat-budget --file budget-enforce.json --revision <n
 
 ## 4. Verify
 
-Send a chat request through the listener port from the route (`19000` above). The
-request body must include a `model`; Flowplane routes it to an eligible backend and
-forwards to the provider:
+Send a chat request through the listener port from the route (`19000` above). The request body must include a `model`; Flowplane routes it to an eligible backend and forwards to the provider:
 
 ```bash
 curl http://127.0.0.1:19000/v1/chat/completions \
@@ -169,7 +132,4 @@ Then confirm usage was recorded:
 flowplane ai usage --provider-id <provider-id-from-step-1>
 ```
 
-This GETs `/api/v1/teams/{team}/ai/usage` and returns `AiUsageSummary` rows with
-`prompt_tokens`, `completion_tokens`, `total_tokens`, and `event_count`. A non-zero
-`event_count` confirms the request routed to the provider and was accounted against the
-budget. You can also filter by `--route-config-id`.
+This GETs `/api/v1/teams/{team}/ai/usage` and returns `AiUsageSummary` rows with `prompt_tokens`, `completion_tokens`, `total_tokens`, and `event_count`. A non-zero `event_count` confirms the request routed to the provider and was accounted against the budget. You can also filter by `--route-config-id`.

--- a/docs/how-to/aws-secure-deployment.md
+++ b/docs/how-to/aws-secure-deployment.md
@@ -1,8 +1,6 @@
 # AWS Secure Deployment Runbook
 
-This runbook is the concrete AWS packaging of Flowplane's provider-agnostic deployment
-invariants; it is self-contained — every step and value needed to stand up the environment is
-here.
+This runbook is the concrete AWS packaging of Flowplane's provider-agnostic deployment invariants; it is self-contained — every step and value needed to stand up the environment is here.
 
 The target is a strict secure smoke environment:
 
@@ -32,9 +30,7 @@ export TF_VAR_oidc_issuer="https://your-issuer.example.com"   # OIDC issuer URL
 export TF_VAR_oidc_audience="your-api-audience"               # expected JWT aud claim
 ```
 
-The default region is `us-east-1` with `availability_zones = ["us-east-1a", "us-east-1b"]`. If you
-change regions, set AZs from the same region explicitly; this keeps planning usable with narrower
-IAM policies that do not allow availability-zone discovery.
+The default region is `us-east-1` with `availability_zones = ["us-east-1a", "us-east-1b"]`. If you change regions, set AZs from the same region explicitly; this keeps planning usable with narrower IAM policies that do not allow availability-zone discovery.
 
 ## Secret Setup
 
@@ -49,17 +45,13 @@ Create Secrets Manager secrets for:
 - dataplane certificate issuer CA certificate PEM
 - dataplane certificate issuer CA private key PEM
 
-The OpenTofu module passes secret ARNs into ECS. The container writes PEM values to files under
-`/tmp/flowplane/tls` before running `flowplane serve`.
+The OpenTofu module passes secret ARNs into ECS. The container writes PEM values to files under `/tmp/flowplane/tls` before running `flowplane serve`.
 
-The module generates the RDS password and stores it in Secrets Manager. Protect the OpenTofu state
-backend because generated secret material is present in state.
+The module generates the RDS password and stores it in Secrets Manager. Protect the OpenTofu state backend because generated secret material is present in state.
 
 ## Network Egress
 
-Auth0/OIDC discovery and JWKS fetches require outbound HTTPS from the private ECS task. The module
-creates NAT egress by default. For the smoke environment it defaults to one NAT gateway to control
-cost; set `single_nat_gateway = false` if you want per-AZ NAT gateways.
+Auth0/OIDC discovery and JWKS fetches require outbound HTTPS from the private ECS task. The module creates NAT egress by default. For the smoke environment it defaults to one NAT gateway to control cost; set `single_nat_gateway = false` if you want per-AZ NAT gateways.
 
 ## OpenTofu
 
@@ -79,8 +71,7 @@ cp.getflowplane.io  -> api_alb_dns_name
 xds.getflowplane.io  -> xds_nlb_dns_name
 ```
 
-Keep `xds.getflowplane.io` DNS-only. Do not proxy xDS through Cloudflare for this smoke path;
-Flowplane must terminate the dataplane mTLS connection itself.
+Keep `xds.getflowplane.io` DNS-only. Do not proxy xDS through Cloudflare for this smoke path; Flowplane must terminate the dataplane mTLS connection itself.
 
 ## Bootstrap
 
@@ -152,8 +143,7 @@ flowplane --out .local/aws-envoy.yaml dataplane bootstrap edge-local \
   --ca-path "$PWD/.local/aws-dp-ca.crt"
 ```
 
-Run Envoy locally with `.local/aws-envoy.yaml`, then apply a simple route/listener and confirm the
-dataplane receives xDS without NACKs.
+Run Envoy locally with `.local/aws-envoy.yaml`, then apply a simple route/listener and confirm the dataplane receives xDS without NACKs.
 
 ## Teardown
 

--- a/docs/how-to/bootstrap-platform.md
+++ b/docs/how-to/bootstrap-platform.md
@@ -2,9 +2,7 @@
 
 > Audience: operators · Status: stable
 
-A fresh, non-dev Flowplane control plane starts **uninitialized**: it has no platform
-organization and no admin. You initialize it once, with a one-shot **bootstrap token** that you
-supply — the control plane never generates or logs it.
+A fresh, non-dev Flowplane control plane starts **uninitialized**: it has no platform organization and no admin. You initialize it once, with a one-shot **bootstrap token** that you supply — the control plane never generates or logs it.
 
 This page is self-contained: every value you need is here.
 
@@ -16,13 +14,11 @@ Pick a high-entropy secret, **at least 32 characters**. For example:
 openssl rand -hex 32        # 64 hex chars — fine
 ```
 
-Keep it where only operators can read it. You will hand it to the control plane and then use it
-once against the API.
+Keep it where only operators can read it. You will hand it to the control plane and then use it once against the API.
 
 ## 2. Supply the token to the control plane
 
-Provide it by **either** of these, before `flowplane serve` starts. The control plane stores only
-its SHA-256 hash and never writes the token to logs.
+Provide it by **either** of these, before `flowplane serve` starts. The control plane stores only its SHA-256 hash and never writes the token to logs.
 
 - A file (preferred — safer than env, which is visible via process inspection):
 
@@ -37,12 +33,9 @@ its SHA-256 hash and never writes the token to logs.
   export FLOWPLANE_BOOTSTRAP_TOKEN="<your-32+-char-token>"
   ```
 
-`FLOWPLANE_BOOTSTRAP_TOKEN_FILE` takes precedence if both are set. Supply the **same** token to
-every replica; a different live token on another replica makes startup fail closed.
+`FLOWPLANE_BOOTSTRAP_TOKEN_FILE` takes precedence if both are set. Supply the **same** token to every replica; a different live token on another replica makes startup fail closed.
 
-Then start the server normally (`flowplane serve`). On an uninitialized instance it seeds the
-token's hash and logs a confirmation **without** the value. If the instance is already initialized,
-the token is ignored.
+Then start the server normally (`flowplane serve`). On an uninitialized instance it seeds the token's hash and logs a confirmation **without** the value. If the instance is already initialized, the token is ignored.
 
 > **Fail-closed:** an uninitialized, non-dev instance started with **no** token refuses to start.
 > This is deliberate — it prevents a misconfigured production instance from silently generating and
@@ -51,8 +44,7 @@ the token is ignored.
 
 ## 3. Initialize the platform
 
-Call the public bootstrap endpoint once, passing the token as a bearer credential. `admin_subject`
-is the OIDC `sub` of your first admin (the identity your IdP will assert):
+Call the public bootstrap endpoint once, passing the token as a bearer credential. `admin_subject` is the OIDC `sub` of your first admin (the identity your IdP will assert):
 
 ```bash
 curl -fsS -X POST https://<control-plane>/api/v1/bootstrap/initialize \
@@ -66,21 +58,16 @@ curl -fsS -X POST https://<control-plane>/api/v1/bootstrap/initialize \
       }'
 ```
 
-A success response returns the new `org_id` and `admin_user_id`. The token is now consumed
-(single-use, 24-hour expiry); a replay returns `401`/`409`.
+A success response returns the new `org_id` and `admin_user_id`. The token is now consumed (single-use, 24-hour expiry); a replay returns `401`/`409`.
 
 ## 4. Verify
 
-- Re-running the same `POST /api/v1/bootstrap/initialize` returns a conflict — the instance is
-  initialized.
+- Re-running the same `POST /api/v1/bootstrap/initialize` returns a conflict — the instance is initialized.
 - Your admin can now authenticate through your OIDC issuer and reach authenticated endpoints.
 
 ## Troubleshooting
 
-- **Server won't start, "no bootstrap token was supplied":** the instance is uninitialized and you
-  set neither `FLOWPLANE_BOOTSTRAP_TOKEN` nor `FLOWPLANE_BOOTSTRAP_TOKEN_FILE`. Set one and restart.
-- **Server won't start, "a different bootstrap token is already active":** another replica was
-  given a different token. Use one identical token across all replicas.
+- **Server won't start, "no bootstrap token was supplied":** the instance is uninitialized and you set neither `FLOWPLANE_BOOTSTRAP_TOKEN` nor `FLOWPLANE_BOOTSTRAP_TOKEN_FILE`. Set one and restart.
+- **Server won't start, "a different bootstrap token is already active":** another replica was given a different token. Use one identical token across all replicas.
 - **"token is too short":** the token must be ≥ 32 characters after trimming whitespace.
-- **`401` on initialize:** the token is wrong, expired (24 h), or already used. Restart an
-  uninitialized instance with a fresh token, or confirm you are sending the exact value you seeded.
+- **`401` on initialize:** the token is wrong, expired (24 h), or already used. Restart an uninitialized instance with a fresh token, or confirm you are sending the exact value you seeded.

--- a/docs/how-to/cli-auth-and-contexts.md
+++ b/docs/how-to/cli-auth-and-contexts.md
@@ -2,18 +2,13 @@
 
 > Audience: cli-users · Status: stable
 
-This guide gets the `flowplane` CLI talking to a control plane: set a token, point at the
-right server, optionally scope to an org/team, and verify. It assumes you have the
-`flowplane` binary on your `PATH` and a control-plane URL to talk to.
+This guide gets the `flowplane` CLI talking to a control plane: set a token, point at the right server, optionally scope to an org/team, and verify. It assumes you have the `flowplane` binary on your `PATH` and a control-plane URL to talk to.
 
-For the full command surface see [`../reference/cli.md`](../reference/cli.md), and for the
-complete list of environment variables and config keys see
-[`../reference/configuration.md`](../reference/configuration.md).
+For the full command surface see [`../reference/cli.md`](../reference/cli.md), and for the complete list of environment variables and config keys see [`../reference/configuration.md`](../reference/configuration.md).
 
 ## Fastest path: token + server, then verify
 
-If you already have a bearer token, the quickest way to get going is two environment
-variables and a `whoami`:
+If you already have a bearer token, the quickest way to get going is two environment variables and a `whoami`:
 
 ```bash
 export FLOWPLANE_TOKEN="<your-token>"
@@ -22,11 +17,9 @@ export FLOWPLANE_SERVER="https://fp.example"
 flowplane auth whoami
 ```
 
-If `whoami` returns your identity, you are authenticated. (`FLOWPLANE_SERVER` is also a
-documented flag — `--server` — and falls back to `http://127.0.0.1:8080` when unset.)
+If `whoami` returns your identity, you are authenticated. (`FLOWPLANE_SERVER` is also a documented flag — `--server` — and falls back to `http://127.0.0.1:8080` when unset.)
 
-Prefer to persist the token to disk instead of carrying an env var? Save it with
-`auth login`:
+Prefer to persist the token to disk instead of carrying an env var? Save it with `auth login`:
 
 ```bash
 # Pass the token directly...
@@ -36,17 +29,11 @@ flowplane auth login --token "<your-token>"
 printf '%s' "<your-token>" | flowplane auth login --token-stdin
 ```
 
-`auth login` writes the token to the credentials file next to your config
-(`~/.flowplane/credentials`, mode `0600`). After that, `flowplane auth whoami` works
-without `FLOWPLANE_TOKEN` set. To remove it later, run `flowplane auth logout` (this
-deletes the credentials file). To print the token the CLI would currently use, run
-`flowplane auth token`.
+`auth login` writes the token to the credentials file next to your config (`~/.flowplane/credentials`, mode `0600`). After that, `flowplane auth whoami` works without `FLOWPLANE_TOKEN` set. To remove it later, run `flowplane auth logout` (this deletes the credentials file). To print the token the CLI would currently use, run `flowplane auth token`.
 
 ## OIDC login (PKCE)
 
-If your control plane uses an OIDC provider, log in interactively with PKCE instead of
-pasting a raw token. This opens a browser authorize URL and waits for the provider to
-redirect back to a loopback callback:
+If your control plane uses an OIDC provider, log in interactively with PKCE instead of pasting a raw token. This opens a browser authorize URL and waits for the provider to redirect back to a loopback callback:
 
 ```bash
 flowplane auth login --pkce \
@@ -57,20 +44,13 @@ flowplane auth login --pkce \
 Defaults you usually do not need to set:
 
 - `--scope` defaults to `openid email profile`.
-- `--callback-url` defaults to `http://127.0.0.1:8976/callback`. The callback must be an
-  `http://` loopback on `127.0.0.1` or `localhost` with an explicit port.
+- `--callback-url` defaults to `http://127.0.0.1:8976/callback`. The callback must be an `http://` loopback on `127.0.0.1` or `localhost` with an explicit port.
 
-The resulting token is saved to the credentials file, just like `auth login --token`.
-`--issuer` and `--client-id` can also come from config (`oidc_issuer` / `oidc_client_id`)
-or the matching env vars — if both are configured, plain `flowplane auth login` will use
-PKCE automatically. For headless machines, use `--device` (alias `--device-code`) instead
-of `--pkce` to run the device-code flow.
+The resulting token is saved to the credentials file, just like `auth login --token`. `--issuer` and `--client-id` can also come from config (`oidc_issuer` / `oidc_client_id`) or the matching env vars — if both are configured, plain `flowplane auth login` will use PKCE automatically. For headless machines, use `--device` (alias `--device-code`) instead of `--pkce` to run the device-code flow.
 
 ## Contexts: stop repeating flags
 
-A context bundles a server (and optionally org, team, token) under a name so you do not
-have to pass `--server`/`--org`/`--team` on every command. Create one with
-`config set-context` (the `--server` value is required; `name` is positional):
+A context bundles a server (and optionally org, team, token) under a name so you do not have to pass `--server`/`--org`/`--team` on every command. Create one with `config set-context` (the `--server` value is required; `name` is positional):
 
 ```bash
 flowplane config set-context prod \
@@ -79,8 +59,7 @@ flowplane config set-context prod \
   --team payments
 ```
 
-Creating a context with `set-context` also makes it the current context if none is set
-yet. List what you have (the current one is marked with `*`):
+Creating a context with `set-context` also makes it the current context if none is set yet. List what you have (the current one is marked with `*`):
 
 ```bash
 flowplane config get-contexts
@@ -92,31 +71,22 @@ Switch the active context:
 flowplane config use-context prod
 ```
 
-To set or change the org/team for a context, re-run `set-context` with the same name — it
-replaces the existing entry. You can also override per-invocation with `--org` / `--team`,
-or select a different context for one command with `--context <name>`.
+To set or change the org/team for a context, re-run `set-context` with the same name — it replaces the existing entry. You can also override per-invocation with `--org` / `--team`, or select a different context for one command with `--context <name>`.
 
-To store a token inside the context itself (instead of the shared credentials file), pass
-`--token` or `--token-stdin` to `set-context`. Note a context token takes precedence over
-the saved credentials file, so `auth login` will warn you if the current context already
-carries its own token.
+To store a token inside the context itself (instead of the shared credentials file), pass `--token` or `--token-stdin` to `set-context`. Note a context token takes precedence over the saved credentials file, so `auth login` will warn you if the current context already carries its own token.
 
-See `flowplane config show` to print the resolved config file and `flowplane config path`
-to print its location (`~/.flowplane/config.toml` by default).
+See `flowplane config show` to print the resolved config file and `flowplane config path` to print its location (`~/.flowplane/config.toml` by default).
 
 ## Precedence: how a value is resolved
 
 For each setting, the CLI walks these sources in order and uses the first one present:
 
-- **Server**: `--server` flag / `FLOWPLANE_SERVER` env → current context → config file
-  `base_url` → default `http://127.0.0.1:8080`.
+- **Server**: `--server` flag / `FLOWPLANE_SERVER` env → current context → config file `base_url` → default `http://127.0.0.1:8080`.
 - **Org**: `--org` flag → `FLOWPLANE_ORG` env → current context → config file `org`.
 - **Team**: `--team` flag → `FLOWPLANE_TEAM` env → current context → config file `team`.
-- **Token**: `FLOWPLANE_TOKEN` env → current context token → config file `token` →
-  credentials file (`~/.flowplane/credentials`).
+- **Token**: `FLOWPLANE_TOKEN` env → current context token → config file `token` → credentials file (`~/.flowplane/credentials`).
 
-The rule of thumb: **flag > env > config file**. The active context is whatever
-`--context` names, otherwise the `current_context` saved by `use-context`.
+The rule of thumb: **flag > env > config file**. The active context is whatever `--context` names, otherwise the `current_context` saved by `use-context`.
 
 ## Verify
 
@@ -126,7 +96,4 @@ Whichever path you took, confirm it end to end:
 flowplane auth whoami
 ```
 
-A successful response means the CLI resolved a server and token correctly and the control
-plane accepted your identity. If it fails, check `flowplane auth token` (is a token
-resolved at all?) and `flowplane config get-contexts` (is the right context active and
-pointing at the right server?).
+A successful response means the CLI resolved a server and token correctly and the control plane accepted your identity. If it fails, check `flowplane auth token` (is a token resolved at all?) and `flowplane config get-contexts` (is the right context active and pointing at the right server?).

--- a/docs/how-to/jwt-auth-rate-limit-route.md
+++ b/docs/how-to/jwt-auth-rate-limit-route.md
@@ -2,41 +2,22 @@
 
 # Add JWT authentication and a local rate limit to an existing route
 
-This protects one route with JWT validation and caps its request rate. It assumes
-you already have a working cluster, listener, and route-config bound together. If
-you do not, start with the [getting-started tutorial](../tutorials/getting-started.md).
+This protects one route with JWT validation and caps its request rate. It assumes you already have a working cluster, listener, and route-config bound together. If you do not, start with the [getting-started tutorial](../tutorials/getting-started.md).
 
-**Prerequisites:** a listener (e.g. `edge`) whose `route_config` points at an
-existing route-config (e.g. `api-routes`) with the route you want to protect, and
-the listener/route revisions to hand (the `revision` field on a `GET`).
+**Prerequisites:** a listener (e.g. `edge`) whose `route_config` points at an existing route-config (e.g. `api-routes`) with the route you want to protect, and the listener/route revisions to hand (the `revision` field on a `GET`).
 
 ## Where each filter lives
 
-Both filters **must be present in the listener filter chain** to be active — a
-per-route/vhost `filter_overrides` entry only emits per-filter *config* that Envoy
-applies to that scope; it cannot add a filter Envoy isn't already running. Within
-that rule, the two filters differ in how the config is split:
+Both filters **must be present in the listener filter chain** to be active — a per-route/vhost `filter_overrides` entry only emits per-filter *config* that Envoy applies to that scope; it cannot add a filter Envoy isn't already running. Within that rule, the two filters differ in how the config is split:
 
-- **`jwt_auth`** — the providers and `requirement_map` (and any `rules`) live
-  **only** in the **listener filter chain** (`HttpFilterEntry`). The per-route/vhost
-  override is **reference-only**: it names a requirement already defined in the
-  chain's `requirement_map` (`{ "type": "jwt_auth", "requirement_name": "<name>" }`).
-  You cannot redefine providers per-route.
-- **`local_rate_limit`** — the chain entry is **required** (it makes the filter run);
-  the **per-route/vhost override carries a full `LocalRateLimitConfig`** that replaces
-  the chain entry's config for that scope. The chain entry is the base/default limit.
+- **`jwt_auth`** — the providers and `requirement_map` (and any `rules`) live **only** in the **listener filter chain** (`HttpFilterEntry`). The per-route/vhost override is **reference-only**: it names a requirement already defined in the chain's `requirement_map` (`{ "type": "jwt_auth", "requirement_name": "<name>" }`). You cannot redefine providers per-route.
+- **`local_rate_limit`** — the chain entry is **required** (it makes the filter run); the **per-route/vhost override carries a full `LocalRateLimitConfig`** that replaces the chain entry's config for that scope. The chain entry is the base/default limit.
 
 Each `type` may appear at most once in the listener chain.
 
 ## 1. Add the filters to the listener chain
 
-Add both a `jwt_auth` entry and a `local_rate_limit` entry to the listener's
-`http_filters`. Both are required for the per-route overrides in step 2 to take
-effect: the chain entry is what makes Envoy run the filter, and the override only
-supplies per-scope config. The `local_rate_limit` chain entry below acts as the
-base/default limit; the route override in step 2 replaces it for one route. The
-entry shape is `HttpFilterEntry`: `{ "filter": <HttpFilterSpec>, "disabled": <bool> }`,
-where the filter is tagged by `type`.
+Add both a `jwt_auth` entry and a `local_rate_limit` entry to the listener's `http_filters`. Both are required for the per-route overrides in step 2 to take effect: the chain entry is what makes Envoy run the filter, and the override only supplies per-scope config. The `local_rate_limit` chain entry below acts as the base/default limit; the route override in step 2 replaces it for one route. The entry shape is `HttpFilterEntry`: `{ "filter": <HttpFilterSpec>, "disabled": <bool> }`, where the filter is tagged by `type`.
 
 ```jsonc
 {
@@ -77,33 +58,17 @@ where the filter is tagged by `type`.
 }
 ```
 
-Notes on the fields used above (full field list in
-[`../reference/filters.md`](../reference/filters.md)):
+Notes on the fields used above (full field list in [`../reference/filters.md`](../reference/filters.md)):
 
-- `jwt_auth.providers` is a map of provider name → provider; at least one is
-  required. `jwks.source` is `remote` (needs `uri` + a same-team `cluster`) or
-  `inline` (`{ "source": "inline", "jwks": "<JWKS JSON>" }`).
-- `requirement_map` names requirements (`kind`: `provider`, `any_of`,
-  `allow_missing`, `allow_missing_or_failed`) that `rules` and per-route overrides
-  reference by name. Defining a requirement here enforces **nothing** on its own —
-  it is just a lookup table.
-- **To protect only one route, leave `rules` empty** and reference the requirement
-  from that route's `filter_overrides` (step 2). With empty `rules` and no per-route
-  reference, Envoy enforces no JWT requirement; the per-route `jwt_auth` override is
-  what attaches `require-auth0` to the `payments` route, leaving every other route
-  unauthenticated.
-- Do **not** use chain-level `rules` for this task: `rules` are listener-wide
-  path matches, so they would force auth on every path they match, not just your
-  one route.
-- `local_rate_limit` requires `stat_prefix` and `token_bucket`
-  (`max_tokens` ≥ 1, `fill_interval_ms` > 0; `tokens_per_fill` defaults to
-  `max_tokens`). `status_code` is optional (400–599; Envoy defaults to 429).
+- `jwt_auth.providers` is a map of provider name → provider; at least one is required. `jwks.source` is `remote` (needs `uri` + a same-team `cluster`) or `inline` (`{ "source": "inline", "jwks": "<JWKS JSON>" }`).
+- `requirement_map` names requirements (`kind`: `provider`, `any_of`, `allow_missing`, `allow_missing_or_failed`) that `rules` and per-route overrides reference by name. Defining a requirement here enforces **nothing** on its own — it is just a lookup table.
+- **To protect only one route, leave `rules` empty** and reference the requirement from that route's `filter_overrides` (step 2). With empty `rules` and no per-route reference, Envoy enforces no JWT requirement; the per-route `jwt_auth` override is what attaches `require-auth0` to the `payments` route, leaving every other route unauthenticated.
+- Do **not** use chain-level `rules` for this task: `rules` are listener-wide path matches, so they would force auth on every path they match, not just your one route.
+- `local_rate_limit` requires `stat_prefix` and `token_bucket` (`max_tokens` ≥ 1, `fill_interval_ms` > 0; `tokens_per_fill` defaults to `max_tokens`). `status_code` is optional (400–599; Envoy defaults to 429).
 
 ## 2. Attach the per-route override
 
-Edit the route-config so the target route demands the JWT requirement and gets its
-own rate limit. Both go in the route's `filter_overrides` (a `RouteRule` field;
-`VirtualHost` has the same field, and a route-level override wins over the vhost's).
+Edit the route-config so the target route demands the JWT requirement and gets its own rate limit. Both go in the route's `filter_overrides` (a `RouteRule` field; `VirtualHost` has the same field, and a route-level override wins over the vhost's).
 
 ```jsonc
 {
@@ -133,16 +98,13 @@ own rate limit. Both go in the route's `filter_overrides` (a `RouteRule` field;
 }
 ```
 
-- `requirement_name` must match a key in the chain filter's `requirement_map`
-  (here `require-auth0`); 1–128 characters.
+- `requirement_name` must match a key in the chain filter's `requirement_map` (here `require-auth0`); 1–128 characters.
 - At most one override per filter `type` in a scope.
-- To turn a chain filter **off** for a scope instead, use
-  `{ "type": "disable", "filter_type": "jwt_auth" }`.
+- To turn a chain filter **off** for a scope instead, use `{ "type": "disable", "filter_type": "jwt_auth" }`.
 
 ## 3. Apply the updates
 
-Updates are optimistic-concurrency-checked: send the current revision as a plain
-integer in the `If-Match` header. Read it from a `GET` (the `revision` field).
+Updates are optimistic-concurrency-checked: send the current revision as a plain integer in the `If-Match` header. Read it from a `GET` (the `revision` field).
 
 ### REST
 
@@ -162,13 +124,11 @@ curl -X PATCH https://control-plane.example/api/v1/teams/<team>/route-configs/ap
   --data @route-config.json
 ```
 
-The PATCH body is `{ "spec": { … } }` exactly as in the JSON above. (Creating
-fresh resources is a `POST` to the collection with `{ "name": "...", "spec": { … } }`.)
+The PATCH body is `{ "spec": { … } }` exactly as in the JSON above. (Creating fresh resources is a `POST` to the collection with `{ "name": "...", "spec": { … } }`.)
 
 ### CLI
 
-The CLI sends `If-Match` from the global `--revision` flag, and the file is the
-same `{ "spec": { … } }` body.
+The CLI sends `If-Match` from the global `--revision` flag, and the file is the same `{ "spec": { … } }` body.
 
 ```bash
 flowplane listener update edge --team <team> --revision <listener-revision> --file listener.json
@@ -187,14 +147,8 @@ for i in $(seq 1 20); do
 done
 ```
 
-Expect `401` without a valid token and `429` once the bucket is empty. The `429`
-here is Envoy's data-plane `local_rate_limit` response; it does **not** carry a
-`Retry-After` header (the translator does not set one). For HTTP status-code
-meanings see [`../reference/errors.md`](../reference/errors.md) — note its
-`rate_limited` (429 with `Retry-After`) row describes the control-plane API write
-throttle, not this data-plane rate limit.
+Expect `401` without a valid token and `429` once the bucket is empty. The `429` here is Envoy's data-plane `local_rate_limit` response; it does **not** carry a `Retry-After` header (the translator does not set one). For HTTP status-code meanings see [`../reference/errors.md`](../reference/errors.md) — note its `rate_limited` (429 with `Retry-After`) row describes the control-plane API write throttle, not this data-plane rate limit.
 
 ## See also
 
-- [`../reference/filters.md`](../reference/filters.md) — full `JwtAuthConfig`,
-  `LocalRateLimitConfig`, and `FilterOverride` field reference.
+- [`../reference/filters.md`](../reference/filters.md) — full `JwtAuthConfig`, `LocalRateLimitConfig`, and `FilterOverride` field reference.

--- a/docs/how-to/production-readiness.md
+++ b/docs/how-to/production-readiness.md
@@ -1,14 +1,11 @@
 # Production Readiness
 
-This is the S12f operator entry point. It describes the shipped v1.0 system only: no new
-product behavior, no dashboard renderer, and no normal workflow that depends on Envoy admin.
+This is the S12f operator entry point. It describes the shipped v1.0 system only: no new product behavior, no dashboard renderer, and no normal workflow that depends on Envoy admin.
 
 ## Evidence
 
 - Secret KEK rotation: [`secret-kek-rotation.md`](secret-kek-rotation.md)
-- Engineering evidence — release packaging, the failure-mode matrix, the
-  adversarial surface map, and the dev-dataplane walkthrough — lives in the
-  internal engineering docs: [`../../internal/README.md`](../../internal/README.md).
+- Engineering evidence — release packaging, the failure-mode matrix, the adversarial surface map, and the dev-dataplane walkthrough — lives in the internal engineering docs: [`../../internal/README.md`](../../internal/README.md).
 
 ## Deployment Shape
 
@@ -47,13 +44,9 @@ FLOWPLANE_PACKAGE_CA_PATH=/etc/flowplane/tls/ca.crt \
 scripts/release/package-release.sh
 ```
 
-Run Envoy and `fp-agent` beside each other in the dataplane network. The dataplane dials the
-control plane over xDS/diagnostics; the control plane must not dial Envoy admin as a product path.
-Envoy admin stays loopback-only and is a manual diagnostic fallback.
+Run Envoy and `fp-agent` beside each other in the dataplane network. The dataplane dials the control plane over xDS/diagnostics; the control plane must not dial Envoy admin as a product path. Envoy admin stays loopback-only and is a manual diagnostic fallback.
 
-Upgrade order is independent: upgrade CP first or DP first within the supported Envoy line. Existing
-dataplanes keep serving last-applied config during a CP restart; new dataplanes cannot join until
-the CP is back.
+Upgrade order is independent: upgrade CP first or DP first within the supported Envoy line. Existing dataplanes keep serving last-applied config during a CP restart; new dataplanes cannot join until the CP is back.
 
 ## Configuration Reference
 
@@ -99,8 +92,7 @@ Packaging:
 | Package outputs | `FLOWPLANE_PACKAGE_IMAGE`, `FLOWPLANE_PACKAGE_DATAPLANE` |
 | Dataplane package | `FLOWPLANE_PACKAGE_TEAM`, `FLOWPLANE_PACKAGE_DATAPLANE_NAME`, `FLOWPLANE_PACKAGE_DATAPLANE_MODE`, `FLOWPLANE_PACKAGE_XDS_HOST`, `FLOWPLANE_PACKAGE_XDS_PORT`, `FLOWPLANE_PACKAGE_ADMIN_PORT`, `FLOWPLANE_PACKAGE_CA_PATH`, `FLOWPLANE_PACKAGE_CERT_PATH`, `FLOWPLANE_PACKAGE_KEY_PATH` |
 
-AI providers, routes, budgets, and usage are runtime product config through the API/CLI, not
-deployment environment variables.
+AI providers, routes, budgets, and usage are runtime product config through the API/CLI, not deployment environment variables.
 
 ## Runbook
 
@@ -126,8 +118,7 @@ Back up together:
 4. Retired-key JSON in `FLOWPLANE_SECRET_ENCRYPTION_KEYS`.
 5. CP xDS/API TLS files and dataplane CA material.
 
-A database restore without the matching KEK material leaves encrypted secret rows undecryptable.
-Keep KEK escrow and rotation overlap aligned with [`secret-kek-rotation.md`](secret-kek-rotation.md).
+A database restore without the matching KEK material leaves encrypted secret rows undecryptable. Keep KEK escrow and rotation overlap aligned with [`secret-kek-rotation.md`](secret-kek-rotation.md).
 
 Restore:
 
@@ -187,5 +178,4 @@ scripts/release/package-release.sh
 FLOWPLANE_PACKAGE_IMAGE=1 scripts/release/package-release.sh
 ```
 
-The failure-mode matrix and adversarial surface map (in the internal engineering docs) are
-release evidence, not day-to-day operator runbooks.
+The failure-mode matrix and adversarial surface map (in the internal engineering docs) are release evidence, not day-to-day operator runbooks.

--- a/docs/how-to/secret-kek-rotation.md
+++ b/docs/how-to/secret-kek-rotation.md
@@ -1,16 +1,12 @@
 # Secret KEK Rotation
 
-Flowplane encrypts stored `SecretSpec` values with AES-256-GCM. Each secret row stores the
-`encryption_key_id` used for that ciphertext.
+Flowplane encrypts stored `SecretSpec` values with AES-256-GCM. Each secret row stores the `encryption_key_id` used for that ciphertext.
 
 ## Environment Contract
 
-- `FLOWPLANE_SECRET_ENCRYPTION_KEY`: active 32-byte key material. Accepts raw 32-byte text,
-  standard base64, or URL-safe base64 without padding.
-- `FLOWPLANE_SECRET_ENCRYPTION_KEY_ID`: id written to new/rotated secrets. Defaults to
-  `default`.
-- `FLOWPLANE_SECRET_ENCRYPTION_KEYS`: optional JSON object of retired keys, keyed by
-  `encryption_key_id`, used for decrypting old ciphertext. Example:
+- `FLOWPLANE_SECRET_ENCRYPTION_KEY`: active 32-byte key material. Accepts raw 32-byte text, standard base64, or URL-safe base64 without padding.
+- `FLOWPLANE_SECRET_ENCRYPTION_KEY_ID`: id written to new/rotated secrets. Defaults to `default`.
+- `FLOWPLANE_SECRET_ENCRYPTION_KEYS`: optional JSON object of retired keys, keyed by `encryption_key_id`, used for decrypting old ciphertext. Example:
 
 ```json
 {
@@ -22,15 +18,11 @@ Flowplane encrypts stored `SecretSpec` values with AES-256-GCM. Each secret row 
 ## Rotation Procedure
 
 1. Pick a new key id, for example `2026-07-primary`.
-2. Move the current key into `FLOWPLANE_SECRET_ENCRYPTION_KEYS` under its current
-   `FLOWPLANE_SECRET_ENCRYPTION_KEY_ID`.
+2. Move the current key into `FLOWPLANE_SECRET_ENCRYPTION_KEYS` under its current `FLOWPLANE_SECRET_ENCRYPTION_KEY_ID`.
 3. Set `FLOWPLANE_SECRET_ENCRYPTION_KEY` to the new key material.
 4. Set `FLOWPLANE_SECRET_ENCRYPTION_KEY_ID` to the new key id.
 5. Restart or roll the control plane so all writers and xDS rebuilders use the same keyring.
-6. Rotate existing Flowplane secrets through the normal secret rotate path. New ciphertext will
-   be written with the new key id.
-7. After all rows using the retired key id have been rotated and xDS has rebuilt successfully,
-   remove that retired key from `FLOWPLANE_SECRET_ENCRYPTION_KEYS`.
+6. Rotate existing Flowplane secrets through the normal secret rotate path. New ciphertext will be written with the new key id.
+7. After all rows using the retired key id have been rotated and xDS has rebuilt successfully, remove that retired key from `FLOWPLANE_SECRET_ENCRYPTION_KEYS`.
 
-Never remove a retired key while any `secrets.encryption_key_id` still references it; those
-secrets will be skipped during SDS rebuild until the key is restored or the secret is rotated.
+Never remove a retired key while any `secrets.encryption_key_id` still references it; those secrets will be skipped during SDS rebuild until the key is restored or the secret is rotated.

--- a/docs/observability-alerts.md
+++ b/docs/observability-alerts.md
@@ -1,13 +1,8 @@
 # Observability Alert Pack
 
-This pack is the S12b operator baseline for v1.0 production readiness. It uses the metrics that
-exist in the current control-plane and data-plane-adjacent services, plus the low-cardinality
-hardening metrics added for S12. Dashboards and alerts should keep labels bounded: do not add
-team, org, dataplane, route, budget, tool, or agent labels unless a later issue explicitly accepts
-the cardinality cost.
+This pack is the S12b operator baseline for v1.0 production readiness. It uses the metrics that exist in the current control-plane and data-plane-adjacent services, plus the low-cardinality hardening metrics added for S12. Dashboards and alerts should keep labels bounded: do not add team, org, dataplane, route, budget, tool, or agent labels unless a later issue explicitly accepts the cardinality cost.
 
-Native OpenTelemetry `gen_ai.*` semantic-convention meters are deferred for v1.0. Flowplane emits
-pragmatic counters for shipped AI budget behavior instead.
+Native OpenTelemetry `gen_ai.*` semantic-convention meters are deferred for v1.0. Flowplane emits pragmatic counters for shipped AI budget behavior instead.
 
 ## Metric Inventory
 
@@ -41,8 +36,7 @@ pragmatic counters for shipped AI budget behavior instead.
 
 ## Alert Baseline
 
-These expressions are a starting point. Tune the thresholds after production traffic establishes
-normal baselines.
+These expressions are a starting point. Tune the thresholds after production traffic establishes normal baselines.
 
 | Alert | Expression | Initial severity | Rationale |
 | --- | --- | --- | --- |
@@ -64,8 +58,7 @@ normal baselines.
 
 Use one production dashboard with these panels:
 
-1. API request rate, error rate, and p95 latency from `fp_api_requests_total` and
-   `fp_api_request_duration_ms`.
+1. API request rate, error rate, and p95 latency from `fp_api_requests_total` and `fp_api_request_duration_ms`.
 2. xDS health: NACKs, quarantines, translation failures, ADS stream opens/closes.
 3. Outbox health: pending events, oldest pending age, handled events, handler failures.
 4. DB pool health: in-use, idle, max, and in-use/max ratio.
@@ -74,11 +67,7 @@ Use one production dashboard with these panels:
 
 ## Operational Notes
 
-- The serve-owned sampler is read-only. It does not advance outbox cursors and does not contact
-  dataplanes.
-- `fp_outbox_pending_events` and `fp_outbox_oldest_pending_age_seconds` are currently emitted for
-  the `xds-snapshot` consumer.
-- `fp_xds_snapshot_rebuilds_total` still has a `team` label from earlier slice work. Do not copy
-  that pattern into new S12 metrics.
-- The ADS stream counters count authenticated ADS streams only. Failed authentication is covered by
-  xDS/API logs and the existing authn/authz surfaces, not these lifecycle counters.
+- The serve-owned sampler is read-only. It does not advance outbox cursors and does not contact dataplanes.
+- `fp_outbox_pending_events` and `fp_outbox_oldest_pending_age_seconds` are currently emitted for the `xds-snapshot` consumer.
+- `fp_xds_snapshot_rebuilds_total` still has a `team` label from earlier slice work. Do not copy that pattern into new S12 metrics.
+- The ADS stream counters count authenticated ADS streams only. Failed authentication is covered by xDS/API logs and the existing authn/authz surfaces, not these lifecycle counters.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2,8 +2,7 @@
 
 > Audience: operators, platform-engineers · Status: stable
 
-Every `FLOWPLANE_*` variable read by the control plane, the dataplane agent, and the
-CLI. Each variable appears once; the **Component** column says which process reads it.
+Every `FLOWPLANE_*` variable read by the control plane, the dataplane agent, and the CLI. Each variable appears once; the **Component** column says which process reads it.
 
 **Precedence**
 
@@ -69,10 +68,7 @@ Booleans accept `true`/`1`/`yes` and `false`/`0`/`no`. Invalid server values fai
 
 ## Constraints
 
-Enforcement timing varies: rows ¹–⁵ are validated at **server startup** (`flowplane serve`);
-rows ⁶, ¹⁰–¹² at **agent startup** (`fp-agent`); rows ⁷–⁹ at **use time** when the secret
-encrypt/decrypt/snapshot paths run (not at server startup). A violation yields an
-`invalid_config` (or, for a missing key, `unavailable`) error.
+Enforcement timing varies: rows ¹–⁵ are validated at **server startup** (`flowplane serve`); rows ⁶, ¹⁰–¹² at **agent startup** (`fp-agent`); rows ⁷–⁹ at **use time** when the secret encrypt/decrypt/snapshot paths run (not at server startup). A violation yields an `invalid_config` (or, for a missing key, `unavailable`) error.
 
 | # | Variable(s) | Constraint |
 |---|-------------|------------|

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -2,10 +2,7 @@
 
 > Audience: api-consumers, operators · Status: stable
 
-Every Flowplane API failure is returned as a single stable JSON envelope carrying a
-machine-readable `code`. Clients branch on `code`; the HTTP status is derived from it.
-The code set is a closed, append-only contract — codes may be added but never change
-meaning.
+Every Flowplane API failure is returned as a single stable JSON envelope carrying a machine-readable `code`. Clients branch on `code`; the HTTP status is derived from it. The code set is a closed, append-only contract — codes may be added but never change meaning.
 
 ## Error envelope
 
@@ -33,8 +30,7 @@ All error responses share this body:
 
 ## Codes
 
-One row per code. **Retryable** = the identical request may succeed if retried without
-modification.
+One row per code. **Retryable** = the identical request may succeed if retried without modification.
 
 | `code` | HTTP status | Retryable | Meaning |
 |--------|-------------|-----------|---------|
@@ -54,25 +50,19 @@ modification.
 
 ## Redaction of internal errors
 
-For `internal` and `invalid_config`, the server does **not** return the underlying
-message or `details`. The response body is:
+For `internal` and `invalid_config`, the server does **not** return the underlying message or `details`. The response body is:
 
 - `message`: `"an internal error occurred; report the request_id to your operator"`
 - `details`: omitted
 - `code` and `request_id`: present as normal
 
-The original message is written to the server log keyed by `request_id`, so an operator
-can correlate the redacted response with the real cause. The original `details` are not
-returned and not logged here.
+The original message is written to the server log keyed by `request_id`, so an operator can correlate the redacted response with the real cause. The original `details` are not returned and not logged here.
 
 ## Retry-After
 
-`rate_limited` (and any error carrying a retry-after value) sets the standard
-`Retry-After` response header to the number of seconds after which a retry may succeed.
+`rate_limited` (and any error carrying a retry-after value) sets the standard `Retry-After` response header to the number of seconds after which a retry may succeed.
 
 ## Source of truth
 
-- Code set, retryable predicate, and per-code meaning: `crates/fp-domain/src/error.rs`
-  (`ErrorCode`, `ErrorCode::is_retryable`).
-- HTTP status mapping, envelope, redaction, and `Retry-After`:
-  `crates/fp-api/src/error.rs` (`ApiError::status`, `ErrorBody`, `IntoResponse`).
+- Code set, retryable predicate, and per-code meaning: `crates/fp-domain/src/error.rs` (`ErrorCode`, `ErrorCode::is_retryable`).
+- HTTP status mapping, envelope, redaction, and `Retry-After`: `crates/fp-api/src/error.rs` (`ApiError::status`, `ErrorBody`, `IntoResponse`).

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -2,15 +2,11 @@
 
 > Audience: newcomers · Status: stable
 
-This tutorial walks you through one happy path from a clean checkout to a working
-gateway: you start the Flowplane control plane in **dev mode**, expose a single
-HTTP upstream through it, connect a local Envoy, and finish with a `curl` that
-reaches your upstream *through the gateway*.
+This tutorial walks you through one happy path from a clean checkout to a working gateway: you start the Flowplane control plane in **dev mode**, expose a single HTTP upstream through it, connect a local Envoy, and finish with a `curl` that reaches your upstream *through the gateway*.
 
 Follow the steps in order. Every command here is copy-pasteable.
 
-Dev mode runs an in-process identity issuer, seeds local resources, and serves the
-API and xDS over plaintext. It is for local exploration only — never production.
+Dev mode runs an in-process identity issuer, seeds local resources, and serves the API and xDS over plaintext. It is for local exploration only — never production.
 
 ---
 
@@ -18,42 +14,24 @@ API and xDS over plaintext. It is for local exploration only — never productio
 
 You need:
 
-- **PostgreSQL** reachable on your machine. This tutorial uses
-  `postgres://postgres:postgres@127.0.0.1:5432/flowplane_dev`. On Linux / containers
-  with a `postgres` superuser, `scripts/ensure-postgres.sh` creates the `flowplane_dev`
-  database and sets the `postgres` password to `postgres`. On **macOS / Homebrew** there
-  is no `postgres` role by default, so create it first (`createuser -s postgres` →
-  `ALTER USER postgres PASSWORD 'postgres'` → `createdb -O postgres flowplane_dev`), or
-  point `FLOWPLANE_DATABASE_URL` at your own superuser.
-- **Envoy installed** — a local `envoy` binary on your `PATH`. You use it in
-  step 6 to actually route traffic. On macOS, prefer the local binary over Docker.
-- **A Rust toolchain via [rustup](https://rustup.rs).** The repo pins its toolchain in
-  `rust-toolchain.toml`, which only takes effect when the build is driven through rustup —
-  it selects the pinned version automatically on first `cargo` invocation. Do **not** use a
-  distro-packaged `cargo` (e.g. `apt-get install cargo`): an older system cargo cannot read
-  this repo's version-4 `Cargo.lock` and fails before the build starts.
+- **PostgreSQL** reachable on your machine. This tutorial uses `postgres://postgres:postgres@127.0.0.1:5432/flowplane_dev`. On Linux / containers with a `postgres` superuser, `scripts/ensure-postgres.sh` creates the `flowplane_dev` database and sets the `postgres` password to `postgres`. On **macOS / Homebrew** there is no `postgres` role by default, so create it first (`createuser -s postgres` → `ALTER USER postgres PASSWORD 'postgres'` → `createdb -O postgres flowplane_dev`), or point `FLOWPLANE_DATABASE_URL` at your own superuser.
+- **Envoy installed** — a local `envoy` binary on your `PATH`. You use it in step 6 to actually route traffic. On macOS, prefer the local binary over Docker.
+- **A Rust toolchain via [rustup](https://rustup.rs).** The repo pins its toolchain in `rust-toolchain.toml`, which only takes effect when the build is driven through rustup — it selects the pinned version automatically on first `cargo` invocation. Do **not** use a distro-packaged `cargo` (e.g. `apt-get install cargo`): an older system cargo cannot read this repo's version-4 `Cargo.lock` and fails before the build starts.
 - **The `flowplane` binary.** Build it from the repo (rustup picks the pinned toolchain):
 
   ```bash
   cargo build --bin flowplane
   ```
 
-  Dev mode requires a binary built **with the `dev-oidc` feature**. That feature
-  is on by default, so a plain `cargo build --bin flowplane` (or `cargo run`)
-  includes it — both debug and local release builds (`cargo build --release`)
-  are fine. The commands below use `./target/debug/flowplane`.
+  Dev mode requires a binary built **with the `dev-oidc` feature**. That feature is on by default, so a plain `cargo build --bin flowplane` (or `cargo run`) includes it — both debug and local release builds (`cargo build --release`) are fine. The commands below use `./target/debug/flowplane`.
 
-  The published release container (`Containerfile.release`) is built
-  `--no-default-features`, so it does **not** include `dev-oidc` and rejects dev
-  mode entirely. Dev mode is for local builds only.
+  The published release container (`Containerfile.release`) is built `--no-default-features`, so it does **not** include `dev-oidc` and rejects dev mode entirely. Dev mode is for local builds only.
 
 ---
 
 ## 2. Start the control plane in dev mode
 
-Run this in its own terminal. These environment variables are the minimal set
-that lets the server start without an external OIDC provider, with the xDS
-listener enabled so Envoy can connect later:
+Run this in its own terminal. These environment variables are the minimal set that lets the server start without an external OIDC provider, with the xDS listener enabled so Envoy can connect later:
 
 ```bash
 FLOWPLANE_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/flowplane_dev \
@@ -66,18 +44,11 @@ FLOWPLANE_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/flowplane_dev
 
 What each variable does:
 
-- `FLOWPLANE_DATABASE_URL` — required; the server refuses to start without it.
-  Migrations are applied automatically on startup.
-- `FLOWPLANE_DEV_MODE=true` — enables the in-process issuer and seeds dev
-  resources. Mutually exclusive with `FLOWPLANE_OIDC_*`.
-- `FLOWPLANE_API_INSECURE=true` — opt in to a plaintext API listener (decision
-  D-008). Without TLS material *and* without this flag, the server refuses to
-  start. Acceptable only for local dev or behind a TLS-terminating proxy.
-- `FLOWPLANE_API_ADDR` — where the REST API listens (defaults to `0.0.0.0:8080`;
-  this tutorial uses `127.0.0.1:8096`).
-- `FLOWPLANE_XDS_ADDR` — where the xDS gRPC listener binds (defaults to
-  `0.0.0.0:18000`). Envoy connects here in step 6. In dev mode this listener is
-  plaintext.
+- `FLOWPLANE_DATABASE_URL` — required; the server refuses to start without it. Migrations are applied automatically on startup.
+- `FLOWPLANE_DEV_MODE=true` — enables the in-process issuer and seeds dev resources. Mutually exclusive with `FLOWPLANE_OIDC_*`.
+- `FLOWPLANE_API_INSECURE=true` — opt in to a plaintext API listener (decision D-008). Without TLS material *and* without this flag, the server refuses to start. Acceptable only for local dev or behind a TLS-terminating proxy.
+- `FLOWPLANE_API_ADDR` — where the REST API listens (defaults to `0.0.0.0:8080`; this tutorial uses `127.0.0.1:8096`).
+- `FLOWPLANE_XDS_ADDR` — where the xDS gRPC listener binds (defaults to `0.0.0.0:18000`). Envoy connects here in step 6. In dev mode this listener is plaintext.
 
 > **Dev mode is triple-gated.** It only runs when (1) the binary was built with
 > the `dev-oidc` feature, (2) `FLOWPLANE_DEV_MODE=true`, and (3) — in
@@ -105,15 +76,13 @@ Dev mode seeds one organization, team, and user:
 
 ## 3. Get a token and confirm authentication
 
-Dev mode mints a bearer token at startup and logs it once. Find the log line that
-looks like:
+Dev mode mints a bearer token at startup and logs it once. Find the log line that looks like:
 
 ```text
 WARN ... dev_token=<long-token-string> dev bearer token (valid 1h, this boot only)
 ```
 
-The token is valid for this control-plane process only and expires after one hour.
-If you restart the server, grab the new token.
+The token is valid for this control-plane process only and expires after one hour. If you restart the server, grab the new token.
 
 In a second terminal, point the CLI at the running server and export the token:
 
@@ -130,8 +99,7 @@ Confirm authentication works:
 ./target/debug/flowplane auth whoami
 ```
 
-This calls `GET /api/v1/auth/whoami` and echoes the principal the server sees. A
-successful response shows your `user_id`, org membership, and grant count.
+This calls `GET /api/v1/auth/whoami` and echoes the principal the server sees. A successful response shows your `user_id`, org membership, and grant count.
 
 If you get `401 token validation failed`, check that:
 
@@ -143,8 +111,7 @@ If you get `401 token validation failed`, check that:
 
 ## 4. Expose one HTTP upstream
 
-First, start a trivial upstream in a third terminal so there is something to route
-to. It must serve the body `hello-flowplane` so you can recognize it later:
+First, start a trivial upstream in a third terminal so there is something to route to. It must serve the body `hello-flowplane` so you can recognize it later:
 
 ```bash
 mkdir -p /tmp/fp-upstream
@@ -153,8 +120,7 @@ printf 'hello-flowplane\n' > index.html
 python3 -m http.server 3001
 ```
 
-Now use the `expose` shortcut. In one command it creates a cluster, a route
-config, and a listener that route to the upstream:
+Now use the `expose` shortcut. In one command it creates a cluster, a route config, and a listener that route to the upstream:
 
 ```bash
 ./target/debug/flowplane expose http://127.0.0.1:3001 \
@@ -169,15 +135,10 @@ The flags map directly to the request the server receives:
 - the positional argument is the **upstream** URL,
 - `--name` names the exposed service (and the resources it creates),
 - `--path` is the route match prefix (defaults to `/`),
-- `--port` is the listener port — this is the port Envoy will listen on, and it
-  must match the `curl` you run in step 7 (`10001` here),
-- `--public-base-url` is the address clients use to reach the listener; keep it
-  consistent with `--port` (`http://127.0.0.1:10001`). For real deployments set
-  it to the dataplane listener address clients can actually reach, or omit it.
+- `--port` is the listener port — this is the port Envoy will listen on, and it must match the `curl` you run in step 7 (`10001` here),
+- `--public-base-url` is the address clients use to reach the listener; keep it consistent with `--port` (`http://127.0.0.1:10001`). For real deployments set it to the dataplane listener address clients can actually reach, or omit it.
 
-On success the command prints a table describing the created resources, including
-a `curl_url` of `http://127.0.0.1:10001/` and the `cluster`, `route_config`, and
-`listener` it created.
+On success the command prints a table describing the created resources, including a `curl_url` of `http://127.0.0.1:10001/` and the `cluster`, `route_config`, and `listener` it created.
 
 (Optional intermediate check — confirm the control plane holds the resources:)
 
@@ -191,8 +152,7 @@ a `curl_url` of `http://127.0.0.1:10001/` and the `cluster`, `route_config`, and
 
 ## 5. Create a dataplane record
 
-Envoy connects to the control plane as a registered dataplane. The bootstrap
-generator needs this record to stamp a stable Envoy `node.id`:
+Envoy connects to the control plane as a registered dataplane. The bootstrap generator needs this record to stamp a stable Envoy `node.id`:
 
 ```bash
 ./target/debug/flowplane dataplane create dp-local --description "local Envoy"
@@ -202,8 +162,7 @@ generator needs this record to stamp a stable Envoy `node.id`:
 
 ## 6. Generate the Envoy bootstrap and start Envoy
 
-Generate the dev (plaintext) Envoy bootstrap config. Note that `--out` is a
-**global** flag and must come *before* the `dataplane bootstrap` subcommand:
+Generate the dev (plaintext) Envoy bootstrap config. Note that `--out` is a **global** flag and must come *before* the `dataplane bootstrap` subcommand:
 
 ```bash
 ./target/debug/flowplane --out /tmp/flowplane-envoy.yaml \
@@ -214,8 +173,7 @@ Generate the dev (plaintext) Envoy bootstrap config. Note that `--out` is a
   --admin-port 9901
 ```
 
-This points Envoy at the plaintext xDS listener you enabled in step 2
-(`FLOWPLANE_XDS_ADDR=0.0.0.0:18000`).
+This points Envoy at the plaintext xDS listener you enabled in step 2 (`FLOWPLANE_XDS_ADDR=0.0.0.0:18000`).
 
 Start Envoy with the generated config (in its own terminal):
 
@@ -227,8 +185,7 @@ envoy -c /tmp/flowplane-envoy.yaml --log-level info
 > `envoyproxy/envoy` image with `--network host` mounting the same config. On
 > macOS, prefer the local `envoy` binary as shown above.
 
-Wait until Envoy connects to xDS and warms the listener (you will see it pull the
-cluster, route, and listener from the control plane).
+Wait until Envoy connects to xDS and warms the listener (you will see it pull the cluster, route, and listener from the control plane).
 
 ---
 
@@ -246,12 +203,9 @@ You should get a `200 OK` whose body is:
 hello-flowplane
 ```
 
-That response came from your upstream (`:3001`) **through Envoy** (`:10001`),
-configured entirely by the Flowplane control plane. That is your first success.
+That response came from your upstream (`:3001`) **through Envoy** (`:10001`), configured entirely by the Flowplane control plane. That is your first success.
 
-If traffic does not flow, check, in order, that the control plane logs show Envoy
-connected to xDS, that the upstream still answers at `http://127.0.0.1:3001/`, and
-that port `10001` is not already in use.
+If traffic does not flow, check, in order, that the control plane logs show Envoy connected to xDS, that the upstream still answers at `http://127.0.0.1:3001/`, and that port `10001` is not already in use.
 
 To tear down what you created:
 
@@ -263,9 +217,7 @@ To tear down what you created:
 
 ## You now have a working gateway
 
-You started Flowplane in dev mode, authenticated with a dev token, exposed an
-upstream, connected a local Envoy, and reached the upstream through the gateway.
-From here:
+You started Flowplane in dev mode, authenticated with a dev token, exposed an upstream, connected a local Envoy, and reached the upstream through the gateway. From here:
 
 - **Securing the dataplane with mTLS:** [`../how-to/register-dataplane-mtls.md`](../how-to/register-dataplane-mtls.md)
 - **Every CLI command and flag:** [`../reference/cli.md`](../reference/cli.md)

--- a/scripts/ci/unwrap-docs.py
+++ b/scripts/ci/unwrap-docs.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Unwrap hard-wrapped prose in Markdown so renderers that treat single newlines as line breaks
+(this project's doc site) show flowing text instead of mid-sentence breaks.
+
+Joins each paragraph and each list item onto a single line, collapsing the wrap whitespace. Leaves
+structure intact: blank lines, ATX headings (#), tables (|), fenced code (``` / ~~~), blockquotes
+(>), indented code (4+ spaces), and any line ending in two spaces (an intentional hard break). A
+list item's wrapped continuation lines are folded into the item; nesting indentation is preserved.
+
+Usage:
+  scripts/ci/unwrap-docs.py --check PATH...   # exit 1 if any file would change (no writes)
+  scripts/ci/unwrap-docs.py         PATH...   # rewrite in place
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+FENCE = re.compile(r"^\s*(```|~~~)")
+HEADING = re.compile(r"^\#{1,6}\s")
+TABLE = re.compile(r"^\s*\|")
+BLOCKQUOTE = re.compile(r"^\s*>")
+HTML = re.compile(r"^\s*<")
+INDENTED_CODE = re.compile(r"^ {4,}\S")
+LIST_ITEM = re.compile(r"^(?P<indent>\s*)(?P<marker>[-*+]|\d+[.)])\s+(?P<body>.*)$")
+
+
+def _is_block_start(line: str) -> bool:
+    """A line that begins (or is) its own block and must never be folded into a paragraph."""
+    return bool(
+        line.strip() == ""
+        or HEADING.match(line)
+        or TABLE.match(line)
+        or BLOCKQUOTE.match(line)
+        or HTML.match(line)
+        or INDENTED_CODE.match(line)
+    )
+
+
+def unwrap(text: str) -> str:
+    lines = text.split("\n")
+    out: list[str] = []
+    in_fence = False
+    # An open accumulator is either a paragraph (prefix == "") or a list item (prefix == marker).
+    buf: list[str] = []
+    prefix: str | None = None  # None = nothing open; "" = paragraph; else the list-item prefix.
+
+    def flush():
+        nonlocal prefix
+        if prefix is not None:
+            joined = " ".join(s.strip() for s in buf if s.strip())
+            out.append(f"{prefix}{joined}" if prefix else joined)
+            buf.clear()
+            prefix = None
+
+    for line in lines:
+        if FENCE.match(line):
+            flush()
+            in_fence = not in_fence
+            out.append(line)
+            continue
+        if in_fence:
+            out.append(line)
+            continue
+
+        item = LIST_ITEM.match(line)
+        if item:
+            flush()
+            prefix = f"{item.group('indent')}{item.group('marker')} "
+            buf.append(item.group("body"))
+            continue
+
+        if _is_block_start(line) or line.endswith("  "):
+            flush()
+            out.append(line)
+            continue
+
+        # Plain text line. It continues an open paragraph / list item, or opens a new paragraph —
+        # preserving its leading indentation so an indented list-continuation paragraph stays
+        # indented (i.e. stays inside its list item) rather than dedenting to column 0.
+        if prefix is None:
+            prefix = re.match(r"\s*", line).group()
+        buf.append(line)
+
+    flush()
+    return "\n".join(out)
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    check = "--check" in args
+    paths = [a for a in args if a != "--check"]
+    changed = []
+    for p in paths:
+        with open(p, encoding="utf-8") as fh:
+            original = fh.read()
+        new = unwrap(original)
+        if new != original:
+            changed.append(p)
+            if not check:
+                with open(p, "w", encoding="utf-8") as fh:
+                    fh.write(new)
+    label = "would unwrap" if check else "unwrapped"
+    for p in changed:
+        print(f"{label}: {p}")
+    return 1 if (check and changed) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The docs site renders single newlines as line breaks, so hard-wrapped paragraphs showed mid-sentence breaks (per your screenshot of `tenancy-grants-xds.md`). This reflows every paragraph and list item in `docs/` onto one line — **word content unchanged** (verified: whitespace-collapsed text is byte-identical to before), boundary check + links still pass.

Adds `scripts/ci/unwrap-docs.py` — structure-aware (leaves headings, tables, fenced code, blockquotes, indented code, and two-space hard breaks intact; folds list-item continuations; preserves nesting indent). Re-runnable with `--check`.

13 files reflowed; no text changes.