### PR TITLE
docs(spec): reconcile spec/05-auth + spec/03-domain-model to v2 code (#153)

### DIFF
--- a/spec/03-domain-model.md
+++ b/spec/03-domain-model.md
@@ -63,12 +63,13 @@ Domain layer (`src/domain/`) is intentionally small; most persistence types are 
 
 | Entity | Table | Meaning / lifecycle |
 |---|---|---|
-| Organization | `organizations` | Outer tenant boundary. Status `active\|suspended\|archived` (CHECK). Special org named `platform` (renamed from `default`, `migrations/20260212000001`) is governance-only, not a tenant. Hard delete (RESTRICTed by teams). |
-| OrganizationMembership | `organization_memberships` | user↔org with role `owner\|admin\|member\|viewer` (CHECK). One row per (user, org). |
-| User | `users` | Humans and machines. `user_type` `human\|machine` (CHECK, `migrations/20260306000001` Part D). `is_admin` = platform superadmin. `zitadel_sub` UNIQUE links to Zitadel JWT `sub` (JIT provisioning; PAT tables were dropped in `migrations/20260228100001`). `agent_context` (`cp-tool\|gateway-tool\|api-consumer`, CHECK, NULL for humans) classifies machine users. `password_hash` still NOT NULL (legacy of pre-Zitadel auth). Status TEXT default `active` (no CHECK). |
-| Team | `teams` | Primary isolation unit. Name unique **per org** (`UNIQUE(org_id,name)` since `migrations/20260208000001`). `envoy_admin_port` BIGINT, globally UNIQUE — auto-allocated per-team Envoy admin port. Status `active\|inactive\|archived` (doc comment only, **no CHECK**). |
-| UserTeamMembership | `user_team_memberships` | user↔team link. The `scopes` JSON column was migrated into `grants` and dropped (`migrations/20260306000002`); the row now only asserts membership. |
-| Grant | `grants` | Unified authorization grant (replaced `scopes`, `agent_grants`, membership scopes — `migrations/20260306000001`). `grant_type` `resource\|gateway-tool\|route`; resource grants carry `(resource_type, action)`, gateway/route grants carry `route_id` + optional `allowed_methods TEXT[]` (NULL = all methods). Optional `expires_at`. |
+| Organization | `organizations` | Outer tenant boundary. Status `active\|suspended` (CHECK). Special org named `platform` is governance-only, not a tenant (`crates/fp-storage/src/repos/identity.rs::set_platform_org`). Hard delete (RESTRICTed by teams). (`migrations/0002_identity.sql:8-15`) |
+| OrgMembership | `org_memberships` | user↔org with role `owner\|admin\|member\|viewer` (CHECK). One row per (user, org). (`migrations/0002_identity.sql:58-65`) |
+| User | `users` | Human identities only. `subject` TEXT NOT NULL UNIQUE is the OIDC `sub` claim — **provider-agnostic** (any compliant IdP; Q-004), populated by JIT provisioning on first authenticated request. `email`/`name` come from the token claims; `status` `active\|suspended` (CHECK). **No** `password_hash`, `is_admin`, `user_type`, or `agent_context` column — machines are a separate `agents` table. (`migrations/0002_identity.sql:31-41`) |
+| Agent | `agents` | Machine identities, org-owned (service accounts / AI tools). `kind` `cp-tool\|gateway-tool\|api-consumer` (CHECK) structurally bounds reachable surfaces. Authenticates via a Flowplane-issued `fpat_*` bearer token whose SHA-256 `token_hash` is stored (`UNIQUE(token_hash)`, `migrations/0028_agents_token_hash_unique.sql`); `status` `active\|suspended`. `UNIQUE(org_id, name)`. (`migrations/0002_identity.sql:43-56`) |
+| Team | `teams` | Primary isolation unit. Name unique **per org** (`UNIQUE(org_id,name)`); also `UNIQUE(id,org_id)` so composite FKs can prove team ∈ org. Status `active\|suspended` (CHECK). (`migrations/0002_identity.sql:17-29`) |
+| TeamMembership | `team_memberships` | user↔team link asserting membership only — no scopes column. `UNIQUE(user_id, team_id)`. (`migrations/0002_identity.sql:67-73`) |
+| Grant | `grants` | Unified authorization grant. `(principal_type` `user\|agent`, `principal_id`, `org_id`, `team_id`, `resource`, `action` `read\|create\|update\|delete\|execute)`; composite FK `(team_id,org_id) → teams(id,org_id)`; `UNIQUE(principal_type,principal_id,team_id,resource,action)`. **No** grant subtype, `route_id`, `allowed_methods`, or `expires_at` — gateway-tool reach is enforced structurally by agent `kind` (spec/05 §3). (`migrations/0002_identity.sql:75-91`) |
 
 ### 2.2 Gateway resources (xDS)
 
@@ -143,69 +144,70 @@ Type/constraint notation is PostgreSQL. "team" semantics: since `migrations/2026
 
 ### 3.1 Org / user / auth
 
+Identity/auth tables are defined fresh in `migrations/0002_identity.sql` — UUID PKs, provider-agnostic OIDC `subject`, separate human (`users`) and machine (`agents`) tables, and a single `grants` table. There is no `password_hash`, `is_admin`, `zitadel_sub`, `user_type`, `agent_context`, or scope-string column.
+
 ```sql
-organizations (
-  id TEXT PK, name TEXT NOT NULL UNIQUE, display_name TEXT NOT NULL, description TEXT,
-  owner_user_id TEXT FK->users(id) ON DELETE SET NULL, settings TEXT,
-  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','suspended','archived')),
-  created_at TIMESTAMPTZ NOT NULL DEFAULT now, updated_at TIMESTAMPTZ NOT NULL DEFAULT now)
--- idx: name, status
+organizations (                                            -- 0002_identity.sql:8-15
+  id UUID PK, name TEXT NOT NULL UNIQUE, display_name TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','suspended')),
+  created_at, updated_at TIMESTAMPTZ NOT NULL DEFAULT now())
 
-organization_memberships (
-  id TEXT PK, user_id TEXT NOT NULL FK->users CASCADE, org_id TEXT NOT NULL FK->organizations CASCADE,
-  role TEXT NOT NULL DEFAULT 'member' CHECK (role IN ('owner','admin','member','viewer')),
-  created_at TIMESTAMPTZ NOT NULL)
--- UNIQUE INDEX (user_id, org_id); idx: org_id
+teams (                                                    -- 0002_identity.sql:17-29
+  id UUID PK, org_id UUID NOT NULL FK->organizations(id) ON DELETE RESTRICT,
+  name TEXT NOT NULL, display_name TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','suspended')),
+  created_at, updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (org_id, name),
+  UNIQUE (id, org_id))                                     -- target of composite FKs proving team ∈ org
 
-users (
-  id TEXT PK, email TEXT NOT NULL UNIQUE, password_hash TEXT NOT NULL, name TEXT NOT NULL,
-  status TEXT NOT NULL DEFAULT 'active',                  -- no CHECK
-  is_admin BOOLEAN NOT NULL DEFAULT FALSE,                -- platform superadmin
-  zitadel_sub TEXT UNIQUE,
-  user_type TEXT NOT NULL DEFAULT 'human' CHECK (user_type IN ('human','machine')),
-  agent_context TEXT NULL CHECK (agent_context IN ('cp-tool','gateway-tool','api-consumer')),
-  created_at, updated_at TIMESTAMPTZ NOT NULL)
--- org_id added 20260206000003 then DROPPED 20260302000002 (membership via organization_memberships)
--- idx: email, status, is_admin, (status,is_admin) WHERE is_admin, zitadel_sub, user_type,
---      agent_context WHERE NOT NULL
+users (                                                    -- humans only, 0002_identity.sql:31-41
+  id UUID PK,
+  subject TEXT NOT NULL UNIQUE,                            -- OIDC `sub`, provider-agnostic (Q-004)
+  email TEXT NOT NULL DEFAULT '', name TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','suspended')),
+  created_at, updated_at TIMESTAMPTZ NOT NULL DEFAULT now())
 
-teams (
-  id TEXT PK, name TEXT NOT NULL, display_name TEXT NOT NULL, description TEXT,
-  owner_user_id TEXT FK->users SET NULL, settings TEXT,
-  status TEXT NOT NULL DEFAULT 'active',                  -- no CHECK
-  envoy_admin_port BIGINT,                                -- UNIQUE INDEX (global)
-  org_id TEXT NOT NULL FK->organizations(id) ON DELETE RESTRICT,
-  created_at, updated_at TIMESTAMPTZ NOT NULL,
-  UNIQUE (org_id, name))                                  -- was globally UNIQUE(name) until 20260208000001
--- idx: status, owner_user_id, org_id, (org_id,name), (status,org_id,name), envoy_admin_port UNIQUE
+agents (                                                   -- machines, 0002_identity.sql:43-56
+  id UUID PK, org_id UUID NOT NULL FK->organizations(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('cp-tool','gateway-tool','api-consumer')),
+  token_hash TEXT NOT NULL,                                -- SHA-256 of fpat_* token; UNIQUE (migration 0028)
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active','suspended')),
+  created_by UUID FK->users(id) ON DELETE SET NULL,
+  created_at, updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (org_id, name))
 
-user_team_memberships (
-  id TEXT PK,
-  user_id TEXT NOT NULL FK->users CASCADE,    -- NB: FK declared twice (inline + fk_user_team_memberships_user_id)
-  team TEXT NOT NULL FK->teams(id) CASCADE,   -- stores team ID
-  created_at TIMESTAMPTZ NOT NULL)
--- scopes column DROPPED 20260306000002
--- UNIQUE INDEX (user_id, team); idx: user_id, team
+org_memberships (                                          -- 0002_identity.sql:58-65
+  id UUID PK, user_id UUID NOT NULL FK->users CASCADE, org_id UUID NOT NULL FK->organizations CASCADE,
+  role TEXT NOT NULL CHECK (role IN ('owner','admin','member','viewer')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, org_id))
 
-grants (                                                  -- 20260306000001
-  id TEXT PK,
-  principal_id TEXT NOT NULL FK->users CASCADE,
-  org_id TEXT NOT NULL FK->organizations CASCADE,
-  team_id TEXT NOT NULL FK->teams CASCADE,
-  grant_type TEXT NOT NULL CHECK (grant_type IN ('resource','gateway-tool','route')),
-  resource_type TEXT, action TEXT,
-  route_id TEXT FK->routes(id) CASCADE,
-  allowed_methods TEXT[],                                 -- NULL = all methods
-  created_by TEXT NOT NULL FK->users(id),                 -- NO ON DELETE action (blocks user delete)
-  created_at TIMESTAMPTZ NOT NULL, expires_at TIMESTAMPTZ,
-  CHECK (grant_type != 'resource' OR (resource_type IS NOT NULL AND action IS NOT NULL)),
-  CHECK (grant_type  = 'resource' OR route_id IS NOT NULL))
--- PARTIAL UNIQUE: (principal_id,team_id,resource_type,action) WHERE grant_type='resource'
--- PARTIAL UNIQUE: (principal_id,grant_type,route_id) WHERE grant_type IN ('gateway-tool','route')
--- idx: principal_id, org_id, team_id
+team_memberships (                                         -- 0002_identity.sql:67-73
+  id UUID PK, user_id UUID NOT NULL FK->users CASCADE, team_id UUID NOT NULL FK->teams CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, team_id))
+
+grants (                                                   -- 0002_identity.sql:75-91
+  id UUID PK,
+  principal_type TEXT NOT NULL CHECK (principal_type IN ('user','agent')),
+  principal_id UUID NOT NULL, org_id UUID NOT NULL, team_id UUID NOT NULL,
+  resource TEXT NOT NULL,
+  action TEXT NOT NULL CHECK (action IN ('read','create','update','delete','execute')),
+  created_by UUID FK->users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  FOREIGN KEY (team_id, org_id) REFERENCES teams(id, org_id) ON DELETE CASCADE,
+  UNIQUE (principal_type, principal_id, team_id, resource, action))
+-- idx: (principal_type, principal_id), team_id
+
+bootstrap_tokens (                                         -- one-shot platform-admin bootstrap, 0002_identity.sql:114-121
+  id UUID PK, token_hash TEXT NOT NULL UNIQUE,             -- SHA-256 of fpboot_* token
+  expires_at TIMESTAMPTZ NOT NULL, used_at TIMESTAMPTZ,    -- 24h, single-use
+  operator_seeded BOOLEAN NOT NULL DEFAULT false,          -- migration 0029
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now())
 ```
 
-Dropped auth tables (must NOT be reimplemented): `personal_access_tokens`, `token_scopes`, `invitations` (`migrations/20260228100001` — replaced by Zitadel), `scopes` and `agent_grants` (`migrations/20260306000001` — replaced by `grants`), `configuration_versions` (`migrations/20241201000006`), `route_access_grants` (never shipped).
+There is no `grant_type`/`resource_type`/`route_id`/`allowed_methods`/`expires_at` on a grant: a grant is one `(principal, resource, action, team)` row, and gateway-tool reach is enforced structurally by agent `kind` (spec/05 §3). Auth tables that never exist in v2 (do **not** reimplement): personal access tokens, token scopes, invitations, a `scopes` table, `agent_grants`, or any `password_hash`/`zitadel_sub` column.
 
 ### 3.2 Gateway resources
 
@@ -535,9 +537,9 @@ instance_apps (
 | `envoy_admin_port` globally unique across teams | `idx_teams_envoy_admin_port` |
 | Per-team name uniqueness: filters, secrets, custom_wasm_filters, mcp_tools, dataplanes, import_metadata (spec_name), learning_sessions (name, partial) | `UNIQUE(team, name)` etc. |
 | One default dataplane per team (partial unique), and exactly one required per non-platform team (D8) | `migrations/20260607000001` |
-| `users.email` UNIQUE, `users.zitadel_sub` UNIQUE | |
+| `users.subject` UNIQUE (OIDC `sub` → local identity), `agents.token_hash` UNIQUE, `agents` `UNIQUE(org_id,name)` | `migrations/0002_identity.sql`, `migrations/0028_agents_token_hash_unique.sql` |
 | One membership per (user, team) and per (user, org) | unique indexes |
-| Grants deduped via **partial** unique indexes (NULLs distinct in plain UNIQUE) | `migrations/20260304000002` comment explains rationale |
+| Grants deduped via one plain `UNIQUE(principal_type, principal_id, team_id, resource, action)` | `migrations/0002_identity.sql:88` (+ indexes on `(principal_type,principal_id)` and `team_id`) |
 | `proxy_certificates.spiffe_uri` UNIQUE (mTLS identity binding must be a point lookup) | `migrations/20260519000001` |
 | Filter order unique per attachment parent | `UNIQUE(parent_id, filter_order)` on all 4 junctions |
 | `route_metadata` 1:1 with route | `UNIQUE(route_id)` |
@@ -546,11 +548,11 @@ instance_apps (
 
 ### 4.2 Referential / cascade rules (delete behavior)
 
-- **Team delete:** RESTRICTed by `clusters`, `route_configs`, `listeners`, `filters`, `secrets`, `custom_wasm_filters` (core resources must be removed first); CASCADEs `learning_sessions`(→`inferred_schemas` via session), `aggregated_api_schemas`, `import_metadata`, `mcp_tools`, `dataplanes`, `user_team_memberships`, `proxy_certificates`, `xds_nack_events`, `grants`, rate-limit tables.
-- **Org delete:** RESTRICTed by `teams.org_id`; CASCADEs `organization_memberships`, `grants`, rate-limit tables.
-- **User delete:** CASCADEs memberships and `grants.principal_id`; SET NULL on `teams.owner_user_id`, `organizations.owner_user_id`, `proxy_certificates.issued_by_user_id`; **blocked** by `grants.created_by` (FK with no ON DELETE action).
+- **Team delete:** RESTRICTed by `clusters`, `route_configs`, `listeners`, `filters`, `secrets`, `custom_wasm_filters` (core resources must be removed first); CASCADEs `learning_sessions`(→`inferred_schemas` via session), `aggregated_api_schemas`, `import_metadata`, `mcp_tools`, `dataplanes`, `team_memberships`, `proxy_certificates`, `xds_nack_events`, `grants` (via the `(team_id,org_id)` composite FK), rate-limit tables.
+- **Org delete:** RESTRICTed by `teams.org_id`; CASCADEs `org_memberships`, `agents`, `grants`, rate-limit tables.
+- **User delete:** CASCADEs `org_memberships` and `team_memberships` (both `user_id` ON DELETE CASCADE, `0002_identity.sql:60,69`); SET NULL on `grants.created_by` and `agents.created_by` (`0002_identity.sql:52,85`). `grants.principal_id` has **no** FK, so a user's grant rows are not auto-removed by the DB on delete.
 - **Cluster delete:** CASCADEs `route_configs` via `cluster_name` FK (deleting a cluster silently deletes route configs that name it!), `cluster_endpoints`, `cluster_references`.
-- **RouteConfig delete:** CASCADEs `virtual_hosts` → `routes` → `route_filters`, `route_config_filters`, `listener_route_configs`, `listener_auto_filters`, and via `routes`: `route_metadata`, `mcp_tools.route_id`, `grants.route_id`.
+- **RouteConfig delete:** CASCADEs `virtual_hosts` → `routes` → `route_filters`, `route_config_filters`, `listener_route_configs`, `listener_auto_filters`, and via `routes`: `route_metadata`, `mcp_tools.route_id`. (v2 `grants` has no `route_id` — route grants do not exist; see §3.1.)
 - **Filter delete:** RESTRICTed by all 4 attachment junctions (must detach first); `listener_auto_filters.source_filter_id` CASCADEs.
 - **Import delete:** CASCADEs `route_configs.import_id` and `listeners.import_id` (resources die with the import) but `clusters.import_id` SET NULL (shared clusters survive; refcounted via `cluster_references.route_count`).
 - **Dataplane delete:** `listeners.dataplane_id` SET NULL.
@@ -575,7 +577,7 @@ One repository module per table-cluster, 35 files. `repository_old.rs` is **dead
 - **VirtualHostRepository / RouteRepository** (`repositories/virtual_host.rs`, `route.rs`): CRUD keyed by parent (`list_by_route_config`, `list_by_virtual_host`, `delete_by_route_config`, `delete_by_virtual_host`); `RouteRepository` adds `find_routes_with_exposure` (external routes for agent grants) and `get_routes_with_related_data` (joined query, avoids N+1). No team columns — scope is inherited via parents.
 - **FilterRepository, SecretRepository, CustomWasmFilterRepository, McpToolRepository, DataplaneRepository**: per-team CRUD (`UNIQUE(team,name)`), `list_by_teams`; `DataplaneRepository` adds `create_tx` (used by team-provisioning), `get_default_for_team`, `find_by_gateway_host`. Secrets are encrypted/decrypted in the service layer (`SecretEncryption`); repository stores ciphertext+nonce only.
 - **TeamRepository** (`repositories/team.rs`): `create_team`/`create_team_tx`, get by id/name/`(org,name)`, `resolve_id_in_org`, `resolve_team_ids`/`resolve_team_names` (id↔name mapping for the team-as-id columns), `is_name_available_in_org`, list/update/delete.
-- **UserRepository** (`repositories/user.rs`): CRUD + `find_by_zitadel_sub`, `upsert_from_jwt` (JIT provisioning), `find_machine_users_by_org`, `list_machine_agents_with_teams_in_org`; membership inserts use `INSERT … SELECT FROM UNNEST($1::text[],…) ON CONFLICT (user_id, team) DO NOTHING` (batch, empty-array-safe).
+- **Identity repo** (`crates/fp-storage/src/repos/identity.rs`): humans via `upsert_user_by_subject` (JIT provisioning on `ON CONFLICT (subject)`), `find_user_by_subject`, `load_principal` (memberships + grants in one load); agents via `create_agent_tx`, `rotate_agent_token_tx`, `disable_agent_tx`, `hash_agent_token`, `load_agent_principal_by_token_hash`; org/team/grant/membership writes (`create_org`, `create_team_tx`, `add_org_membership`, `add_team_membership`, `add_grant`/`add_agent_grant_in_tx`).
 - **OrganizationRepository, GrantRepository, MachineUserRepository**: org CRUD with member management; grant create/list-for-principal/delete/check-access scoped by org_id/team_id.
 - **RateLimitRepository** (`repositories/rate_limit.rs`): see §5.3/§6 — gold standard.
 - **AuditLogRepository** (`repositories/audit_log.rs`): append + `list`/`list_by_org`/ `list_by_team` with resource_type/action/time filters; severity derived at read time.
@@ -734,5 +736,6 @@ Only `grants`, `rate_limit_*`, and `audit_log` carry `org_id`. Gateway resources
     (`routes`→`route_configs`, `route_rules`→`routes`) — any external SQL/tooling that says
     "routes" must be checked against the post-rename meaning (a route RULE, not a route
     config).
-20. **`users.password_hash NOT NULL`** survives even though auth moved to Zitadel
-    (`20260228100001`, `20260302000001`) — JIT-provisioned users need a placeholder hash.
+20. **Resolved in v2:** v1's dead `users.password_hash` and the `zitadel_sub` naming are gone —
+    `migrations/0002_identity.sql` defines `users` with a provider-agnostic `subject` column and
+    no password storage; machines moved to a dedicated `agents` table.

--- a/spec/05-auth.md
+++ b/spec/05-auth.md
@@ -1,13 +1,11 @@
 # 05 — Authentication and Authorization
 
-Extracted from Flowplane v1 (v0.2.10). Sources cited inline as v1 paths. This spec is self-contained: it defines the behavior the v2 rewrite must implement without reference to v1 source.
+v2 as-built. Sources cited inline as v2 paths (`crates/fp-*/src/...`, `crates/fp-storage/migrations/...`). Authorization design rationale is Q-004 (provider-agnostic identity) and D-014 (multi-org active-org selection).
 
 Two separate questions, two separate layers:
 
-- **Authentication** — "who are you?" — is OIDC. Zitadel in prod mode, an embedded mock OIDC server in dev mode. JWTs are identity-only; they carry **no** authorization data.
-- **Authorization** — "what can you do?" — is one in-process function, `check_resource_access(ctx, resource, action, team)`, that every surface (REST, MCP control plane, MCP gateway) converges on. Permissions live in the database, never in the token.
-
-Anchor doc in v1: `docs/explanation/auth-model.md`. Gate: `src/auth/authorization.rs`.
+- **Authentication** — "who are you?" — is OIDC, against any compliant IdP in prod mode and an in-process issuer in dev mode. JWTs are identity-only; they carry **no** authorization data. Machine identities (agents) authenticate with locally-issued bearer tokens, not OIDC. (`crates/fp-core/src/oidc.rs`, `crates/fp-api/src/auth.rs`)
+- **Authorization** — "what can you do?" — is one in-process function, `check_resource_access(ctx, resource, action, team) -> Decision`, that every surface (REST, MCP) converges on. Permissions live in the database as `grants`, never in the token. (`crates/fp-core/src/authz.rs`)
 
 ---
 
@@ -15,48 +13,50 @@ Anchor doc in v1: `docs/explanation/auth-model.md`. Gate: `src/auth/authorizatio
 
 ### 1.1 Entities
 
-| Entity | Key fields | Notes |
-|---|---|---|
-| **Organization** (`organizations`) | `id`, `name` (immutable, lowercase-hyphen `NAME_REGEX`), `display_name`, `description`, `owner_user_id?`, `settings` (JSON), `status` (`active`/`suspended`/`archived`) | Governance layer above teams. A special org named **`platform`** holds platform operators. (`src/auth/organization.rs`) |
-| **Team** (`teams`) | `id` (UUID), `name` (immutable, unique **per org**), `display_name`, `description?`, `owner_user_id?`, `org_id` (required FK), `settings`, `status` (`active`/`suspended`/`archived`), `envoy_admin_port?` | Tenancy unit. All tenant resources carry a team FK. (`src/auth/team.rs`) |
-| **User** (`users`) | `id` (UUID), `email` (NOT NULL UNIQUE), `name`, `status` (`active`/`inactive`/`suspended`), `is_admin` (legacy bool, not consulted by the gate), `zitadel_sub` (UNIQUE — OIDC `sub` claim), `user_type` (`"human"` \| `"machine"`), `agent_context` (NULL for humans; `"cp-tool"` \| `"gateway-tool"` \| `"api-consumer"` for machines), `password_hash` (legacy, always `''`) | `zitadel_sub` is the bridge from OIDC identity to local permissions. (`src/auth/user.rs`) |
-| **Org membership** (`organization_memberships`) | `(user_id, org_id)` unique, `role` ∈ {`owner`, `admin`, `member`, `viewer`} | Source of org-level scopes. |
-| **Team membership** (`user_team_memberships`) | `(user_id, team)` unique (team column stores team UUID) | Records which teams a user belongs to. Membership alone grants **nothing** — grants do. Grant creation requires membership (§3.4). |
-| **Grant** (`grants`) | `id`, `principal_id` (user id, human or machine), `org_id`, `team_id`, `grant_type` ∈ {`resource`, `gateway-tool`, `route`}, `resource_type?`, `action?` (resource grants), `route_id?`, `allowed_methods?` (gateway/route grants), `created_by`, `created_at`, `expires_at?` | The team-level permission row. Unique index prevents duplicates (conflict → 409). (`src/auth/models.rs`) |
+Identity tables are defined in `crates/fp-storage/migrations/0002_identity.sql`. Humans and machines are **separate tables** — there is no `user_type`/`agent_context` discriminator on a shared `users` row.
 
-### 1.2 Org roles → scopes
+| Entity | Table | Key fields | Notes |
+|---|---|---|---|
+| **Organization** | `organizations` | `id` (UUID), `name` (NOT NULL UNIQUE), `display_name`, `status` (`active`/`suspended`) | Governance layer above teams. A special org named **`platform`** holds platform operators (`crates/fp-storage/src/repos/identity.rs::set_platform_org`). (`0002_identity.sql:8-15`) |
+| **Team** | `teams` | `id` (UUID), `org_id` (NOT NULL FK), `name` (unique **per org**), `status`; `UNIQUE(org_id, name)` and `UNIQUE(id, org_id)` | Tenancy unit. The `UNIQUE(id, org_id)` lets composite FKs prove team ∈ org at the schema level. (`0002_identity.sql:17-29`) |
+| **User** (human) | `users` | `id` (UUID), `subject` (TEXT NOT NULL UNIQUE — the OIDC `sub` claim, provider-agnostic), `email`, `name`, `status` (`active`/`suspended`) | `subject` is the bridge from OIDC identity to local permissions. No password storage, ever — there is no `password_hash`, `is_admin`, `user_type`, or `agent_context` column. (`0002_identity.sql:31-41`) |
+| **Agent** (machine) | `agents` | `id` (UUID), `org_id` (NOT NULL FK), `name`, `kind` (`cp-tool`/`gateway-tool`/`api-consumer`, CHECK), `token_hash`, `status`; `UNIQUE(org_id, name)`, `UNIQUE(token_hash)` | Machine identity, org-owned. Authenticates with a locally-issued bearer token whose SHA-256 hash is stored. `kind` structurally bounds what the agent can ever reach (§3.3). (`0002_identity.sql:43-56`, `migrations/0028_agents_token_hash_unique.sql`) |
+| **Org membership** | `org_memberships` | `(user_id, org_id)` UNIQUE, `role` ∈ {`owner`, `admin`, `member`, `viewer`} (CHECK) | Source of a user's org role. (`0002_identity.sql:58-65`) |
+| **Team membership** | `team_memberships` | `(user_id, team_id)` UNIQUE | Records which teams a user belongs to. Membership alone grants **nothing** — grants do. (`0002_identity.sql:67-73`) |
+| **Grant** | `grants` | `id`, `principal_type` (`user`/`agent`), `principal_id`, `org_id`, `team_id`, `resource`, `action` (`read`/`create`/`update`/`delete`/`execute`, CHECK), `created_by`; composite FK `(team_id, org_id) → teams(id, org_id)`; `UNIQUE(principal_type, principal_id, team_id, resource, action)` | The team-level permission row — a `(principal × resource × action × team)` tuple. The composite FK makes a grant whose team is outside its org unrepresentable. (`0002_identity.sql:75-91`) |
 
-Org-level access is expressed as **scope strings** computed at request time from `organization_memberships` (`src/auth/permissions.rs::map_org_role_to_scopes`):
+There is no `scopes` table and no scope-string column anywhere. Authorization is the `grants` rows plus the principal's typed org role (§3).
 
-| DB role | Org | Scopes produced |
-|---|---|---|
-| `owner` | `platform` | `admin:all` **and** `org:platform:admin` |
-| `owner` or `admin` | any other org | `org:{org_name}:admin` |
-| `member` | any | `org:{org_name}:member` |
-| `viewer` | any | `org:{org_name}:viewer` |
-| anything else | — | nothing (warn-logged, skipped) |
+### 1.2 Org roles
 
-`admin:all` exists **only** via platform-org ownership. There is no other path to it.
+Org-level access is a **typed role** (`OrgRole`) loaded from `org_memberships`, not a scope string computed at request time. The DB roles are `owner`, `admin`, `member`, `viewer` (`0002_identity.sql:62`). Platform-admin status is a boolean derived once per request — it is `true` iff the user is an `owner` of the `platform` org (`crates/fp-api/src/auth.rs:177-185`, `crates/fp-core/src/authz.rs:55-77`). There is no `admin:all` / `org:{name}:{role}` string representation at runtime (the v1 scope-string vocabulary is gone — `crates/fp-domain/src/authz.rs`).
 
-### 1.3 User types
+### 1.3 Principal kinds
 
-- **human** — interactive operator (UI/CLI). `agent_context = NULL`.
-- **machine** — Zitadel machine user (service account / AI agent) provisioned by an org admin. `agent_context` partitions what the machine may touch:
-  - `cp-tool`: control-plane MCP tools; uses the same `resource` grants as humans.
-  - `gateway-tool`: MCP gateway tools (proxy calls to upstream APIs); `gateway-tool` grants only.
-  - `api-consumer`: direct data-plane access enforced via Envoy RBAC; `route` grants only.
+- **human** — interactive operator (CLI/UI). Authenticates via OIDC JWT; resolves to `PrincipalCtx::User`.
+- **agent** — machine identity (service account / AI tool). Authenticates via a `fpat_…` bearer token; resolves to `PrincipalCtx::Agent`. `kind` partitions what the agent may touch (§3.3):
+  - `cp-tool`: control-plane access; uses the same `(resource, action)` grants as humans, with no governance or org-admin arm.
+  - `gateway-tool`: structurally limited to the `McpTools` resource; access there still requires a matching grant. Denied every other resource.
+  - `api-consumer`: data-plane only via Envoy RBAC; structurally denied every control-plane resource.
 
-Grant-type ↔ principal compatibility is validated at grant creation (§3.4).
+(`crates/fp-core/src/authz.rs:55-77,145-200`)
 
 ### 1.4 Provisioning flows
 
-- **JIT (every authenticated request):** after JWT validation, the middleware upserts the user by `zitadel_sub` (`src/storage/repositories/user.rs::upsert_from_jwt`): `INSERT ... ON CONFLICT (zitadel_sub) DO UPDATE`. If the token has no `email` claim, a placeholder `zitadel-{sub}@jit.local` is used; on conflict a real (non-placeholder) email is never overwritten by a placeholder. Name is updated only when non-empty. JIT creates the user row only — no memberships, no grants; a fresh JIT user can do nothing until invited/granted.
-- **Invite (org member):** `POST /api/v1/admin/organizations/{id}/members/invite` (platform admin **or** that org's admin). Searches Zitadel by email; creates a Zitadel human user if absent (optionally with `initial_password`, set with `changeRequired:false` via Zitadel v2 password API); upserts local user; inserts `organization_memberships` row with the requested role; fans out `user_team_memberships` across all teams in the org; cross-org conflict (user already belongs to another org) → 403. (`src/api/handlers/organizations.rs`)
-- **Agent provisioning:** `POST /api/v1/orgs/{org_name}/agents` — caller needs `agents:create` grant on the first listed team (checked via `check_resource_access`). Creates a Zitadel machine user named `{org}--{agent-name}`, generates client credentials (`client_id`/`client_secret` returned **once**, at creation only), creates local user (`user_type='machine'`, `agent_context='cp-tool'` — hardcoded in v1, TODO to make configurable), org membership, and team memberships with **empty** scopes — access is then managed via the grants table. Idempotent: re-creating the same name returns 200 without credentials. Audited as governance `user.create`.
-- **DCR proxy:** `POST /api/v1/oauth/register` (RFC 7591) — authenticated, org-admin-only (`require_org_admin_only`, platform admin excluded). Same `provision_machine_user()` helper; requested `scope` string is parsed into per-team groups (`team:{name}:{res}:{act}` entries; all others silently dropped); teams must exist in the caller's org. (`src/api/handlers/oauth.rs`)
-- **Superadmin seeding (boot, prod):** if `FLOWPLANE_SUPERADMIN_EMAIL` is set, a background task polls Zitadel readiness (1s→60s exponential backoff), finds/creates that human user (password from `FLOWPLANE_SUPERADMIN_INITIAL_PASSWORD` if set), upserts the local row, and creates an `owner` membership in the `platform` org → `admin:all`. Idempotent. (`src/api/handlers/bootstrap.rs::seed_superadmin`)
-- **Bootstrap endpoint:** `POST /api/v1/bootstrap/initialize` creates the `platform` org + `platform-admin` team and the first tenant org/team. Not on the JWT path (runs before any admin exists); gated by a one-time static token: caller presents `Authorization: Bearer <FLOWPLANE_BOOTSTRAP_TOKEN>`. Env unset/empty → 403 (endpoint self-disabled); missing bearer or mismatch → 401. Comparison is constant-time over SHA-256 digests of both values (length non-leaking). Returns 409 once a non-platform org exists.
-- **Dev seeding (boot, dev mode):** `src/startup.rs::seed_dev_resources` — idempotent inserts: org `dev-org` (id `dev-org-id`), team `default` (id `dev-default-team-id`), user `dev-user-id` (email `dev@flowplane.local`, `zitadel_sub = "dev-sub"`, human, `is_admin=false`), org membership role **`admin`** (→ scope `org:dev-org:admin`; note: *not* `owner`, and there is no platform org in dev, so no `admin:all` exists in dev), team membership, default dataplane `dev-dataplane` (is_default), a registered proxy certificate row binding the dev SPIFFE URI to the team, and the stats-dashboard app enabled. Canonical constants `DEV_USER_SUB = "dev-sub"`, `DEV_USER_EMAIL = "dev@flowplane.local"` live in `src/auth/dev_token.rs`.
+- **JIT (every authenticated request, humans):** after JWT validation the middleware upserts the user by `subject` (`crates/fp-storage/src/repos/identity.rs::upsert_user_by_subject`, called from `crates/fp-api/src/auth.rs:156-162`): `INSERT ... ON CONFLICT (subject) DO UPDATE`. `email`/`name` are taken from the token claims. JIT creates the user row only — no memberships, no grants; a fresh JIT user can do nothing until granted.
+- **Members:** a user is added to an org/team by an org admin via the identity API (`crates/fp-api/src/identity_api.rs`, registered in `crates/fp-api/src/routes.rs:65-68`). Membership is by `subject`/email lookup — there is **no** invite-token email flow and **no** IdP Management-API call. (Invite tokens: ABSENT.)
+- **Agent provisioning:** an org admin creates an agent (`crates/fp-core/src/services/agents.rs:26-43`). A fresh token `fpat_{uuid}{uuid}` is minted, returned **once**, and only its SHA-256 hash is persisted (`agents.rs:82-87,132-174`; `identity.rs::hash_agent_token:39`). The token is rotated with `rotate_agent_token` (new token, replaces hash) and revoked by setting `status='suspended'` (`agents.rs:192-228`, `identity.rs:368-410`). No OIDC client, no `client_credentials`, no Dynamic Client Registration. (Zitadel / Management API / DCR / `client_credentials`: ABSENT.)
+- **Bootstrap (first platform admin):** `POST /api/v1/bootstrap/initialize`, off the JWT path, gated by a one-shot operator token. See §1.5.
+- **Dev seeding (boot, dev mode):** `crates/fp-storage/src/seed.rs::seed_dev` — idempotent (`ON CONFLICT DO NOTHING`) inserts: org `dev-org`, team `default`, user with `subject = "dev-user"`, an `org_memberships` row with role **`owner`** in `dev-org`, and a team membership (`seed.rs:13-79`). Dev mode has **no platform org and no platform admin** (`seed.rs:6`) — the dev user is an org owner of the single dev org only.
+
+### 1.5 Bootstrap
+
+The first platform admin is created before any JWT-authenticated principal exists, via a one-shot operator-supplied token (`crates/fp-storage/src/repos/bootstrap.rs`, table `bootstrap_tokens` in `0002_identity.sql:114-121`).
+
+- **Token:** format `fpboot_{uuid}{uuid}`; only its SHA-256 hash is stored, never logged (`bootstrap.rs:23-49`). Expires 24 h after seeding (`bootstrap.rs:55,165`). Single-use — `used_at` is stamped on consume (`bootstrap.rs:230`).
+- **Provenance (`operator_seeded`, `migrations/0029_bootstrap_token_operator_seeded.sql`):** `true` = operator-supplied via `seed_token_hash_if_uninitialized` (the normal path); `false` = the legacy generate-and-log path, behind the `FLOWPLANE_ALLOW_LOGGED_BOOTSTRAP_TOKEN` opt-in. A successful operator seed invalidates prior unused *legacy* tokens; a different live *operator-seeded* token fails closed rather than being clobbered.
+- **Endpoint:** `POST /api/v1/bootstrap/initialize` with `Authorization: Bearer fpboot_*` and body `{org_name, org_display_name, admin_subject, admin_email}` (`crates/fp-api/src/routes.rs:224-227`, handler `bootstrap.rs:181+`). Serialized and made idempotent across replicas by `pg_advisory_xact_lock(BOOTSTRAP_LOCK_KEY)` (`bootstrap.rs:21,210`). In one transaction it consumes the token, creates the `platform` org, creates the admin user, adds an `owner` membership, and audits.
+- `GET /api/v1/bootstrap/status` (unauthenticated) reports whether the instance is initialized (`routes.rs:223`).
 
 ---
 
@@ -64,246 +64,166 @@ Grant-type ↔ principal compatibility is validated at grant creation (§3.4).
 
 ### 2.1 Mode selection
 
-`AuthMode` ∈ {`Dev`, `Prod`}, parsed from `FLOWPLANE_AUTH_MODE` (`"dev"` / `"prod"`); **defaults to Prod**; any other value is a hard config error (`src/config/mod.rs`). Dev mode requires the `dev-oidc` cargo feature; a non-dev build refuses to start with `FLOWPLANE_AUTH_MODE=dev`.
+Auth mode is selected by **`FLOWPLANE_DEV_MODE`** (`true`/`false`), not a `FLOWPLANE_AUTH_MODE` enum (`crates/fp-core/src/config.rs:263-266`). Dev mode and prod OIDC config are **mutually exclusive**: setting `FLOWPLANE_DEV_MODE=true` together with `FLOWPLANE_OIDC_*` is a hard config error (`config.rs:298-303`). Dev mode requires the `dev-oidc` cargo feature (a default feature of the `flowplane` crate, `crates/flowplane/Cargo.toml:10`); a build without it has `setup_dev_mode` reject dev mode at startup (`crates/flowplane/src/serve.rs:344`). Build the release artifact without default features to harden it against dev mode.
 
-Critical property: **dev and prod share one auth code path.** Dev differs only in who signs the JWT (embedded mock vs Zitadel). There is no `if dev { skip_auth() }` branch anywhere; the same `validate_jwt_extract_sub → JIT upsert → load_permissions → check_resource_access` chain runs in both modes.
+Critical property: **dev and prod share one auth code path.** Dev differs only in who signs the JWT (an in-process issuer vs the external IdP). There is no `if dev { skip_auth() }` branch — the same `validate → JIT upsert → load_principal → check_resource_access` chain runs in both modes (`crates/fp-api/src/auth.rs`). When no OIDC issuer is configured and dev mode is off, authenticated endpoints fail closed (`config.rs:43-44`).
 
-`GET /api/v1/auth/mode` (unauthenticated) returns `{auth_mode, oidc_issuer?, oidc_client_id?}` for CLI/frontend discovery; issuer/client-id only in prod (`FLOWPLANE_OIDC_CLI_CLIENT_ID`, falling back to `FLOWPLANE_OIDC_SPA_CLIENT_ID`).
+### 2.2 OIDC JWT validation (`crates/fp-core/src/oidc.rs`)
 
-### 2.2 Prod: Zitadel JWT validation (`src/auth/zitadel.rs`)
-
-Config (`ZitadelConfig::from_env`, opt-in on `FLOWPLANE_OIDC_ISSUER`):
+Provider-agnostic: the validator works against any compliant IdP (e.g. Auth0, Keycloak, Okta, Entra) or the dev mock. Configuration (`OidcConfig`, `config.rs:54-59`):
 
 | Env var | Meaning | Default |
 |---|---|---|
-| `FLOWPLANE_OIDC_ISSUER` | must equal JWT `iss` | required |
-| `FLOWPLANE_OIDC_PROJECT_ID` | Zitadel project id | required when issuer set (hard error otherwise) |
-| `FLOWPLANE_OIDC_AUDIENCE` | expected `aud` | defaults to project_id |
-| `FLOWPLANE_OIDC_JWKS_URL` | JWKS endpoint | `{issuer}/oauth/v2/keys` |
-| `FLOWPLANE_OIDC_USERINFO_URL` | userinfo fallback | `{jwks base}/oidc/v1/userinfo` |
+| `FLOWPLANE_OIDC_ISSUER` | must equal JWT `iss` | required (in prod) |
+| `FLOWPLANE_OIDC_AUDIENCE` | expected `aud` | required (in prod) |
+| `FLOWPLANE_OIDC_JWKS_URI` | JWKS endpoint | discovered from `{issuer}/.well-known/openid-configuration` when unset |
 
-JWT validation (`validate_jwt_extract_sub`):
-1. Decode header; require `kid` (missing → 401).
-2. Look up `kid` in the cached JWKS; on miss, `refresh_if_due(kid)` then retry; still missing → 401 `no JWKS key for kid=...`.
-3. Only RSA JWKs accepted; build the decoding key from `(n, e)`.
-4. Validation pins **RS256** (no algorithm confusion), validates `iss`, `aud`, `exp`, and **explicitly enables `nbf`** (the jsonwebtoken crate default leaves `validate_nbf=false` — a v2 implementation must not regress this), with explicit 60 s clock-skew leeway.
-5. Extract **only** `sub` (required, string — fail closed otherwise), `email?`, `name?`. Role claims (`urn:zitadel:iam:org:project:id:{pid}:roles`), scopes, and everything else are ignored at request time — permissions come from the DB.
+`FLOWPLANE_OIDC_ISSUER` and `FLOWPLANE_OIDC_AUDIENCE` must be set together (`config.rs:268-288`). There is no project-id or admin-PAT env var.
 
-**Userinfo fallback:** Zitadel access tokens commonly omit `email`. On JIT-provision cache miss with empty email, the middleware calls the userinfo endpoint with the bearer token to fetch `email`/`name`; any failure degrades gracefully (placeholder email used).
+JWT validation (`OidcValidator::validate`):
+1. Decode header; require `kid`.
+2. Look up `kid` in the cached JWKS; on miss, refresh (single-flight, cooldown-bounded) then retry (`oidc.rs:170-173`).
+3. Build the decoding key from the RSA JWK `(n, e)`.
+4. Validation pins **RS256** — `alg=none` and HS256 confusion are rejected at the validation config, not by string checks (`oidc.rs:158-161`). Validates `iss` (`oidc.rs:186`), `aud` (`:187`), requires `exp` and `sub` (`:188`), and **enables `nbf`** (`validation.validate_nbf = true`, `:189`; the jsonwebtoken crate leaves this `false` by default — a regression to avoid), with **30 s** clock-skew leeway (`:185`).
+5. Extract **only** `subject` (required), `email?`, `name?` into `ValidatedClaims` (`oidc.rs:35-39`). Role claims, scopes, and everything else are ignored at request time — permissions come from the DB.
 
-**Host-header handling:** Zitadel resolves instances by hostname. When JWKS/userinfo/token URLs point at a container-internal address, requests carry a `Host:` header equal to the public issuer's `host[:port]`.
+**JWKS cache / rotation:** keys cached in `KeyCache` (`oidc.rs:58-61`); an unknown `kid` triggers a refresh guarded by a per-issuer **30 s cooldown** (`oidc.rs:86`) and a single-flight mutex (`oidc.rs:103-110`) so a flood of bogus tokens cannot hammer the IdP. Discovery via `{issuer}/.well-known/openid-configuration` (`oidc.rs:116-132`).
 
-**JWKS cache/rotation** (`JwksCache`):
-- TTL cache, 1 hour (`JWKS_CACHE_TTL`).
-- Unknown-`kid` triggers `refresh_if_due`: single-flight via a mutex-guarded last-attempt timestamp; per-issuer **30 s cooldown** (`REFRESH_COOLDOWN`) bounds attacker-driven refetch floods (N random kids → at most one burst per window). Inside the cooldown the current cache (or empty set) is returned without network I/O.
-- Burst with expected kid: initial fetch + retries after backoffs **200ms, 500ms, 1000ms** (4 fetches max) to cover Zitadel key-publish propagation lag.
-- Each HTTP fetch hard-capped at **2 s** (`JWKS_FETCH_TIMEOUT`).
-- Timestamp bumped both before (failed bursts still consume cooldown — no hammering a down IdP) and after the burst (slow bursts don't degrade single-flight).
+**Userinfo fallback:** ABSENT — `email`/`name` come from the token claims only; there is no secondary userinfo call.
 
-**Revocation latency (accepted risk):** validation is stateless — no `jti` blocklist, no introspection. A revoked Zitadel session's access token remains valid until `exp` (≤ ~1 h); grant/permission changes propagate within the 60 s permission-cache TTL (plus explicit eviction, §2.6). Documented v1 decision; v2 may keep or tighten.
+**Revocation latency (accepted risk):** validation is stateless — no `jti` blocklist, no introspection. A revoked session's access token remains valid until `exp`. Grant/permission changes take effect on the **next request**, because the principal (memberships + grants) is loaded fresh from the DB every request (§2.3) — there is no permission cache to stale out.
 
-### 2.3 Request authentication middleware (`src/auth/middleware.rs::authenticate`)
+### 2.3 Request authentication middleware (`crates/fp-api/src/auth.rs`)
 
-Applied to all `/api/v1/*` routes except the deliberately public set (§2.7). Order of operations:
+Applied to the secured router (all `/api/v1/*` except the public set in §2.5). Flow:
 
-1. **OPTIONS passthrough** (CORS preflight).
-2. **Per-IP rate limit** before any JWT work. Client IP resolved through trusted-proxy config: `FLOWPLANE_TRUSTED_PROXY_HEADER` (default `X-Forwarded-For`) and `FLOWPLANE_TRUSTED_PROXY_DEPTH` (default 1). Depth 0 → socket peer only, header ignored. Depth N → take the entry N positions from the right of the header; fewer than N hops → fall back to peer (truncated/spoofed chain). Prevents forged-XFF rate-limit-key rotation and audit-IP spoofing. 429 with `retry_after` on limit.
-3. **Credential extraction:** `Authorization: Bearer <jwt>` always wins (CLI/machine). If absent and the BFF is enabled, decrypt the `fp_session` cookie; absent/tampered cookie → 401 "authentication required". BFF disabled + no bearer → 401 (cookies never read).
-4. **CSRF (cookie-authenticated, state-changing only):** POST/PUT/PATCH/DELETE authenticated via cookie require the double-submit check — non-HttpOnly `fp_csrf` cookie value must equal the `x-csrf-token` header, non-empty; else 403. Bearer clients are exempt (token is not ambient).
-5. **Transparent refresh (cookie path):** if the session's access token is expired or within 60 s of expiry (`REFRESH_SKEW_SECS`), exchange the stored refresh token at the provider; on success re-seal the cookie and attach `Set-Cookie` to the response; no refresh token or provider rejection → 401 (SPA bounces to login). Must surface 401, never 500, on a dead provider.
-6. **JWT validation** (§2.2) on whichever token was resolved.
-7. **Permission resolution:** check the in-memory **permission cache keyed by `sub`** (§2.6); on miss: JIT user upsert (with userinfo email fallback) → `load_permissions(pool, user_id)` → cache insert. `load_permissions` returns:
-   - `org_scopes` from `organization_memberships` (§1.2);
-   - `grants` from the `grants` table joined to team names, **filtered by
-     `expires_at IS NULL OR expires_at > NOW()`**;
-   - org memberships from `organization_memberships` are retained as a set. For tenant-scoped
-     operations, `org_id`/`org_name`/`org_role` are derived from the validated request org
-     context (`X-Flowplane-Org`, CLI `--org`, or active CLI config). With no selector, the
-     server may infer an org only when the user has exactly one active non-platform org
-     membership; the platform org never becomes the request org context.
-   For machine users, `agent_context` is parsed from the user row.
-8. **Build `AuthContext`** and insert into request extensions: `token_id = "zitadel:{sub}"`, `token_name = "zitadel/{sub}"`, `user_id`, `user_email`, `user_name?`, `org_scopes` (private set, queried via `has_scope`), `grants`, `agent_context?`, all active org memberships, validated request `org_id?`/`org_name?`, plus `client_ip`/`user_agent` for audit. A user with multiple tenant memberships and no selector must never receive an implicit default org for tenant-scoped authorization; `/auth/whoami` exposes the membership set so CLI context setup can offer/select an org without platform governance access.
+1. **Bearer extraction:** read `Authorization: Bearer <token>`; missing → 401 (`auth.rs:21-27,107-114`).
+2. **Principal-kind split** on token prefix (`auth.rs:116-118`):
+   - token starts with `fpat_` → **agent** path.
+   - otherwise → **user (OIDC)** path.
+3. **User path** (`auth.rs:96-195`): `OidcValidator::validate` → `ValidatedClaims`; on failure, a best-effort audit row (`actor=anonymous`, `action="authn.failed"`, `outcome=failure`) then 401 (`auth.rs:129-151`). Then JIT upsert by `subject` (`upsert_user_by_subject`) → `load_principal` (memberships + grants from DB) → active-org resolution (D-014, §2.4) → build `PrincipalCtx::User` (`auth.rs:156-185`).
+4. **Agent path** (`auth.rs:197-224`): SHA-256-hash the token and look it up in `agents` by `token_hash` (`load_agent_principal_by_token_hash`, `identity.rs:152-204`); not found or suspended → best-effort audit + 401; else build `PrincipalCtx::Agent` (`auth.rs:206-211`).
+5. The `PrincipalCtx` is inserted into request extensions (`auth.rs:185,211`).
 
-### 2.4 Dev mode: embedded mock OIDC (`src/dev/oidc_server.rs`, feature `dev-oidc`)
+There is **no permission cache** — the principal is loaded from the DB on every authenticated request. **Rate limiting** is not in the auth middleware (it is a separate write-path layer, `routes.rs:202-205`). **CSRF**, **cookie/session auth**, and **CORS preflight handling** are ABSENT — authentication is bearer-token only.
 
-- On boot with `AuthMode::Dev`, the CP starts an in-process mock OIDC server on an ephemeral loopback port and points the standard Zitadel middleware at it (`ZitadelConfig::from_mock` — issuer/jwks/userinfo all derived from the live bound URL; BFF is disabled in dev, bearer-only).
-- Mock endpoints: OIDC discovery, JWKS, `/authorize` (PKCE S256; skipped if no challenge sent), `/token` (authorization_code, refresh_token, device_code grants), `/device/authorize`, `/userinfo`. Signs RS256 JWTs with an ephemeral in-memory 2048-bit RSA key (fresh per process); default token expiry 1 h, refresh 24 h; claims: `iss` (mock base URL), `sub = "dev-sub"`, `aud` (`test-project-id` by default), `exp`, `iat`, `email`/`name`. Configurable failure modes exist for tests (invalid_grant, expired tokens, slow, 500, device-pending).
-- If `FLOWPLANE_CREDENTIALS_PATH` is set, the CP mints a dev JWT and writes it as JSON `{access_token, refresh_token: null, expires_at: null, issuer}` to that path (atomic write-then-rename, dir 0700, file 0600 — `src/auth/dev_token.rs`). `flowplane init` relies on this; the CLI then reads `~/.flowplane/credentials`.
-- The minted token's `sub` matches the seeded dev user, so the normal JIT/permission path resolves to `org:dev-org:admin` — dev user is an org admin of the one dev org, **not** a platform admin.
+### 2.4 Active-org resolution (D-014, `crates/fp-api/src/auth.rs:39-94`)
 
-### 2.5 Session/BFF auth for the UI (`src/api/handlers/auth_bff.rs`)
+A user may belong to more than one org, so the active org for a tenant-scoped request is resolved explicitly and fails closed on ambiguity:
 
-Prod-only backend-for-frontend so the SPA never holds raw tokens. Enabled when `FLOWPLANE_OIDC_ISSUER` + `FLOWPLANE_OIDC_SPA_CLIENT_ID` are set **and** the secret-encryption key is available (otherwise BFF is disabled, not insecure). Endpoint URLs default to Zitadel's layout under the issuer (`/oauth/v2/authorize`, `/oauth/v2/token`, `/oidc/v1/end_session`, `/oauth/v2/revoke`), each individually overridable via env. `FLOWPLANE_APP_URL` (default `http://localhost:8080`) determines `redirect_uri = {app}/api/v1/auth/callback` and gates the cookie `Secure` attribute (`https://` app URL ⇒ Secure).
+- **With selector** (`X-Flowplane-Org` header / CLI `--org`): must resolve to an org the user is a member of, else fail closed (`auth.rs:52-63`).
+- **No selector, exactly one non-platform membership:** use it (`auth.rs:89-90`).
+- **No selector, zero or ≥2 candidates:** no active org; `org_selector_required = true` is recorded on the principal and tenant-scoped operations fail until the caller names an org (`auth.rs:91-93`).
+- The `platform` org is never implicitly selectable as a tenant context (`auth.rs:71`).
 
-Three unauthenticated endpoints:
-- `GET /api/v1/auth/login` — generates PKCE verifier (48 random bytes) + state (24 bytes), seals `{state, verifier}` into the encrypted `fp_oidc_tx` cookie, 302 to the provider's authorize URL (`response_type=code`, scopes `openid profile email offline_access`, S256 challenge).
-- `GET /api/v1/auth/callback` — provider error → redirect to `{app}/login?error=provider_error`. Otherwise: open tx cookie, verify `state` equality, exchange code (+verifier) for tokens, seal `{access_token, id_token?, refresh_token?, access_expires_at}` into the **encrypted, HttpOnly, SameSite=Lax, Path=/** `fp_session` cookie; also issue a fresh random `fp_csrf` cookie (non-HttpOnly, same flags) for double-submit; remove tx cookie; redirect to the app. All failures redirect to `/login?error=auth_failed` — never a raw 500 leaking provider detail.
-- `GET /api/v1/auth/logout` — read session cookie; **revoke refresh token first** (RFC 7009 — Zitadel cascades to its access tokens), then access token; revocations awaited but failures logged-and-swallowed (user is still signed out locally); remove `fp_session` + `fp_csrf`; 302 to provider end_session with `post_logout_redirect_uri = {app}/login`.
+`GET /api/v1/auth/whoami` echoes the validated principal, its membership set, the org-selector state, and grant count so a CLI can offer/select an org (`crates/fp-api/src/routes.rs:258-310`).
 
-Cookie crypto: AES-GCM via the platform `SecretEncryption` (master key `FLOWPLANE_SECRET_ENCRYPTION_KEY`); value layout `base64url(nonce[12] || ciphertext||tag)`; distinct AEAD associated-data labels per cookie purpose (`flowplane:bff:oidc-tx:v1` vs `flowplane:bff:session:v1`) so a tx cookie can never be replayed as a session cookie. Any tamper/AAD mismatch ⇒ "no session".
+### 2.5 Dev mode and public endpoints
 
-`GET /api/v1/auth/session` (authenticated) returns the DB-sourced session shape for the SPA: `{user_id, email, name (OIDC name or email-prefix fallback), is_admin/is_platform_admin (= has admin:all), org_scopes, grants[{teamName,resourceType,action}], teams (from grants), org_id?, org_name?, org_role?}`. The frontend never parses JWT claims.
+- **Dev OIDC:** in dev mode the CP runs an in-process issuer (feature `dev-oidc`) and points the same `OidcValidator` at it; the seeded dev user's `subject` is `dev-user` so the normal JIT/authorization path resolves to org-owner of `dev-org` (`crates/fp-storage/src/seed.rs:23-79`).
+- **Public (unauthenticated) routes** (`crates/fp-api/src/routes.rs:212-227`): `GET /healthz`, `GET /readyz`, `GET /metrics`, `GET /api-docs/openapi.json`, `GET /api/v1/bootstrap/status`, and `POST /api/v1/bootstrap/initialize` (itself gated by the one-shot `fpboot_*` token, §1.5).
 
-### 2.6 Permission cache (`src/auth/cache.rs`)
+There is **no** BFF/cookie/session surface in v2 — `/auth/login`, `/auth/callback`, `/auth/logout`, `/auth/session`, `/auth/mode`, and `/oauth/register` (DCR) are all ABSENT (`routes.rs`). Browser clients that need an interactive login obtain a JWT from the IdP directly and present it as a bearer token.
 
-In-memory TTL map keyed by `sub`. TTL from `FLOWPLANE_PERMISSION_CACHE_TTL_SECS`, default **60 s**. Snapshot holds user_id/email/name/org_scopes/grants/org context/agent_context. Explicit eviction (`evict(sub)` / `evict_by_user_id`) is called by every mutation that changes a principal's permissions: grant create/delete, membership add/remove/role-change, agent provisioning/reconciliation, DCR. Worst-case staleness for a change without eviction = TTL.
+### 2.6 MCP client auth (`crates/fp-api/src/mcp_api.rs`)
 
-### 2.7 CLI auth (`src/cli/auth.rs`)
-
-`flowplane auth login | token | whoami | logout`.
-
-- Mode discovery via `GET /api/v1/auth/mode`. Dev mode → no login; use the credentials file written at `flowplane init`.
-- Prod login resolves issuer/client-id from `--flags` → CP-advertised values → env (`FLOWPLANE_OIDC_ISSUER` / `FLOWPLANE_OIDC_CLIENT_ID`). The cached `config.toml` values are deliberately **not** consulted (stale Zitadel app ids after a rebuild cause `Errors.App.NotFound`).
-- **PKCE flow (default):** OIDC discovery → spawn loopback HTTP listener on an ephemeral `127.0.0.1` port → open browser to authorize URL (S256 challenge, random state, scopes `openid profile email offline_access`, **`prompt=login`** so re-login after logout cannot silently reuse the SSO session) → callback validated for state (CSRF) and error params → code exchange. 5-minute timeout with a hint to use `--device-code`.
-- **Device-code flow (`--device-code`):** requires the provider to advertise `device_authorization_endpoint`; prints `verification_uri` + `user_code`; polls token endpoint every 5 s handling `authorization_pending` / `slow_down` / `expired_token` / `access_denied`.
-- Credentials stored at `~/.flowplane/credentials` as JSON `{access_token, refresh_token?, expires_at?, issuer?}`, file 0600 / dir 0700.
-- **Auto-refresh:** before use, if expired (60 s buffer), refresh-token grant against the stored issuer's token endpoint; persists rotated tokens.
-- **Logout:** best-effort RFC 7009 revocation (refresh token preferred) when the provider advertises `revocation_endpoint`, then delete the local file; prints an honest warning that already-issued access tokens stay valid until `exp` (stateless CP validation) and the browser IdP session persists.
-
-### 2.8 MCP client auth
-
-MCP is served over streamable HTTP at `/api/v1/mcp` behind the **same** `authenticate` middleware. D-019 updates this for v2 S11: humans use bearer JWTs, and agents use Flowplane agent bearer tokens that resolve to `PrincipalCtx::Agent`; there is no MCP-only credential type separate from the normal API authentication middleware. Additional MCP-layer protections (`src/mcp/security.rs`): Origin-header allowlist as CSRF defense-in-depth for browser clients (default allowlist `http://localhost`, `http://127.0.0.1`, `http://[::1]` — any port; override via comma-separated `FLOWPLANE_MCP_ALLOWED_ORIGINS`; matching ignores port, requires exact scheme+host); session ids are `mcp-{uuidv4}` and format-validated; connection ids are `conn-{team}-{uuid}`; `check_team_ownership(resource_team, request_team)` requires exact, case-sensitive equality.
+MCP is served as JSON-RPC 2.0 over `POST /api/v1/mcp`, behind the **same** auth middleware (§2.3) — humans use bearer JWTs, agents use `fpat_*` tokens; there is no MCP-only credential type. `api-consumer` agents are rejected at `initialize` (`mcp_api.rs:126-140`). Additional MCP-layer protection: an **Origin allowlist** (`mcp_api.rs:1797-1826`) — env `FLOWPLANE_MCP_ALLOWED_ORIGINS` (comma-separated), default `http://localhost,http://127.0.0.1,http://[::1]`, matched on scheme+host ignoring port; a present, non-allowed Origin → JSON-RPC error `-32600 "origin is not allowed"`. Sessions are in-memory, keyed by principal, with a `connection_id` UUID and a 3600 s TTL (`mcp_api.rs:24-37`). The origin check is defense-in-depth for browser clients, not the primary boundary (bearer auth is).
 
 ---
 
 ## 3. Authorization
 
-### 3.1 The single gate: `check_resource_access(context, resource, action, team) -> bool`
+### 3.1 The single gate: `check_resource_access(ctx, resource, action, team) -> Decision`
 
-(`src/auth/authorization.rs`). Inputs: the request `AuthContext`; a resource string (e.g. `"routes"`, `"clusters"`, `"organizations"`); an action (`"read"|"create"|"update"| "delete"|"execute"`); an optional team **name** (not UUID — callers resolve UUIDs to names first via `resolve_team_id_to_name`).
+(`crates/fp-core/src/authz.rs:138-279`.) Inputs: the request `PrincipalCtx`; a typed `Resource`; a typed `Action` (`Read`/`Create`/`Update`/`Delete`/`Execute`); an optional `TeamRef` (`{id, org_id}` — so the cross-org check is part of the decision, not a separate handler call). It returns a `Decision` — `Allow(Reason)` or `Deny(Reason)` (`authz.rs:120-135`) — where `Reason` is a stable wire string for audit (`authz.rs:81-115`):
 
-Exact decision logic (order matters):
+- Allow reasons: `platform_governance`, `grant_match`, `org_admin_implicit_team`, `any_team_grant`, `governance_read`, `org_admin_tenant_default`.
+- Deny reasons: `agent_structurally_denied`, `cross_org`, `governance_write_requires_platform_admin`, `tenant_resource_invisible_to_platform_admin`, `no_matching_grant`.
+
+Decision logic (order matters):
 
 ```
-fn check_resource_access(ctx, resource, action, team) -> bool:
+fn check_resource_access(ctx, resource, action, team) -> Decision:
 
   # 0. Agent structural guard — evaluated FIRST, short-circuits everything below
-  if ctx.agent_context is Some(agent):
-      match agent:
-        CpTool      -> if team is Some(t): return has_grant(resource, action, t)   # GrantType::Resource only
-                       else:               return has_any_grant(resource, action)
-        GatewayTool -> return false        # never reaches CP resources
-        ApiConsumer -> return false        # never reaches CP resources
+  if ctx is Agent(kind, org_id, grants):
+      match kind:
+        CpTool      -> grants-only: cross-org guard (team.org == agent.org), then
+                       Allow(grant_match) iff a grant matches (resource, action, team)
+                       [team=None: Allow(any_team_grant) iff any-team grant];
+                       else Deny(no_matching_grant). No governance, no org-admin arm.
+        GatewayTool -> if resource == McpTools: same grants-only path as CpTool;
+                       else Deny(agent_structurally_denied).
+                       (kind limits the *resource* to McpTools; a grant is still required —
+                        the read/execute action limit is enforced at grant creation, not here)
+        ApiConsumer -> Deny(agent_structurally_denied)   # never reaches any resource
 
   # 1. Platform-admin governance bypass (governance resources ONLY)
-  if ctx.has_scope("admin:all") and is_governance_resource(resource):
-      return true
+  if ctx.platform_admin and resource.is_governance():
+      return Allow(platform_governance)
 
-  if team is Some(team_name):
-      # 2a. Exact grant row
-      if ctx.has_grant(resource, action, team_name):       # grant_type==Resource,
-          return true                                       # matching (resource, action, team_name)
-      # 2b. Org-admin implicit team access — only when the scope's org
-      #     matches the user's DB-loaded org_name (defense in depth against
-      #     a corrupted/foreign scope; warn-logged denial otherwise)
-      for (org, role) in parse org_scopes matching "org:{name}:{admin|member|viewer}":
-          if role == "admin" and ctx.org_name == Some(org):
-              return true
-      return false
+  if team is Some(team_ref):
+      # 2a. Cross-org guard before grants
+      if ctx.org is None or ctx.org.id != team_ref.org_id:
+          return Deny(cross_org)
+      # 2b. Exact grant row
+      if ctx.grants has (resource, action, team_ref.id):
+          return Allow(grant_match)
+      # 2c. Org-admin implicit team access (tenant resources only)
+      if ctx.org.role == Admin/Owner:
+          return Allow(org_admin_implicit_team)
+      return Deny(no_matching_grant)
 
   else:  # team is None
       # 3a. ANY-team grant — lets team-scoped users hit list endpoints,
       #     which then filter rows to their teams
-      if ctx.has_any_grant(resource, action):
-          return true
-      # 3b. Governance resources, org-scoped callers:
-      #     reads: ANY org scope (admin/member/viewer) suffices
-      #     writes: NEVER reachable via org scopes (admin:all only, via step 1)
-      if is_governance_resource(resource):
-          return action == "read" and org_scopes is non-empty
-      # 3c. Tenant resources without team: org ADMIN only, with the same
-      #     scope-org == ctx.org_name cross-check; member/viewer blocked
-      for (org, role) in org_scopes:
-          if role == "admin" and ctx.org_name == Some(org):
-              return true
-      return false
+      if ctx.grants has any (resource, action, *):
+          return Allow(any_team_grant)
+      # 3b. Governance resources: reads via any org membership; writes need platform admin
+      if resource.is_governance():
+          return action == Read and ctx.org.is_some() ? Allow(governance_read)
+                                                       : Deny(governance_write_requires_platform_admin)
+      # 3c. Tenant resource without team: org admin/owner only
+      if ctx.org.role == Admin/Owner:
+          return Allow(org_admin_tenant_default)
+      return Deny(no_matching_grant / tenant_resource_invisible_to_platform_admin)
 ```
 
-`require_resource_access(...)` = same check, `Err(Forbidden)` → HTTP 403 on failure.
+(`authz.rs:145-277`.) The function is pure — no IO, no clock, no globals — so it is exhaustively property-testable and a decision is predictable from the principal's grant set.
 
-**Governance resource list** (`is_governance_resource`) — exact closed set:
+### 3.2 Resource / Action vocabulary
 
-```
-admin · admin-orgs · admin-users · admin-audit · admin-summary
-admin-teams · admin-scopes · admin-apps · admin-filter-schemas
-organizations · users · teams · stats
-```
+`Resource` and `Action` are typed enums with one source of truth (`crates/fp-domain/src/authz.rs:25-50,102,130-136`). `Resource::is_governance()` (`fp-domain/src/authz.rs:57-62`) classifies the closed governance set; everything else is tenant.
 
-Everything else (clusters, routes, listeners, filters, secrets, dataplanes, learning-sessions, proxy-certificates, agents, …) is a **tenant** resource.
+- **Governance resources:** `Organizations`, `Users`, `Teams`, `Audit`, `Platform`.
+- **Tenant resources:** `Clusters`, `RouteConfigs`, `Listeners`, `Filters`, `Secrets`, `Dataplanes`, `ProxyCertificates`, `Agents`, `Grants`, `ApiDefinitions`, `LearningSessions`, `McpTools`, `RateLimits`, `AiProviders`, `AiRoutes`, `AiBudgets`, `AiUsage`, `Stats`.
+- **Actions:** `Read`, `Create`, `Update`, `Delete`, `Execute`.
 
-### 3.2 Three hard invariants (test-asserted in v1; v2 must preserve)
+A grant is one `(principal, resource, action, team)` row (`0002_identity.sql:75-91`); there is no scope-string grammar, no `resource_type`/`route_id`/`allowed_methods`/`expires_at` on the grant, and no separate gateway-tool/route grant type — gateway-tool reach is enforced structurally by agent `kind` (§3.1, §3.3), not by a grant subtype.
 
-1. **`admin:all` is governance, not resource bypass.** A platform admin manages orgs, users, teams, audit, and platform stats. They cannot read/list/create/delete any tenant resource — tenant resources are invisible to a pure `admin:all` context. Likewise `InternalAuthContext.is_admin` never bypasses `can_access_team`/`can_create_for_team`/ `verify_team_access`. Tenant-internal reads use `has_org_membership_only` / `require_org_admin_only` variants that exclude the `admin:all` arm (member CRUD, team management, DCR, grants).
-2. **Cross-org access requires explicit grant.** Org context (`org_id`/`org_name`) is loaded from the DB, never from the URL. The org-admin implicit-team arm cross-checks the scope's org against `ctx.org_name`. `verify_org_boundary(ctx, team_org_id)` returns **404** (not 403, anti-enumeration) when user-org ≠ team-org or when the user has no org and the team does; platform admins do NOT bypass it.
-3. **Team isolation is enforced in DB queries.** Every tenant resource read/write filters by team FK; `verify_team_access` (REST: `src/api/handlers/team_access.rs`; internal: `src/internal_api/auth.rs`) returns 404 for cross-team hits (existence-hiding) and emits a cross-team-access metric. There is no API path returning a tenant resource without a team check.
+### 3.3 Three hard invariants
 
-### 3.3 Role summary
+1. **Platform admin is governance, not a resource bypass.** A platform admin (`platform_admin == true`) can read/write governance resources only. A pure platform-admin context is *denied* tenant resources outright — it cannot read another tenant's clusters by virtue of being admin (`authz.rs` step 1 gates on `resource.is_governance()`; the `team`-present path returns `cross_org`/`no_matching_grant`). Cross-tenant reads go through an explicit `TeamScope::PlatformAdmin { reason }` at the storage layer (spec/08a), not through the authorization gate.
+2. **Cross-org access requires an in-org grant.** The active org (`ctx.org`) is loaded from the DB, never from the URL. With a target team, the gate denies `cross_org` before consulting grants when `ctx.org.id != team.org_id`. The API renders an org-boundary denial as **404** (anti-enumeration), not 403 — see spec/08a.
+3. **Team isolation is enforced in the typed `team` argument and in DB queries.** Every tenant decision carries a `TeamRef` whose `org_id` is checked against the principal's org; storage reads scope by team via `TeamScope` (spec/03 §… repository layer). There is no API path returning a tenant resource without a team check.
+
+### 3.4 Role summary
 
 | Role / context | Can |
 |---|---|
-| Platform admin (`admin:all`, platform-org owner) | All governance reads/writes (orgs, users, teams, audit, summary, admin-apps, admin-filter-schemas, scopes listing); create/delete orgs; invite the first org admin; query all audit logs. Cannot touch tenant resources, org member CRUD, org team CRUD, grants, or DCR. |
-| Org admin (`org:{o}:admin` = DB role `owner`/`admin`) | Everything in every team of their own org (implicit team access, expanded to all org teams for listing via `get_effective_team_scopes_with_org`); manage org members/roles, org teams, agents (with `agents:*` grant for create), grants, DCR; governance reads; update own org. Not platform governance writes; nothing in other orgs. |
-| Org member (`org:{o}:member`) | Governance **reads** (org/user/team listings, stats); tenant access only through explicit grant rows. |
-| Org viewer (`org:{o}:viewer`) | Same gate behavior as member at this layer (governance reads; needs grants for tenant resources); intended read-only. NOTE: the scope-format regex (`scope_registry.rs`) accepts only `admin|member` for org scopes while the runtime parser accepts `viewer` — see Gaps. |
+| Platform admin (`owner` of `platform` org) | All governance reads/writes (orgs, users, teams, audit, platform). **Cannot** touch any tenant resource (clusters/routes/secrets/…), which are invisible to a pure platform-admin context. |
+| Org admin/owner (`org_memberships.role` ∈ {`owner`,`admin`} in the active org) | Implicit access to every team in their own org (tenant resources) and `org_admin_tenant_default` for team-less tenant ops; governance **reads**. Nothing in other orgs; no platform governance writes. |
+| Org member/viewer | Governance **reads** (`governance_read`) and any tenant access explicitly granted by a `grants` row. (member vs viewer is not differentiated at the gate; intended read-only-ness for viewers is by convention.) |
 | Team-scoped user (grants only) | Exactly the `(resource, action, team)` triples in their grant rows. |
-| cp-tool agent | Grant-based like a human, `Resource` grants only; no governance bypass arm, no org-admin arm. |
-| gateway-tool agent | MCP gateway tools only (per `gateway-tool` grants + route exposure); structurally denied all CP resources. |
-| api-consumer agent | Data-plane only via Envoy RBAC compiled from `route` grants; structurally denied all CP resources. |
-
-### 3.4 Grant model and validation
-
-Valid resource/action pairs are a **code constant** (`scope_registry.rs::VALID_GRANTS` — the `scopes` DB table was dropped):
-
-```
-clusters/routes/listeners/filters/secrets/dataplanes/custom-wasm-filters/agents:
-    read create update delete
-ai-providers/ai-routes/ai-budgets:
-    read create update delete
-ai-usage:
-    read
-learning-sessions: read create execute delete
-aggregated-schemas: read execute
-proxy-certificates: read create delete
-reports/audit/stats: read
-```
-
-S10 AI gateway resources are tenant resources. `AiProvider`, `AiRoute`, and `AiBudget` CRUD uses the `ai-providers`, `ai-routes`, and `ai-budgets` grants above. `AiUsage` is read-only: usage rows are append-only system events, not caller-created resources, and `ai-usage:read` must filter by the caller's authorized team before aggregating token counts, model names, provider names, or budget status. Creating/updating an `AiProvider` validates that the referenced `Secret` belongs to the same team and that the caller can read/reference that secret; deleting an AI resource follows the same dependency-blocking pattern as gateway resources.
-
-Scope-string grammar (for DCR scope parsing and validation): `{resource}:{action}` · `team:{name}:{resource}:{action}` · `team:{name}:*:*` · `org:{name}:{admin|member}` · `admin:all`. Team/org name segments use the canonical name regex (lowercase-letter-leading, single-hyphen-separated; `a--b`, `-foo`, `foo-` rejected).
-
-Grant CRUD: `POST/GET/DELETE /api/v1/orgs/{org}/principals/{principal_id}/grants` — `require_org_admin_only`. Creation validates: grant_type ∈ {resource, gateway-tool, route}; principal must hold a membership row in this org (404 otherwise); type compatibility (human → resource only; machine → grant type must match its `agent_context`); resource grants need a valid `(resource_type, action)` pair; gateway-tool/route grants need a `route_id` whose route has `exposure == "external"`; the team must exist in the org and the principal must be a member of that team. On create/delete: permission-cache eviction (by `zitadel_sub` when known) and, for `route` grants, an xDS listener refresh so the Envoy RBAC filter updates. Audited as governance `grant.create` / `grant.delete`. Grants may carry `expires_at`; expired rows are excluded at load time (§2.3 step 7) — expiry is enforcement-by-omission, no reaper required.
+| `cp-tool` agent | Grant-based like a human, but with no governance bypass and no org-admin arm; same-org check applies. |
+| `gateway-tool` agent | `McpTools` resource only, and only with a matching grant; structurally denied all other resources. |
+| `api-consumer` agent | Data-plane only via Envoy RBAC; structurally denied all control-plane resources. |
 
 ### 3.5 Where the gate is invoked, per surface
 
-- **REST, layer 1 — dynamic scope middleware** (`ensure_dynamic_scopes`, on the secured router): derives `resource = resource_from_path(path)`, `action = action_from_request(method, path)`, and calls `require_resource_access(ctx, resource, action, None)` (team=None — team checked at handler level). Path → resource mapping rules (`resource_from_path`):
-  - non-`/api/v1/*` paths and these prefixes **skip the middleware entirely** (handler enforces):
-    `/api/v1/teams` (bare list), `/api/v1/auth/*`, `/api/v1/orgs/*`,
-    `/api/v1/admin/organizations/*`, `/api/v1/audit-logs`, `/api/v1/org/*` (in-org audit),
-    `/api/v1/mcp` (JSON-RPC method-level auth).
-  - renames: `route-configs|route-views → routes`, `filter-types → filters`,
-    `openapi/* → openapi-import`; team-scoped sub-resources
-    `/api/v1/teams/{team}/{res}` → `{res}` with `custom-filters → custom-wasm-filters`,
-    `rate-limit-domains|rate-limit-policies → rate-limit`,
-    `/teams/{team}/bootstrap → generate-envoy-config`, `/teams/{team}/ops/{sub}` →
-    {trace→routes, topology|validate|xds→clusters, audit→audit, learning→learning-sessions,
-    default→clusters}.
-  - action mapping: GET/HEAD/OPTIONS→read, POST→create, PUT/PATCH→update, DELETE→delete; paths
-    ending `/export` or `/compare`, or containing a whole segment `search` or `query`, are
-    semantically **read** regardless of method (no substring false-positives:
-    `search-configs` POST stays create).
-- **REST, layer 2 — handlers**: re-check with the concrete team (`require_resource_access_resolved` resolves UUID→name first), then row-level `verify_team_access` / `verify_org_boundary` on fetched resources. Org/member/team/grant management handlers use the `require_admin` / `require_org_admin[_only]` / `has_org_membership[_only]` helpers as in §3.3's table.
-- **MCP control plane**: every `tools/call` goes through `check_tool_authorization(tool, team)` — each tool in the static registry declares `(resource, action)` (`src/mcp/tool_registry.rs::get_tool_authorization`), and the handler calls `check_resource_access(ctx, resource, action, team_opt)` (empty team string → None, governance tools). Tool/resource listing filters teams by `check_resource_access(ctx, "api", "read", team)`; gateway tool execution requires `api:execute` on at least one team and searches only authorized teams. `resources/read` paths re-check per team.
-- **Internal API** (`src/internal_api/auth.rs::InternalAuthContext`): surface-agnostic adapter. `from_rest` / `from_rest_with_org` (org-admin team expansion) for REST; `from_mcp(team, org_id, org_name)` for MCP — **an empty team string yields a powerless context, never admin** (a v1 vuln fix: `is_admin` is never inferred from emptiness; governance callers must use the explicit `InternalAuthContext::admin()`, which still cannot touch team resources). `requested_team` (from URL path) additionally pins `verify_team_access` to the exact team, preventing cross-team reads via unrelated paths. `can_create_for_team(None) == false` — no create path may write a NULL-team (global) resource.
-
-### 3.6 Org-scoped helper semantics (handler-level checks)
-
-| Helper | admin:all passes? | Logic |
-|---|---|---|
-| `has_org_admin(ctx, org)` | yes | `admin:all` OR `org:{org}:admin` — for governance ops like inviting the first org admin |
-| `has_org_admin_only(ctx, org)` | **no** | `org:{org}:admin` only — member CRUD, team CRUD, grants, DCR |
-| `has_org_membership(ctx, org)` | yes | admin/member/viewer scope OR `admin:all` |
-| `has_org_membership_only(ctx, org)` | **no** | admin/member/viewer scope — tenant-internal reads platform admin must not see |
-| `verify_same_org(team_org, user_org, is_admin)` | yes (explicit flag) | org equality required; team-without-org (global) or both-None allowed |
+- **Tenant resource services** call `check_resource_access(ctx, resource, action, team)` with the concrete resource/action and, where a team is in scope, a resolved `TeamRef`; a `Deny` maps to HTTP 403 (or 404 for an org-boundary denial, §3.3). (`crates/fp-core/src/services/*.rs`.)
+- **Governance / org-admin flows** (team, org-member, grant, agent management) do **not** go through the resource gate; they use org-role helpers — e.g. `authorize_member_admin` — that check the caller's `org_memberships` role directly. (`crates/fp-core/src/services/teams.rs:18`, `services/agents.rs:26`, `services/orgs.rs:130`.)
+- **MCP** `tools/call` resolves each tool to its `(resource, action)` and calls the same gate; `api-consumer` agents are excluded at `initialize` (`crates/fp-api/src/mcp_api.rs:126-140`).
 
 ---
 
@@ -311,83 +231,43 @@ Grant CRUD: `POST/GET/DELETE /api/v1/orgs/{org}/principals/{principal_id}/grants
 
 | Credential | Issued by | Lifetime | Refresh | Revocation |
 |---|---|---|---|---|
-| Access JWT (human, prod) | Zitadel (PKCE / device code) | provider-set, ≤ ~1 h | refresh-token grant (CLI auto-refresh with 60 s buffer; BFF server-side silent refresh with 60 s skew) | RFC 7009 revoke on CLI/BFF logout; **stateless CP keeps accepting until `exp`** (documented accepted risk) |
-| Access JWT (machine) | Zitadel `client_credentials` | provider-set | re-request | client-secret rotation via Zitadel; permission changes via grants + cache evict |
-| Dev JWT | embedded mock OIDC | 1 h default | mock supports refresh grant; the seeded credentials file has no refresh token | none (ephemeral signing key dies with the process) |
-| BFF session cookie | CP (encrypts provider tokens) | bounded by refresh-token life | transparent middleware refresh | logout revokes underlying tokens + clears cookie; cookie is AEAD-sealed, tamper ⇒ no session |
-| `client_secret` (agents/DCR) | Zitadel via Management API | until rotated | n/a | delete agent (`DELETE /orgs/{o}/agents/{id}`, requires `agents:delete`) |
-| Bootstrap token | operator env `FLOWPLANE_BOOTSTRAP_TOKEN` | until env cleared | n/a | unset env (endpoint 403s) |
-| Zitadel admin PAT | Zitadel (`FLOWPLANE_OIDC_ADMIN_PAT`) | Zitadel-managed | n/a | rotate in Zitadel; absence disables DCR/invite/agent provisioning (503) |
-| Grants (authz rows) | org admin | optional `expires_at` | n/a | delete row; effective within cache TTL / on evict |
+| Access JWT (human) | the configured OIDC IdP (or dev in-process issuer) | provider-set | provider's refresh flow (client-side) | stateless CP keeps accepting until `exp` (accepted risk); permission changes apply next request (DB-loaded principal) |
+| Agent token (`fpat_*`) | Flowplane (`crates/fp-core/src/services/agents.rs:82-87`) | until rotated/suspended | `rotate_agent_token` (new token, replaces hash) | suspend agent (`status='suspended'`) or rotate; only the SHA-256 hash is stored |
+| Bootstrap token (`fpboot_*`) | operator-supplied (or legacy generate-and-log) | 24 h, single-use | n/a | expiry, single-use `used_at`, or operator re-seed (§1.5) |
+| Grants (authz rows) | org admin | n/a (no `expires_at` column) | n/a | delete the row; effective next request |
 
-There are **no Flowplane-native personal access tokens or API keys** in v1: every credential is an OIDC token (or the one bootstrap env token). The legacy `password_hash` column is dead (always `''`).
-
-`GET /api/v1/scopes` lists UI-visible scope definitions (any authenticated user); `GET /api/v1/admin/scopes` (admin:all) additionally includes `admin:all`. Both are generated from the code constant — there is no scopes table.
+There are **no** OIDC `client_credentials` machine tokens, no Dynamic Client Registration, no IdP admin PAT, and no `password_hash` (the column does not exist). Every human credential is an OIDC token; every machine credential is a Flowplane-issued `fpat_*` token.
 
 ---
 
-## 5. Dataplane identity (cross-ref spec/04)
+## 5. Audit (`crates/fp-storage/src/repos/audit.rs`, table `audit_log` `0002_identity.sql:95-112`)
 
-Operator identity (JWT) and dataplane identity (mTLS client cert) are disjoint; neither credential works on the other surface. xDS mTLS is unconditional — no plaintext gRPC.
+Audit covers mutations, authorization denials, and authentication failures.
 
-Authz-relevant part (`src/xds/services/mtls.rs`):
-- The Envoy client cert's URI SAN must be SPIFFE: `spiffe://{trust_domain}/org/{org}/team/{team}/proxy/{proxy_id}` (org-scoped) or legacy `spiffe://{trust_domain}/team/{team}/proxy/{proxy_id}`.
-- `ClientIdentity {org?, team, proxy_id, spiffe_uri, serial_number}` is parsed from the **certificate**, never from node metadata (node-metadata team is logged, never authorized).
-- The SPIFFE URI must match a registered, non-revoked `proxy_certificates` row binding it to a team; that team scopes every xDS read — the connection only ever receives that team's resources.
-- Because the URI SAN *content* is trusted as identity, the CA must refuse client-chosen URI SANs. For the Vault PKI backend the CP enforces this with a **boot probe**: it refuses to start if the PKI role's `allowed_uri_sans` is empty or contains `*` (`src/secrets/vault.rs::read_pki_role_uri_sans`). Other cert backends (cert-manager, GCP CAS, AWS PCA, Roles Anywhere) rely on operator-side issuance policy — operator checklist in v1 `docs/explanation/auth-model.md` §"Cert-backend invariant".
-- Dev mode seeds one proxy-certificate row for the generated dev dataplane cert (`DEV_DATAPLANE_SPIFFE_URI`), 30-day expiry, upserted on each boot.
+- **Entry shape** (`audit.rs:72-87`): `request_id?`, `actor_type` (`user`/`agent`/`dataplane`/`system`/`anonymous`), `actor_id?`, `actor_label`, `surface` (`rest`/`mcp`/`cli`/`xds`/`system`), `action` (verb-style, e.g. `team.create`, `authz.denied`, `authn.failed`), `resource`, `org_id?`, `team_id?`, `outcome` (`success`/`denied`/`failure`), `detail` (JSONB structured context — must not contain secrets/tokens/payloads). The table has **no FKs**, so rows survive subject deletion.
+- **Write paths:** transactional (`record_in_tx` — the audit row commits with the mutation or rolls back with it) and best-effort (`record_best_effort` — never fails the caller; errors are logged and counted) (`audit.rs:156-176`).
+- **Authorization denials** from the resource gate are recorded via `fp_core::services::record_authz_denial` (`crates/fp-core/src/services/mod.rs:56,80`), which builds a best-effort `audit_log` row carrying the gate's `Reason` (`AuditEntry::denial`, `audit.rs:103-127`). Note two current limitations: the shared helper hardcodes `surface = Rest` even for MCP callers, and denials raised by the org-role helpers (§3.5) are not consistently audited. **Authn failures** are recorded best-effort from the middleware (`auth.rs:132-151,226-244`).
 
----
-
-## 6. Audit
-
-Audit writes are **best-effort** (failures are error-logged and swallowed, never failing the request) into the `audit_log` table (`src/internal_api/audit.rs`, `src/storage/.../audit_log.rs`).
-
-Auth-relevant audited events:
-- **Governance actions** (`record_governance_action`): resource_type ∈ {`organization`, `user`, `org_membership`, `grant`, `team`}, action a bare verb (`create`, `update`, `delete`, `invite`, `add`, `remove`); carries acting `user_id` and affected `org_id`; deliberately carries **no resource id/name** (redaction posture of the platform-admin feed). Emitted by: org create/update/delete, member add/invite/role-change/remove, team create/update/delete, team-member add/remove, agent create/delete, grant create/delete.
-- **Provisioning creates** (`record_provisioning_create`): clusters/listeners/route-configs create, dataplane register — with org/team/user context (feeds governance rollups).
-- **Secrets access** via the audited secrets client (`src/secrets/audited.rs`).
-- `AuthContext.to_audit_context()` supplies `(user_id, client_ip, user_agent)` — client IP from the trusted-proxy resolution, so forged XFF cannot spoof audit IPs.
-
-Query surfaces: `GET /api/v1/audit-logs` — requires `admin:all`; org-scoped admins (admin:all + org_id) are forcibly filtered to their own org; pure platform admins can query any org. In-org views `GET /api/v1/org/audit-logs|audit-volume` require `audit:read` access and 403 when the context carries no org_id. Team-scoped `/teams/{team}/ops/audit` maps to the `audit:read` grant.
-
-**Not audited** (log-only via `tracing`): authentication failures, JWT validation errors, rate-limit hits, cross-team access attempts (metric only), CSRF failures, BFF login/logout. v2 should consider promoting login failures and authz denials to audit rows (see Gaps).
+Severity is derived at read time from the action verb. (Detailed query surfaces live with the REST API reference.)
 
 ---
 
-## 7. Gaps and smells (feeds spec/08, 08a)
+## 6. Dataplane identity (cross-ref spec/04)
 
-1. **No login/authn-failure audit trail.** Failed JWT validation, rate-limit trips, CSRF failures, and cookie-session refresh failures are tracing-logs only — no `audit_log` rows, no alerting hook. Authorization denials likewise (cross-team attempts are a metric only).
-2. **Stateless revocation window.** Revoked/rotated Zitadel sessions remain valid until `exp` (≤ ~1 h) — no `jti` blocklist or introspection. Explicitly accepted in v1 and surfaced honestly in CLI logout, but it is a real window; v2 should decide deliberately.
-3. **`viewer` role inconsistency.** `map_org_role_to_scopes` and `parse_org_from_scope` accept `viewer`, and `has_org_membership*` honor it, but `scope_registry.rs`'s `SCOPE_FORMAT_REGEX`/`is_valid_org_scope` accept only `admin|member` — `org:{name}:viewer` fails scope validation while existing at runtime. At the gate, viewer behaves identically to member (governance reads); nothing actually enforces read-only-ness for viewers holding grants.
-4. **Dual authz vocabularies.** Org-level = scope strings, team-level = grant rows, plus the legacy `team:{name}:{res}:{act}` *string* grammar still validated by `scope_registry` and used in DCR scope parsing — three representations of permission that must be kept coherent by hand. v2 should collapse to one.
-5. **`users.is_admin` is dead weight.** Column exists, is seeded `false` everywhere, and is never consulted by the gate — confusing; drop or use.
-6. **Middleware-skip list is hand-maintained.** `resource_from_path` returning `None` (orgs, admin/organizations, audit-logs, org/*, mcp, auth, bare teams list) shifts the entire burden to handler-level checks; a new handler under a skipped prefix that forgets its check ships with **no** authorization. Same risk for the semantic-read rules (`/export`, `/compare`, `search`, `query` segments): any future state-changing endpoint under such a path is auto-downgraded to `read`. v2 should make authz declarations per-route and fail-closed.
-7. **`verify_same_org` allows team-without-org ("global team") and unscoped-user/unscoped-team combinations**, and `verify_team_access` treats NULL-team resources as globally readable. Combined with the nullable `team` columns on clusters/route_configs/listeners (creates are blocked from writing NULL by `can_create_for_team`, but legacy rows may exist), a NULL-team row is visible to everyone. Make team non-nullable in v2.
-8. **Bootstrap token is a static bearer secret in an env var** — constant-time-compared and self-disabling, but long-lived if the operator never unsets it; any holder can create orgs pre-JIT. Prefer one-shot/expiring bootstrap in v2.
-9. **Dev-mode prod-leak surfaces.** (a) `auth_mode_handler` reads `FLOWPLANE_AUTH_MODE` directly from env at request time rather than the parsed `AuthMode` — drift risk between what the server runs and what it advertises; (b) dev mock OIDC binds an unauthenticated token-minting endpoint on loopback — fine locally, but nothing prevents `FLOWPLANE_AUTH_MODE=dev` in a container exposed to a network (guarded only by the cargo feature); (c) dev seeds and credentials use fixed IDs (`dev-sub`, `dev-user-id`, `dev-org-id`) — harmless if dev mode never runs in prod, catastrophic if it does. v2: refuse dev mode when a prod-ish env marker is present.
-10. **Hardcoded/printed credentials paths.** `initial_admin_password` /
-    `initial_password` / `FLOWPLANE_SUPERADMIN_INITIAL_PASSWORD` flow plaintext passwords
-    through API bodies/env into Zitadel (deliberate no-SMTP convenience; marked never-logged but
-    review for accidental logging); `setup-zitadel.sh` writes the Zitadel admin PAT into
-    `.env.zitadel` (`ZITADEL_ADMIN_PAT`, `FLOWPLANE_OIDC_ADMIN_PAT`) on disk; agent/DCR
-    `client_secret` is returned once in an HTTP response (acceptable, but ensure no
-    request/response logging captures it).
-11. **`create_org_agent` authz asymmetry.** The `agents:create` check runs against only the
-    *first* team in the request; the agent is then made a member of *all* listed teams. A
-    grantee with `agents:create` on one team can attach an agent to other org teams (grants
-    still gate what it can do there, but team membership is a prerequisite for grants —
-    membership escalation). Also `agent_context` is hardcoded to `cp-tool` (open TODO E.3).
-12. **`list_org_agents`/`delete_org_agent` org check is name-based** (`context.org_name ==
-    org_name` plus `agents:read|delete` any-team) rather than the id-based
-    `verify_org_boundary`; consistent renames/odd states could diverge. Minor, but v2 should
-    standardize on org-id comparison.
-13. **Permission cache has no size bound** — keyed by attacker-suppliable-ish `sub` (only after
-    a *valid* signature, so bounded by IdP user count in practice) but unbounded growth and no
-    LRU; also `evict_by_user_id` is O(n).
-14. **MCP origin allowlist defaults are permissive for any-port localhost** and origin matching
-    ignores ports entirely — fine as defense-in-depth (bearer auth is primary), but document
-    that origin checks are not a security boundary.
-15. **JWKS fetch lacks TLS pinning/issuer-cert validation knobs** and `JWKS_FETCH_TIMEOUT=2s`
-    with empty-cache cooldown returns an empty key set → all logins 401 for the cooldown window
-    after a failed first fetch at boot (cold-start brownout on slow IdP).
+Operator identity (JWT / agent token) and dataplane identity (mTLS client cert) are disjoint; neither credential works on the other surface. xDS mTLS is unconditional — there is no plaintext gRPC path in prod (`crates/fp-xds/src/ads.rs`; TLS material via `FLOWPLANE_XDS_TLS_CERT`/`_KEY`/`_CLIENT_CA`, `config.rs:202-225`).
+
+Authz-relevant part (`crates/fp-xds/src/ads.rs:41-150`):
+- The Envoy client cert's URI SAN (SPIFFE) is the identity; it is parsed from the **verified certificate**, never from node metadata.
+- Two resolvers: a **NodeIdTeamResolver** for dev/test (trusts `team=<uuid>` in `node.id`, `ads.rs:65-87`) and a **CertRegistryResolver** for production that looks the SPIFFE URI up in the certificate registry (`fp_storage::repos::dataplanes::find_active_certificate`, `ads.rs:93-135`).
+- A match yields a `PeerIdentity { team_id, dataplane_id?, certificate_id? }`; that team scopes every xDS read — the connection only ever receives that team's resources. A missing/revoked/expired certificate returns one uniform error (`ads.rs:125-132`); revoking a certificate ends the live stream via a broadcast watch (`ads.rs:138-157`).
+
+The exact SPIFFE URI template, trust-domain handling, and CA issuance-policy invariant are specified in spec/04.
+
+---
+
+## 7. Notes and accepted risks
+
+1. **Stateless revocation window.** A revoked/rotated OIDC session's access token stays valid until `exp` — no `jti` blocklist or introspection. Permission (grant/membership) changes apply on the next request because the principal is DB-loaded each request. Accepted; revisit if a hard logout is required.
+2. **Origin allowlist is defense-in-depth.** The MCP Origin check ignores port and is not the security boundary — bearer auth is. Documented so it is not mistaken for one.
+3. **member vs viewer is not gate-differentiated.** Both reach governance reads; read-only-ness for viewers holding grants is by convention, not enforcement.
+4. **JWKS cold-start.** A failed first JWKS fetch consumes the 30 s cooldown; logins can 401 for that window on a slow IdP at boot. The single-flight + cooldown bound deliberately trade a short brownout for not hammering the IdP.


### PR DESCRIPTION
Closes #153.

`spec/05-auth.md` and `spec/03-domain-model.md` were extracted from Flowplane v1 and described Zitadel-specific authentication machinery (`zitadel_sub` column, Zitadel-managed machine users, Management-API invite, DCR, admin PAT, BFF cookie sessions, scope strings) that the shipped v2 code never built. This reconciles both docs to the as-built v2 implementation.

## What changed

**spec/05-auth.md** — rewritten to v2 as-built:
- Provider-agnostic OIDC (`OidcConfig`, RS256-pinned, `nbf` enabled, JWKS cooldown/single-flight, discovery); **no** userinfo fallback, project-id, or admin PAT.
- Identity split into humans (`users`, OIDC `subject`) and machines (`agents`, `fpat_` bearer token → `token_hash`).
- `PrincipalCtx` (User/Agent) + typed `Resource`/`Action` gate `check_resource_access -> Decision` with `Reason` strings; runtime scope strings (`admin:all`, `org:{name}:role`) removed.
- `FLOWPLANE_DEV_MODE` (not `FLOWPLANE_AUTH_MODE`); `fpboot_` one-shot bootstrap; dev seed `subject=dev-user`, `owner` role, no platform admin.
- Removed v1 machinery absent in v2: BFF/cookie/session/CSRF, permission cache (v2 loads the principal from the DB per request), DCR, invite, superadmin seeding, `client_credentials`.
- Agent-kind structural rules corrected: `gateway-tool` is limited to `McpTools` but still requires a matching grant (the read/execute limit is grant-creation validation, not gate behaviour).

**spec/03-domain-model.md** — identity/auth sections reconciled to `migrations/0002_identity.sql`:
- §2.1 entity rows (Organization/OrgMembership/User/**Agent**/Team/TeamMembership/Grant), §3.1 DDL (UUID PKs, `subject`, `agents`, simplified `grants`, `bootstrap_tokens`), §4.1 uniqueness, §4.2 delete behaviour, §5 repo layer, §8 gap #20.
- No `password_hash` / `is_admin` / `zitadel_sub` / `user_type` / `agent_context`; grants carry no `grant_type` / `resource_type` / `route_id` / `allowed_methods` / `expires_at`.

## Verification

Every claim is grounded in cited v2 source (`crates/`, migrations). Independently reviewed by Codex over **four read-only passes** against the code — converging 6 → 1 → 1 → 0 findings — final verdict **APPROVE**, "no remaining identity/auth inaccuracies." Review trail in #153 comments.

Scope: documentation only — no code or schema change (the column is already `subject` in code). README.md changes are tracked separately.
