### PR TITLE
docs: add FLOWPLANE_UPSTREAM_CA_BUNDLE to env var catalogue

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -44,6 +44,7 @@ Booleans accept `true`/`1`/`yes` and `false`/`0`/`no`. Invalid server values fai
 | `FLOWPLANE_CERT_ISSUER_CA_CERT_PATH` | server | — | for issuance | Issuing CA certificate PEM path. |
 | `FLOWPLANE_CERT_ISSUER_CA_KEY_PATH` | server | — | for issuance | Issuing CA private key PEM path. |
 | `FLOWPLANE_CERT_ISSUER_TRUST_DOMAIN` | server | `flowplane.local` | no | SPIFFE trust domain for issued dataplane identities. |
+| `FLOWPLANE_UPSTREAM_CA_BUNDLE` | server | `/etc/ssl/certs/ca-certificates.crt` | no | CA bundle path Envoy uses to verify materialized TLS upstreams that name neither an SDS validation secret nor an explicit `ca_cert_file`. The control plane reads this value at xDS-translation time, but the file itself is read by Envoy/dataplane (it must exist on the dataplane host), not by the control plane. Per-cluster `insecure_skip_verify` opts a cluster out of verification. |
 | `FLOWPLANE_DISCOVERY_ALLOWED_DESTINATIONS` | server | — | no | Comma-separated `host:port` allowlist for traffic discovery. |
 | `FLOWPLANE_MCP_ALLOWED_ORIGINS` | server | `http://localhost,http://127.0.0.1,http://[::1]` | no | Comma-separated allowed `Origin` values for the MCP endpoint. |
 | `FLOWPLANE_AGENT_ENVOY_ADMIN_URL` | agent | `http://127.0.0.1:9901` | no | Envoy admin base URL (usually loopback). |


### PR DESCRIPTION
Closes #132

## Problem
`docs/reference/configuration.md` opens by claiming it lists **every** `FLOWPLANE_*` variable read by the control plane, dataplane agent, and CLI. But `FLOWPLANE_UPSTREAM_CA_BUNDLE` — read by the control plane in `crates/fp-xds/src/translate.rs:672-675` (`default_upstream_ca_bundle()`) at xDS-translation time — was missing. The same knob is already documented in `docs/how-to/production-readiness.md`, so the two user docs were inconsistent.

## Fix
Docs-only. Add one row to the Variables table:

- Component: `server` (control plane reads the env var during xDS translation)
- Default: `/etc/ssl/certs/ca-certificates.crt` (matches the code fallback)
- Required: no
- Meaning: notes the file is resolved/read by Envoy/dataplane (not the control plane) and mentions the per-cluster `insecure_skip_verify` opt-out

No TOML key added — the variable is env-only from the xDS translator.

## Verification
- `grep -c UPSTREAM_CA docs/reference/configuration.md` → `1`
- Table row has the same 5 columns as the header
- Codex (independent verifier) approved both the design (GATE 1) and the diff (GATE 2); ran `cargo test -p fp-xds upstream_tls` (5 passed) and `scripts/ci/check-docs-boundary.py` (passed)