### PR TITLE
docs(aws): operator-seeded bootstrap + wire FLOWPLANE_BOOTSTRAP_TOKEN

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -100,15 +100,16 @@ mTLS terminated by Flowplane.
 
 ## Bootstrap Token
 
-On first boot, the control plane logs a single-use bootstrap token. Retrieve it from CloudWatch:
+The control plane is operator-seeded — it never generates or logs a bootstrap token, and an uninitialized non-dev instance with no token fails closed at startup. Generate a token, store it in Secrets Manager, and pass its ARN as `bootstrap_token_secret_arn`; the module injects it as `FLOWPLANE_BOOTSTRAP_TOKEN`:
 
 ```bash
-aws logs filter-log-events \
-  --log-group-name "$(tofu -chdir=deploy/aws output -raw cloudwatch_log_group)" \
-  --filter-pattern "bootstrap_token"
+BOOTSTRAP_TOKEN="$(openssl rand -hex 32)"
+aws secretsmanager create-secret \
+  --name /flowplane/prod/bootstrap-token \
+  --secret-string "$BOOTSTRAP_TOKEN"
 ```
 
-Use the token to initialize the platform admin with the verified OIDC subject.
+If the secret uses a customer-managed KMS key, add that key to `secret_kms_key_arns`. Use the same token to initialize the platform admin with the verified OIDC subject (`POST /api/v1/bootstrap/initialize`).
 
 ## Local Dataplane Smoke Test
 

--- a/deploy/aws/ecs.tf
+++ b/deploy/aws/ecs.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "task_execution_secrets" {
       "secretsmanager:GetSecretValue",
     ]
 
-    resources = [
+    resources = compact([
       var.secret_encryption_key_secret_arn,
       var.api_tls_cert_secret_arn,
       var.api_tls_key_secret_arn,
@@ -49,7 +49,8 @@ data "aws_iam_policy_document" "task_execution_secrets" {
       var.cert_issuer_ca_cert_secret_arn,
       var.cert_issuer_ca_key_secret_arn,
       aws_secretsmanager_secret.db_password.arn,
-    ]
+      var.bootstrap_token_secret_arn,
+    ])
   }
 
   dynamic "statement" {
@@ -127,17 +128,20 @@ resource "aws_ecs_task_definition" "control_plane" {
         var.oidc_jwks_uri == "" ? [] : [{ name = "FLOWPLANE_OIDC_JWKS_URI", value = var.oidc_jwks_uri }],
       )
 
-      secrets = [
-        { name = "FLOWPLANE_SECRET_ENCRYPTION_KEY", valueFrom = var.secret_encryption_key_secret_arn },
-        { name = "FLOWPLANE_API_TLS_CERT_PEM", valueFrom = var.api_tls_cert_secret_arn },
-        { name = "FLOWPLANE_API_TLS_KEY_PEM", valueFrom = var.api_tls_key_secret_arn },
-        { name = "FLOWPLANE_XDS_TLS_CERT_PEM", valueFrom = var.xds_tls_cert_secret_arn },
-        { name = "FLOWPLANE_XDS_TLS_KEY_PEM", valueFrom = var.xds_tls_key_secret_arn },
-        { name = "FLOWPLANE_XDS_TLS_CLIENT_CA_PEM", valueFrom = var.xds_tls_client_ca_secret_arn },
-        { name = "FLOWPLANE_CERT_ISSUER_CA_CERT_PEM", valueFrom = var.cert_issuer_ca_cert_secret_arn },
-        { name = "FLOWPLANE_CERT_ISSUER_CA_KEY_PEM", valueFrom = var.cert_issuer_ca_key_secret_arn },
-        { name = "FLOWPLANE_DB_PASSWORD", valueFrom = aws_secretsmanager_secret.db_password.arn },
-      ]
+      secrets = concat(
+        [
+          { name = "FLOWPLANE_SECRET_ENCRYPTION_KEY", valueFrom = var.secret_encryption_key_secret_arn },
+          { name = "FLOWPLANE_API_TLS_CERT_PEM", valueFrom = var.api_tls_cert_secret_arn },
+          { name = "FLOWPLANE_API_TLS_KEY_PEM", valueFrom = var.api_tls_key_secret_arn },
+          { name = "FLOWPLANE_XDS_TLS_CERT_PEM", valueFrom = var.xds_tls_cert_secret_arn },
+          { name = "FLOWPLANE_XDS_TLS_KEY_PEM", valueFrom = var.xds_tls_key_secret_arn },
+          { name = "FLOWPLANE_XDS_TLS_CLIENT_CA_PEM", valueFrom = var.xds_tls_client_ca_secret_arn },
+          { name = "FLOWPLANE_CERT_ISSUER_CA_CERT_PEM", valueFrom = var.cert_issuer_ca_cert_secret_arn },
+          { name = "FLOWPLANE_CERT_ISSUER_CA_KEY_PEM", valueFrom = var.cert_issuer_ca_key_secret_arn },
+          { name = "FLOWPLANE_DB_PASSWORD", valueFrom = aws_secretsmanager_secret.db_password.arn },
+        ],
+        var.bootstrap_token_secret_arn == "" ? [] : [{ name = "FLOWPLANE_BOOTSTRAP_TOKEN", valueFrom = var.bootstrap_token_secret_arn }],
+      )
 
       logConfiguration = {
         logDriver = "awslogs"

--- a/deploy/aws/outputs.tf
+++ b/deploy/aws/outputs.tf
@@ -29,7 +29,7 @@ output "ecs_service_name" {
 }
 
 output "cloudwatch_log_group" {
-  description = "CloudWatch log group containing control-plane logs and bootstrap token lines."
+  description = "CloudWatch log group containing control-plane logs."
   value       = aws_cloudwatch_log_group.control_plane.name
 }
 

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -199,3 +199,9 @@ variable "cert_issuer_trust_domain" {
   type        = string
   default     = "getflowplane.io"
 }
+
+variable "bootstrap_token_secret_arn" {
+  description = "Optional Secrets Manager ARN holding the operator-supplied bootstrap token. When set, it is injected as FLOWPLANE_BOOTSTRAP_TOKEN so the uninitialized control plane can be seeded. Empty = not wired (the instance will fail closed until initialized by other means)."
+  type        = string
+  default     = ""
+}

--- a/docs/how-to/aws-secure-deployment.md
+++ b/docs/how-to/aws-secure-deployment.md
@@ -75,19 +75,24 @@ Keep `xds.getflowplane.io` DNS-only. Do not proxy xDS through Cloudflare for thi
 
 ## Bootstrap
 
-The first CP task logs a single-use bootstrap token. It expires after 24 hours.
+The control plane is **operator-seeded**: it never generates or logs a bootstrap token. You supply one, and an uninitialized non-dev instance started with no token refuses to start (fails closed). See [Bootstrap the platform](bootstrap-platform.md) for the full model.
+
+Generate a token and store it in AWS Secrets Manager:
 
 ```bash
-aws logs filter-log-events \
-  --log-group-name "$(tofu -chdir=deploy/aws output -raw cloudwatch_log_group)" \
-  --filter-pattern "bootstrap_token"
+BOOTSTRAP_TOKEN="$(openssl rand -hex 32)"
+aws secretsmanager create-secret \
+  --name /flowplane/prod/bootstrap-token \
+  --secret-string "$BOOTSTRAP_TOKEN"
 ```
 
-Use it with your verified Auth0/OIDC subject:
+Pass the secret's ARN to the module via `bootstrap_token_secret_arn`; it is injected into the CP task as `FLOWPLANE_BOOTSTRAP_TOKEN`. (If the secret uses a customer-managed KMS key, also add that key to `secret_kms_key_arns`.) On first boot the CP seeds the token's hash and logs a confirmation **without** the value.
+
+Then initialize the platform admin once, using the **same** token and your verified Auth0/OIDC subject:
 
 ```bash
 curl -fsS -X POST https://cp.getflowplane.io/api/v1/bootstrap/initialize \
-  -H "Authorization: Bearer fpboot_xxxxxxxx" \
+  -H "Authorization: Bearer $BOOTSTRAP_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
         "org_name": "platform",


### PR DESCRIPTION
Closes #141

The AWS guide + deploy/aws/README described the pre-#113 generate-and-log bootstrap token; the ECS task wired none, so the documented deployment fails closed at boot. Rewrote both docs to the operator-seeded model and added optional non-breaking Terraform wiring (`bootstrap_token_secret_arn`, conditional secret + IAM). `tofu validate`/`fmt` pass.

Verified by Codex (GATE 1 + GATE 2).