### PR TITLE
fix(api): malformed JSON body returns the error envelope, not a bare 422

### DIFF
--- a/crates/fp-api/src/ai_api.rs
+++ b/crates/fp-api/src/ai_api.rs
@@ -1,5 +1,6 @@
 //! AI gateway REST endpoints.
 
+use crate::extract::ApiJson;
 use crate::error::ApiError;
 use crate::resources::{resolve_team, revision_from, ListQuery, Page};
 use crate::state::AppState;
@@ -178,7 +179,7 @@ pub async fn create_ai_provider(
     Path(team): Path<String>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<CreateAiProviderBody>,
+    ApiJson(body): ApiJson<CreateAiProviderBody>,
 ) -> Result<(axum::http::StatusCode, Json<AiProviderView>), ApiError> {
     let run = async {
         let team = resolve_team(&state, &ctx, &team).await?;
@@ -228,7 +229,7 @@ pub async fn update_ai_provider(
     headers: HeaderMap,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<UpdateAiProviderBody>,
+    ApiJson(body): ApiJson<UpdateAiProviderBody>,
 ) -> Result<Json<AiProviderView>, ApiError> {
     let run = async {
         let revision = revision_from(&headers)?;
@@ -299,7 +300,7 @@ pub async fn create_ai_route(
     Path(team): Path<String>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<CreateAiRouteBody>,
+    ApiJson(body): ApiJson<CreateAiRouteBody>,
 ) -> Result<(axum::http::StatusCode, Json<AiRouteView>), ApiError> {
     let run = async {
         let team = resolve_team(&state, &ctx, &team).await?;
@@ -349,7 +350,7 @@ pub async fn update_ai_route(
     headers: HeaderMap,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<UpdateAiRouteBody>,
+    ApiJson(body): ApiJson<UpdateAiRouteBody>,
 ) -> Result<Json<AiRouteView>, ApiError> {
     let run = async {
         let revision = revision_from(&headers)?;
@@ -420,7 +421,7 @@ pub async fn create_ai_budget(
     Path(team): Path<String>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<CreateAiBudgetBody>,
+    ApiJson(body): ApiJson<CreateAiBudgetBody>,
 ) -> Result<(axum::http::StatusCode, Json<AiBudgetView>), ApiError> {
     let run = async {
         let team = resolve_team(&state, &ctx, &team).await?;
@@ -470,7 +471,7 @@ pub async fn update_ai_budget(
     headers: HeaderMap,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<UpdateAiBudgetBody>,
+    ApiJson(body): ApiJson<UpdateAiBudgetBody>,
 ) -> Result<Json<AiBudgetView>, ApiError> {
     let run = async {
         let revision = revision_from(&headers)?;

--- a/crates/fp-api/src/api_lifecycle_api.rs
+++ b/crates/fp-api/src/api_lifecycle_api.rs
@@ -1,5 +1,6 @@
 //! API lifecycle REST endpoints (S8.2).
 
+use crate::extract::ApiJson;
 use crate::error::ApiError;
 use crate::resources::{resolve_team, revision_from, ListQuery, Page};
 use crate::state::AppState;
@@ -241,7 +242,7 @@ pub async fn create_api(
     Path(team): Path<String>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<CreateApiBody>,
+    ApiJson(body): ApiJson<CreateApiBody>,
 ) -> Result<(axum::http::StatusCode, Json<ApiStatusView>), ApiError> {
     let run = async {
         let team = resolve_team(&state, &ctx, &team).await?;
@@ -322,7 +323,7 @@ pub async fn update_mcp_tool(
     Path((team, name)): Path<(String, String)>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<UpdateApiToolBody>,
+    ApiJson(body): ApiJson<UpdateApiToolBody>,
 ) -> Result<Json<ApiToolView>, ApiError> {
     let run = async {
         let team = resolve_team(&state, &ctx, &team).await?;
@@ -351,7 +352,7 @@ pub async fn reject_spec_version(
     Path((team, name, version)): Path<(String, String, i64)>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<SpecReviewBody>,
+    ApiJson(body): ApiJson<SpecReviewBody>,
 ) -> Result<Json<SpecVersionSummary>, ApiError> {
     let run = async {
         let team = resolve_team(&state, &ctx, &team).await?;
@@ -397,7 +398,7 @@ pub async fn publish_spec_version(
     Path((team, name, version)): Path<(String, String, i64)>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<SpecReviewBody>,
+    ApiJson(body): ApiJson<SpecReviewBody>,
 ) -> Result<Json<PublishSpecView>, ApiError> {
     let run = async {
         let team = resolve_team(&state, &ctx, &team).await?;

--- a/crates/fp-api/src/dataplanes_api.rs
+++ b/crates/fp-api/src/dataplanes_api.rs
@@ -1,6 +1,7 @@
 //! Dataplane management endpoints. The certificate registry and xDS binding internals
 //! shipped in S5.4; S6 exposes the operator-facing REST surface.
 
+use crate::extract::ApiJson;
 use crate::error::{ApiError, ErrorBody};
 use crate::resources::{resolve_team, ListQuery, Page};
 use crate::state::AppState;
@@ -282,7 +283,7 @@ pub async fn create_dataplane(
     Path(team): Path<String>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<CreateDataplaneBody>,
+    ApiJson(body): ApiJson<CreateDataplaneBody>,
 ) -> Result<(StatusCode, Json<DataplaneView>), ApiError> {
     let run = async {
         let team = resolve_team(&state, &ctx, &team).await?;
@@ -336,7 +337,7 @@ pub async fn record_dataplane_telemetry(
     Path((team, name)): Path<(String, String)>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<DataplaneTelemetryBody>,
+    ApiJson(body): ApiJson<DataplaneTelemetryBody>,
 ) -> Result<Json<DataplaneView>, ApiError> {
     let run = async {
         if body.requests_delta < 0 || body.errors_delta < 0 || body.warming_failures_delta < 0 {
@@ -460,7 +461,7 @@ pub async fn register_proxy_certificate(
     Path(team): Path<String>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<RegisterProxyCertificateBody>,
+    ApiJson(body): ApiJson<RegisterProxyCertificateBody>,
 ) -> Result<(StatusCode, Json<ProxyCertificateView>), ApiError> {
     let run = async {
         let team = resolve_team(&state, &ctx, &team).await?;
@@ -499,7 +500,7 @@ pub async fn issue_proxy_certificate(
     Path(team): Path<String>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<IssueProxyCertificateBody>,
+    ApiJson(body): ApiJson<IssueProxyCertificateBody>,
 ) -> Result<(StatusCode, Json<IssuedProxyCertificateView>), ApiError> {
     let run = async {
         let team = resolve_team(&state, &ctx, &team).await?;
@@ -541,7 +542,7 @@ pub async fn revoke_proxy_certificate(
     Path((team, serial_number)): Path<(String, String)>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<RevokeProxyCertificateBody>,
+    ApiJson(body): ApiJson<RevokeProxyCertificateBody>,
 ) -> Result<Json<ProxyCertificateView>, ApiError> {
     let run = async {
         let team = resolve_team(&state, &ctx, &team).await?;

--- a/crates/fp-api/src/discovery_api.rs
+++ b/crates/fp-api/src/discovery_api.rs
@@ -1,5 +1,6 @@
 //! Discovery-session REST endpoints (S9).
 
+use crate::extract::ApiJson;
 use crate::error::ApiError;
 use crate::learning_api::LearnedSpecVersionView;
 use crate::resources::{resolve_team, Page};
@@ -198,7 +199,7 @@ pub async fn start_discovery_session(
     Path(team): Path<String>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<StartDiscoverySessionBody>,
+    ApiJson(body): ApiJson<StartDiscoverySessionBody>,
 ) -> Result<(axum::http::StatusCode, Json<DiscoverySessionView>), ApiError> {
     let input = body.into_service().map_err(|e| ApiError::new(e, rid))?;
     let run = async {

--- a/crates/fp-api/src/expose_api.rs
+++ b/crates/fp-api/src/expose_api.rs
@@ -1,6 +1,7 @@
 //! Expose shortcut REST surface. The shortcut creates/deletes normal gateway resources; it is
 //! operator UX, not a separate product source of truth.
 
+use crate::extract::ApiJson;
 use crate::error::{ApiError, ErrorBody};
 use crate::resources::{resolve_team, ClusterView, ListenerView, RouteConfigView};
 use crate::state::AppState;
@@ -97,7 +98,7 @@ pub async fn expose(
     Path(team): Path<String>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<ExposeBody>,
+    ApiJson(body): ApiJson<ExposeBody>,
 ) -> Result<(StatusCode, Json<ExposeView>), ApiError> {
     let run = async {
         let team = resolve_team(&state, &ctx, &team).await?;

--- a/crates/fp-api/src/extract.rs
+++ b/crates/fp-api/src/extract.rs
@@ -1,0 +1,48 @@
+//! Request extractors that keep failures on the standard error envelope.
+
+use axum::extract::rejection::JsonRejection;
+use axum::extract::{FromRequest, Request};
+use fp_domain::{DomainError, RequestId};
+
+use crate::error::ApiError;
+
+/// JSON body extractor that renders deserialization failures as the standard
+/// [`ApiError`] envelope (`validation_failed` → 400) instead of axum's default
+/// bare `422` plain-text [`JsonRejection`]. Use this for every REST request body
+/// so the documented contract ("every failure is the envelope; status derived
+/// from `code`") holds on the malformed-JSON path too.
+pub struct ApiJson<T>(pub T);
+
+impl<T, S> FromRequest<S> for ApiJson<T>
+where
+    T: serde::de::DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        // RequestId is injected into extensions by the request-id middleware before
+        // any extractor runs; fall back to a fresh one only if it is somehow absent.
+        let rid = req
+            .extensions()
+            .get::<RequestId>()
+            .copied()
+            .unwrap_or_else(RequestId::generate);
+
+        match axum::Json::<T>::from_request(req, state).await {
+            Ok(axum::Json(value)) => Ok(ApiJson(value)),
+            Err(rejection) => Err(ApiError::new(
+                DomainError::validation(rejection_message(&rejection)),
+                rid,
+            )),
+        }
+    }
+}
+
+/// axum's `JsonRejection::body_text()` already carries an informative,
+/// non-secret message (e.g. "Failed to deserialize the JSON body into the
+/// target type: ..."). Surface it as the envelope message, matching the
+/// existing well-typed-but-invalid validation path.
+fn rejection_message(rejection: &JsonRejection) -> String {
+    rejection.body_text()
+}

--- a/crates/fp-api/src/identity_api.rs
+++ b/crates/fp-api/src/identity_api.rs
@@ -1,6 +1,7 @@
 //! Team, membership, and grant endpoints (D-002: every identity workflow has an API/CLI
 //! path in v2 — the UI is gone).
 
+use crate::extract::ApiJson;
 use crate::error::{ApiError, ErrorBody};
 use crate::resources::resolve_team;
 use crate::state::AppState;
@@ -153,7 +154,7 @@ pub async fn create_team(
     State(state): State<AppState>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<CreateTeamBody>,
+    ApiJson(body): ApiJson<CreateTeamBody>,
 ) -> Result<(StatusCode, Json<TeamView>), ApiError> {
     let team = svc::create_team(&state.pool, &ctx, &body.name, &body.display_name, rid)
         .await
@@ -221,7 +222,7 @@ pub async fn add_member(
     Path(team): Path<String>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<AddMemberBody>,
+    ApiJson(body): ApiJson<AddMemberBody>,
 ) -> Result<StatusCode, ApiError> {
     let run = async {
         let team = resolve_team(&state, &ctx, &team).await?;
@@ -288,7 +289,7 @@ pub async fn add_grant(
     Path(team): Path<String>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<AddGrantBody>,
+    ApiJson(body): ApiJson<AddGrantBody>,
 ) -> Result<StatusCode, ApiError> {
     let run = async {
         let resource = Resource::parse(&body.resource)?;
@@ -343,7 +344,7 @@ pub async fn create_agent(
     State(state): State<AppState>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<CreateAgentBody>,
+    ApiJson(body): ApiJson<CreateAgentBody>,
 ) -> Result<(StatusCode, Json<AgentTokenView>), ApiError> {
     let grants = agent_grants(body.grants).map_err(|e| ApiError::new(e, rid))?;
     let kind = AgentKind::parse(&body.kind).map_err(|e| ApiError::new(e, rid))?;

--- a/crates/fp-api/src/learning_api.rs
+++ b/crates/fp-api/src/learning_api.rs
@@ -1,5 +1,6 @@
 //! Learning session REST endpoints (S8.3).
 
+use crate::extract::ApiJson;
 use crate::error::ApiError;
 use crate::resources::{resolve_team, Page};
 use crate::state::AppState;
@@ -234,7 +235,7 @@ pub async fn start_learning_session(
     Path(team): Path<String>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<StartLearningSessionBody>,
+    ApiJson(body): ApiJson<StartLearningSessionBody>,
 ) -> Result<(axum::http::StatusCode, Json<LearningSessionView>), ApiError> {
     let run = async {
         let team = resolve_team(&state, &ctx, &team).await?;

--- a/crates/fp-api/src/lib.rs
+++ b/crates/fp-api/src/lib.rs
@@ -11,6 +11,7 @@ pub mod dataplanes_api;
 pub mod discovery_api;
 pub mod error;
 pub mod expose_api;
+pub mod extract;
 pub mod identity_api;
 pub mod learning_api;
 pub mod mcp_api;

--- a/crates/fp-api/src/mcp_api.rs
+++ b/crates/fp-api/src/mcp_api.rs
@@ -95,8 +95,16 @@ pub async fn post(
     headers: HeaderMap,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(req): Json<JsonRpcRequest>,
+    body: axum::body::Bytes,
 ) -> Response {
+    // JSON-RPC transport: a malformed body is a Parse error (-32700), not the
+    // REST error envelope and not axum's bare 422.
+    let req: JsonRpcRequest = match serde_json::from_slice(&body) {
+        Ok(req) => req,
+        Err(_) => {
+            return rpc_error(None, -32700, "Parse error", rid, "validation").into_response()
+        }
+    };
     if let Err(error) = check_origin(&headers) {
         return rpc_error(req.id, -32600, error, rid, "origin").into_response();
     }
@@ -2321,22 +2329,26 @@ mod tests {
         }
     }
 
-    fn initialize_request() -> JsonRpcRequest {
-        JsonRpcRequest {
-            jsonrpc: Some("2.0".into()),
-            method: "initialize".into(),
-            params: json!({ "protocolVersion": PREFERRED_VERSION }),
-            id: Some(json!(1)),
-        }
+    fn initialize_request() -> axum::body::Bytes {
+        serde_json::to_vec(&json!({
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "params": { "protocolVersion": PREFERRED_VERSION },
+            "id": 1,
+        }))
+        .unwrap()
+        .into()
     }
 
-    fn ping_request() -> JsonRpcRequest {
-        JsonRpcRequest {
-            jsonrpc: Some("2.0".into()),
-            method: "ping".into(),
-            params: json!({}),
-            id: Some(json!(2)),
-        }
+    fn ping_request() -> axum::body::Bytes {
+        serde_json::to_vec(&json!({
+            "jsonrpc": "2.0",
+            "method": "ping",
+            "params": {},
+            "id": 2,
+        }))
+        .unwrap()
+        .into()
     }
 
     async fn json_body(response: Response<Body>) -> Value {
@@ -2378,7 +2390,7 @@ mod tests {
             HeaderMap::new(),
             Extension(ctx.clone()),
             Extension(RequestId::generate()),
-            Json(initialize_request()),
+            initialize_request(),
         )
         .await;
         let session = response
@@ -2400,7 +2412,7 @@ mod tests {
             headers,
             Extension(ctx),
             Extension(RequestId::generate()),
-            Json(ping_request()),
+            ping_request(),
         )
         .await;
         let body = json_body(response).await;
@@ -2415,7 +2427,7 @@ mod tests {
             HeaderMap::new(),
             Extension(user(UserId::generate(), org_id)),
             Extension(RequestId::generate()),
-            Json(initialize_request()),
+            initialize_request(),
         )
         .await;
         let session = response
@@ -2435,7 +2447,7 @@ mod tests {
             headers,
             Extension(user(UserId::generate(), org_id)),
             Extension(RequestId::generate()),
-            Json(ping_request()),
+            ping_request(),
         )
         .await;
         let body = json_body(response).await;
@@ -2452,7 +2464,7 @@ mod tests {
             headers,
             Extension(ctx.clone()),
             Extension(RequestId::generate()),
-            Json(initialize_request()),
+            initialize_request(),
         )
         .await;
         let body = json_body(response).await;
@@ -2468,7 +2480,7 @@ mod tests {
             headers,
             Extension(ctx),
             Extension(RequestId::generate()),
-            Json(initialize_request()),
+            initialize_request(),
         )
         .await;
         let body = json_body(response).await;

--- a/crates/fp-api/src/orgs_api.rs
+++ b/crates/fp-api/src/orgs_api.rs
@@ -1,5 +1,6 @@
 //! Organization endpoints (platform governance + org-admin member management).
 
+use crate::extract::ApiJson;
 use crate::error::{ApiError, ErrorBody};
 use crate::state::AppState;
 use axum::extract::{Extension, Path, State};
@@ -118,7 +119,7 @@ pub async fn create_org(
     State(state): State<AppState>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<CreateOrgBody>,
+    ApiJson(body): ApiJson<CreateOrgBody>,
 ) -> Result<(StatusCode, Json<OrgView>), ApiError> {
     let org = svc::create_org(&state.pool, &ctx, &body.name, &body.display_name, rid)
         .await
@@ -198,7 +199,7 @@ pub async fn add_member(
     Path(org): Path<String>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<AddOrgMemberBody>,
+    ApiJson(body): ApiJson<AddOrgMemberBody>,
 ) -> Result<StatusCode, ApiError> {
     let run = async {
         let role = OrgRole::parse(&body.role)?;

--- a/crates/fp-api/src/resources.rs
+++ b/crates/fp-api/src/resources.rs
@@ -3,6 +3,7 @@
 //! Every handler carries its OpenAPI declaration — the router and the document are split
 //! from the same `routes!` registration (spec/10 §9), so they cannot drift.
 
+use crate::extract::ApiJson;
 use crate::error::ApiError;
 use crate::state::AppState;
 use axum::extract::{Extension, Path, Query, State};
@@ -213,7 +214,7 @@ macro_rules! endpoints {
                 Path(team): Path<String>,
                 Extension(ctx): Extension<PrincipalCtx>,
                 Extension(rid): Extension<RequestId>,
-                Json(body): Json<$create_body>,
+                ApiJson(body): ApiJson<$create_body>,
             ) -> Result<(axum::http::StatusCode, Json<$view>), ApiError> {
                 let run = async {
                     let team = resolve_team(&state, &ctx, &team).await?;
@@ -265,7 +266,7 @@ macro_rules! endpoints {
                 headers: HeaderMap,
                 Extension(ctx): Extension<PrincipalCtx>,
                 Extension(rid): Extension<RequestId>,
-                Json(body): Json<$update_body>,
+                ApiJson(body): ApiJson<$update_body>,
             ) -> Result<Json<$view>, ApiError> {
                 let run = async {
                     let revision = revision_from(&headers)?;

--- a/crates/fp-api/src/route_generation_api.rs
+++ b/crates/fp-api/src/route_generation_api.rs
@@ -1,5 +1,6 @@
 //! S9 route generation plan REST endpoints.
 
+use crate::extract::ApiJson;
 use crate::error::ApiError;
 use crate::resources::resolve_team;
 use crate::state::AppState;
@@ -65,7 +66,7 @@ pub async fn create_route_plan(
     Path(team): Path<String>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<CreateRoutePlanBody>,
+    ApiJson(body): ApiJson<CreateRoutePlanBody>,
 ) -> Result<(axum::http::StatusCode, Json<RouteGenerationPlanView>), ApiError> {
     let run = async {
         let team = resolve_team(&state, &ctx, &team).await?;

--- a/crates/fp-api/src/routes.rs
+++ b/crates/fp-api/src/routes.rs
@@ -1,5 +1,6 @@
 //! Router assembly: health, readiness, metrics, JSON 404 fallback.
 
+use crate::extract::ApiJson;
 use crate::error::ApiError;
 use crate::middleware::request_id;
 use crate::state::AppState;
@@ -427,7 +428,7 @@ async fn bootstrap_initialize(
     State(state): State<AppState>,
     Extension(rid): Extension<RequestId>,
     headers: axum::http::HeaderMap,
-    Json(body): Json<BootstrapInitialize>,
+    ApiJson(body): ApiJson<BootstrapInitialize>,
 ) -> Result<Json<BootstrapResult>, ApiError> {
     let token = headers
         .get(axum::http::header::AUTHORIZATION)

--- a/crates/fp-api/src/secrets_api.rs
+++ b/crates/fp-api/src/secrets_api.rs
@@ -1,6 +1,7 @@
 //! Secret management endpoints. Values are write-only: create/rotate accept a SecretSpec,
 //! but every response is metadata plus `value_redacted = true`.
 
+use crate::extract::ApiJson;
 use crate::error::{ApiError, ErrorBody};
 use crate::resources::{resolve_team, revision_from, ListQuery, Page};
 use crate::state::AppState;
@@ -107,7 +108,7 @@ pub async fn create_secret(
     Path(team): Path<String>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<CreateSecretBody>,
+    ApiJson(body): ApiJson<CreateSecretBody>,
 ) -> Result<(StatusCode, Json<SecretView>), ApiError> {
     let run = async {
         let team = resolve_team(&state, &ctx, &team).await?;
@@ -177,7 +178,7 @@ pub async fn rotate_secret(
     headers: HeaderMap,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
-    Json(body): Json<RotateSecretBody>,
+    ApiJson(body): ApiJson<RotateSecretBody>,
 ) -> Result<Json<SecretView>, ApiError> {
     let run = async {
         let revision = revision_from(&headers)?;

--- a/crates/fp-api/tests/api_crud.rs
+++ b/crates/fp-api/tests/api_crud.rs
@@ -1697,3 +1697,68 @@ async fn secret_values_are_write_only_over_http() {
     assert_eq!(body["value_redacted"], true);
     assert!(body.get("spec").is_none());
 }
+
+// Regression for #138: a type-malformed JSON body must return the standard
+// error envelope (validation_failed -> 400), not axum's bare plain-text 422.
+#[tokio::test]
+async fn malformed_json_body_returns_validation_envelope() {
+    let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+        eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+        return;
+    };
+    let pool = fp_storage::connect(&url, 4).await.expect("connect");
+    fp_storage::migrate(&pool).await.expect("migrate");
+
+    let issuer = DevIssuer::generate().expect("issuer");
+    let validator = fp_core::OidcValidator::new(issuer.oidc_config());
+    validator
+        .load_jwks_json(issuer.jwks_json())
+        .await
+        .expect("jwks");
+    let subject = unique("sub");
+    let token = issuer
+        .mint(&subject, "malformed@test", "Malformed", 600)
+        .expect("mint");
+
+    let org = identity::create_org(&pool, &unique("org"), "")
+        .await
+        .expect("org");
+    let team = identity::create_team(&pool, org.id, &unique("team"), "")
+        .await
+        .expect("team");
+    let user = identity::upsert_user_by_subject(&pool, &subject, "malformed@test", "Malformed")
+        .await
+        .expect("user");
+    identity::add_org_membership(&pool, user, org.id, OrgRole::Admin)
+        .await
+        .expect("member");
+
+    let app = fp_api::build_router(fp_api::AppState {
+        pool,
+        prometheus: PrometheusBuilder::new().build_recorder().handle(),
+        version: "test",
+        validator: Some(std::sync::Arc::new(validator)),
+        write_throttle: std::sync::Arc::new(fp_api::throttle::WriteThrottle::new(1000)),
+        xds_readiness: None,
+        discovery_forwarding_policy: Default::default(),
+    });
+
+    // `port` typed as a string -> JSON deserialization failure.
+    let bad = r#"{"name":"x","spec":{"endpoints":[{"host":"10.0.0.1","port":"oops"}]}}"#;
+    let request = Request::builder()
+        .method("POST")
+        .uri(format!("/api/v1/teams/{}/clusters", team.name))
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from(bad))
+        .expect("request");
+
+    let response = app.oneshot(request).await.expect("send");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = json_of(response).await;
+    assert_eq!(body["code"], "validation_failed");
+    assert!(
+        body.get("request_id").and_then(|v| v.as_str()).is_some(),
+        "envelope must carry request_id, got: {body}"
+    );
+}

--- a/crates/fp-api/tests/mcp_transport.rs
+++ b/crates/fp-api/tests/mcp_transport.rs
@@ -346,3 +346,23 @@ async fn mcp_rejects_unsupported_protocol_versions() {
     let json = body_json(response).await;
     assert_eq!(json["error"]["data"]["kind"], "protocol");
 }
+
+// Regression for #138: a malformed JSON-RPC body must return a JSON-RPC parse
+// error (-32700), not axum's bare 422 and not the REST error envelope.
+#[tokio::test]
+async fn mcp_malformed_body_returns_jsonrpc_parse_error() {
+    let Some((app, token, _token_b, _team)) = app_with_tokens().await else {
+        return;
+    };
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/mcp")
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::from("{ this is not valid json"))
+        .expect("request");
+
+    let response = app.oneshot(request).await.expect("send");
+    let json = body_json(response).await;
+    assert_eq!(json["error"]["code"], -32700);
+}


### PR DESCRIPTION
Closes #138

Handlers used the stock `axum::Json` extractor, so a type-malformed body leaked axum's default plain-text 422 with no `code`. Added a `crate::extract::ApiJson<T>` extractor mapping `JsonRejection` to the standard `validation_failed` 400 envelope (30 REST sites); `mcp::post` (JSON-RPC) now returns `-32700`. Adds regression tests; full `fp-api` suite green, clippy clean.

Verified by Codex (GATE 1 + GATE 2).