### PR TITLE
style(fp-api): fix cargo fmt --check broken by #138 import order

### DIFF
--- a/crates/fp-api/src/ai_api.rs
+++ b/crates/fp-api/src/ai_api.rs
@@ -1,7 +1,7 @@
 //! AI gateway REST endpoints.
 
-use crate::extract::ApiJson;
 use crate::error::ApiError;
+use crate::extract::ApiJson;
 use crate::resources::{resolve_team, revision_from, ListQuery, Page};
 use crate::state::AppState;
 use axum::extract::{Extension, Path, Query, State};

--- a/crates/fp-api/src/api_lifecycle_api.rs
+++ b/crates/fp-api/src/api_lifecycle_api.rs
@@ -1,7 +1,7 @@
 //! API lifecycle REST endpoints (S8.2).
 
-use crate::extract::ApiJson;
 use crate::error::ApiError;
+use crate::extract::ApiJson;
 use crate::resources::{resolve_team, revision_from, ListQuery, Page};
 use crate::state::AppState;
 use axum::extract::{Extension, Path, Query, State};

--- a/crates/fp-api/src/dataplanes_api.rs
+++ b/crates/fp-api/src/dataplanes_api.rs
@@ -1,8 +1,8 @@
 //! Dataplane management endpoints. The certificate registry and xDS binding internals
 //! shipped in S5.4; S6 exposes the operator-facing REST surface.
 
-use crate::extract::ApiJson;
 use crate::error::{ApiError, ErrorBody};
+use crate::extract::ApiJson;
 use crate::resources::{resolve_team, ListQuery, Page};
 use crate::state::AppState;
 use axum::extract::{Extension, Path, Query, State};

--- a/crates/fp-api/src/discovery_api.rs
+++ b/crates/fp-api/src/discovery_api.rs
@@ -1,7 +1,7 @@
 //! Discovery-session REST endpoints (S9).
 
-use crate::extract::ApiJson;
 use crate::error::ApiError;
+use crate::extract::ApiJson;
 use crate::learning_api::LearnedSpecVersionView;
 use crate::resources::{resolve_team, Page};
 use crate::state::AppState;

--- a/crates/fp-api/src/expose_api.rs
+++ b/crates/fp-api/src/expose_api.rs
@@ -1,8 +1,8 @@
 //! Expose shortcut REST surface. The shortcut creates/deletes normal gateway resources; it is
 //! operator UX, not a separate product source of truth.
 
-use crate::extract::ApiJson;
 use crate::error::{ApiError, ErrorBody};
+use crate::extract::ApiJson;
 use crate::resources::{resolve_team, ClusterView, ListenerView, RouteConfigView};
 use crate::state::AppState;
 use axum::extract::{Extension, Path, State};

--- a/crates/fp-api/src/identity_api.rs
+++ b/crates/fp-api/src/identity_api.rs
@@ -1,8 +1,8 @@
 //! Team, membership, and grant endpoints (D-002: every identity workflow has an API/CLI
 //! path in v2 — the UI is gone).
 
-use crate::extract::ApiJson;
 use crate::error::{ApiError, ErrorBody};
+use crate::extract::ApiJson;
 use crate::resources::resolve_team;
 use crate::state::AppState;
 use axum::extract::{Extension, Path, State};

--- a/crates/fp-api/src/learning_api.rs
+++ b/crates/fp-api/src/learning_api.rs
@@ -1,7 +1,7 @@
 //! Learning session REST endpoints (S8.3).
 
-use crate::extract::ApiJson;
 use crate::error::ApiError;
+use crate::extract::ApiJson;
 use crate::resources::{resolve_team, Page};
 use crate::state::AppState;
 use axum::extract::{Extension, Path, Query, State};

--- a/crates/fp-api/src/mcp_api.rs
+++ b/crates/fp-api/src/mcp_api.rs
@@ -101,9 +101,7 @@ pub async fn post(
     // REST error envelope and not axum's bare 422.
     let req: JsonRpcRequest = match serde_json::from_slice(&body) {
         Ok(req) => req,
-        Err(_) => {
-            return rpc_error(None, -32700, "Parse error", rid, "validation").into_response()
-        }
+        Err(_) => return rpc_error(None, -32700, "Parse error", rid, "validation").into_response(),
     };
     if let Err(error) = check_origin(&headers) {
         return rpc_error(req.id, -32600, error, rid, "origin").into_response();

--- a/crates/fp-api/src/orgs_api.rs
+++ b/crates/fp-api/src/orgs_api.rs
@@ -1,7 +1,7 @@
 //! Organization endpoints (platform governance + org-admin member management).
 
-use crate::extract::ApiJson;
 use crate::error::{ApiError, ErrorBody};
+use crate::extract::ApiJson;
 use crate::state::AppState;
 use axum::extract::{Extension, Path, State};
 use axum::http::StatusCode;

--- a/crates/fp-api/src/resources.rs
+++ b/crates/fp-api/src/resources.rs
@@ -3,8 +3,8 @@
 //! Every handler carries its OpenAPI declaration — the router and the document are split
 //! from the same `routes!` registration (spec/10 §9), so they cannot drift.
 
-use crate::extract::ApiJson;
 use crate::error::ApiError;
+use crate::extract::ApiJson;
 use crate::state::AppState;
 use axum::extract::{Extension, Path, Query, State};
 use axum::http::HeaderMap;

--- a/crates/fp-api/src/route_generation_api.rs
+++ b/crates/fp-api/src/route_generation_api.rs
@@ -1,7 +1,7 @@
 //! S9 route generation plan REST endpoints.
 
-use crate::extract::ApiJson;
 use crate::error::ApiError;
+use crate::extract::ApiJson;
 use crate::resources::resolve_team;
 use crate::state::AppState;
 use axum::extract::{Extension, Path, State};

--- a/crates/fp-api/src/routes.rs
+++ b/crates/fp-api/src/routes.rs
@@ -1,7 +1,7 @@
 //! Router assembly: health, readiness, metrics, JSON 404 fallback.
 
-use crate::extract::ApiJson;
 use crate::error::ApiError;
+use crate::extract::ApiJson;
 use crate::middleware::request_id;
 use crate::state::AppState;
 use axum::extract::{Extension, State};

--- a/crates/fp-api/src/secrets_api.rs
+++ b/crates/fp-api/src/secrets_api.rs
@@ -1,8 +1,8 @@
 //! Secret management endpoints. Values are write-only: create/rotate accept a SecretSpec,
 //! but every response is metadata plus `value_redacted = true`.
 
-use crate::extract::ApiJson;
 use crate::error::{ApiError, ErrorBody};
+use crate::extract::ApiJson;
 use crate::resources::{resolve_team, revision_from, ListQuery, Page};
 use crate::state::AppState;
 use axum::extract::{Extension, Path, Query, State};


### PR DESCRIPTION
Follow-up to #138 (PR #148). The added `use crate::extract::ApiJson;` was inserted before `use crate::error::ApiError;`, breaking rustfmt's import ordering — the `quality` job (`cargo fmt --check` under `-D warnings`) went red on main after the squash-merge. `cargo fmt` reorders the import across the 13 affected fp-api modules. Verified: `cargo fmt --check` clean, `cargo clippy -p fp-api` and `cargo build` clean under `-D warnings`.