### PR TITLE
feat(serve): dev-only FLOWPLANE_DEV_TOKEN_PATH token file sink (#156)

### DIFF
--- a/crates/flowplane/src/serve.rs
+++ b/crates/flowplane/src/serve.rs
@@ -26,7 +26,7 @@ pub async fn run() -> anyhow::Result<()> {
     tracing::info!("database connected and migrations applied");
 
     let validator: Option<std::sync::Arc<fp_core::OidcValidator>> = if config.dev_mode {
-        Some(setup_dev_mode(&pool).await?)
+        Some(setup_dev_mode(&pool, config.dev_token_path.as_deref()).await?)
     } else if let Some(oidc) = &config.oidc {
         tracing::info!(issuer = %oidc.issuer, "OIDC authentication enabled");
         Some(std::sync::Arc::new(fp_core::OidcValidator::new(
@@ -316,6 +316,7 @@ pub async fn migrate_only() -> anyhow::Result<()> {
 #[cfg(feature = "dev-oidc")]
 async fn setup_dev_mode(
     pool: &sqlx::PgPool,
+    dev_token_path: Option<&std::path::Path>,
 ) -> anyhow::Result<std::sync::Arc<fp_core::OidcValidator>> {
     if !cfg!(debug_assertions) {
         let ack = std::env::var("FLOWPLANE_DEV_MODE_ACK").unwrap_or_default();
@@ -333,6 +334,12 @@ async fn setup_dev_mode(
     // Dev-only by triple gate: the token grants access to the seeded local instance only
     // and dies with this process (per-boot key).
     tracing::warn!(dev_token = %token, "dev bearer token (valid 1h, this boot only)");
+    // Dev-only file sink (#156): a compose `init`/sibling container can't read another
+    // container's stdout, so when an operator names a path we also write the raw token there.
+    if let Some(path) = dev_token_path {
+        write_dev_token(path, &token)?;
+        tracing::warn!(path = %path.display(), "dev bearer token also written to file (dev mode)");
+    }
     let validator = fp_core::OidcValidator::new(issuer.oidc_config());
     validator
         .load_jwks_json(issuer.jwks_json())
@@ -344,11 +351,20 @@ async fn setup_dev_mode(
 #[cfg(not(feature = "dev-oidc"))]
 async fn setup_dev_mode(
     _pool: &sqlx::PgPool,
+    _dev_token_path: Option<&std::path::Path>,
 ) -> anyhow::Result<std::sync::Arc<fp_core::OidcValidator>> {
     Err(anyhow::anyhow!(
         "FLOWPLANE_DEV_MODE=true but this binary was built without the dev-oidc feature \
          (release artifact); use a development build or configure a real OIDC issuer"
     ))
+}
+
+/// Persist the minted dev token to an operator-named path so a sibling container can read it.
+/// Dev-mode only; a write failure is fatal so a misconfigured eval bundle fails loud, not silent.
+#[cfg(feature = "dev-oidc")]
+fn write_dev_token(path: &std::path::Path, token: &str) -> anyhow::Result<()> {
+    std::fs::write(path, token)
+        .with_context(|| format!("failed to write dev token to {}", path.display()))
 }
 
 /// Minimum length of an operator-supplied bootstrap token after trimming (#113). First-platform-
@@ -611,5 +627,41 @@ mod bootstrap_token_tests {
         let secret = "supersecretbutslightlytooshort"; // 30 chars
         let err = validate_bootstrap_token(secret).unwrap_err().to_string();
         assert!(!err.contains(secret), "error must not echo the token");
+    }
+}
+
+#[cfg(all(test, feature = "dev-oidc"))]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod dev_token_tests {
+    use super::*;
+    use std::process;
+
+    #[test]
+    fn write_dev_token_persists_exact_bytes() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("flowplane-dev-token-{}.txt", process::id()));
+        let _ = std::fs::remove_file(&path);
+
+        let token = "dev.token.value-123";
+        write_dev_token(&path, token).expect("write must succeed");
+
+        let read_back = std::fs::read_to_string(&path).expect("file must be readable");
+        assert_eq!(
+            read_back, token,
+            "file content must match minted token byte-for-byte"
+        );
+
+        std::fs::remove_file(&path).expect("cleanup");
+    }
+
+    #[test]
+    fn write_dev_token_errors_with_context_on_bad_path() {
+        // A path whose parent does not exist is unwritable; the error must carry the path context.
+        let bad = std::path::Path::new("/nonexistent-flowplane-dir/does/not/exist/token.txt");
+        let err = write_dev_token(bad, "x").expect_err("must fail on unwritable path");
+        assert!(
+            err.to_string().contains("failed to write dev token to"),
+            "error must carry write context, got: {err}"
+        );
     }
 }

--- a/crates/fp-core/src/config.rs
+++ b/crates/fp-core/src/config.rs
@@ -49,6 +49,10 @@ pub struct ServerConfig {
     /// operator-supplied bootstrap token falls back to generating one and logging it. Enabled
     /// only by the exact value `yes-this-is-local-only`; otherwise the instance fails closed.
     pub allow_logged_bootstrap_token: bool,
+    /// Dev mode only: when set, the minted per-boot dev token is also written to this path so a
+    /// sibling container's init step can read it (the token is otherwise only logged). Ignored
+    /// outside dev mode. Env `FLOWPLANE_DEV_TOKEN_PATH`.
+    pub dev_token_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -102,6 +106,7 @@ struct FileConfig {
     log_format: Option<LogFormat>,
     log_filter: Option<String>,
     otlp_endpoint: Option<String>,
+    dev_token_path: Option<String>,
 }
 
 const DEFAULT_API_ADDR: &str = "0.0.0.0:8080";
@@ -306,6 +311,10 @@ impl ServerConfig {
         let allow_logged_bootstrap_token =
             get("FLOWPLANE_ALLOW_LOGGED_BOOTSTRAP_TOKEN") == Some("yes-this-is-local-only");
 
+        let dev_token_path = get("FLOWPLANE_DEV_TOKEN_PATH")
+            .map(PathBuf::from)
+            .or_else(|| file.dev_token_path.map(PathBuf::from));
+
         Ok(Self {
             api_addr,
             xds_addr,
@@ -321,6 +330,7 @@ impl ServerConfig {
             oidc,
             tenant_write_limit_per_minute,
             allow_logged_bootstrap_token,
+            dev_token_path,
         })
     }
 }
@@ -389,6 +399,31 @@ mod tests {
         };
         let cfg = ServerConfig::resolve(&env, file);
         assert_eq!(cfg.ok().map(|c| c.api_addr.port()), Some(9999));
+    }
+
+    #[test]
+    fn dev_token_path_resolves_env_over_file() {
+        // Absent in both → None.
+        let cfg = ServerConfig::resolve(&base_env(), FileConfig::default()).expect("resolves");
+        assert_eq!(cfg.dev_token_path, None);
+
+        // File only.
+        let file = FileConfig {
+            dev_token_path: Some("/from/file".into()),
+            ..FileConfig::default()
+        };
+        let cfg = ServerConfig::resolve(&base_env(), file).expect("resolves");
+        assert_eq!(cfg.dev_token_path, Some(PathBuf::from("/from/file")));
+
+        // Env overrides file.
+        let mut env = base_env();
+        env.insert("FLOWPLANE_DEV_TOKEN_PATH".into(), "/from/env".into());
+        let file = FileConfig {
+            dev_token_path: Some("/from/file".into()),
+            ..FileConfig::default()
+        };
+        let cfg = ServerConfig::resolve(&env, file).expect("resolves");
+        assert_eq!(cfg.dev_token_path, Some(PathBuf::from("/from/env")));
     }
 
     #[test]

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -32,6 +32,7 @@ Booleans accept `true`/`1`/`yes` and `false`/`0`/`no`. Invalid server values fai
 | `FLOWPLANE_OTLP_ENDPOINT` | server | — | no | OTLP trace export endpoint; unset disables export. |
 | `FLOWPLANE_DEV_MODE` | server | `false` | no ⁴ | In-process OIDC issuer + seeded resources; needs the `dev-oidc` build feature. |
 | `FLOWPLANE_DEV_MODE_ACK` | server | — | no ⁴ | In release builds, dev mode requires this to equal `yes-this-is-not-production`. |
+| `FLOWPLANE_DEV_TOKEN_PATH` | server | — | no | Dev mode only: also write the per-boot dev bearer token to this file (it is otherwise only logged), so a sibling/init container can read it. Ignored outside dev mode. |
 | `FLOWPLANE_BOOTSTRAP_TOKEN` | server | — | first boot ¹³ | Operator-supplied one-shot bootstrap token (≥ 32 chars after trimming). Seeds first-admin setup; the value is never logged. |
 | `FLOWPLANE_BOOTSTRAP_TOKEN_FILE` | server | — | first boot ¹³ | Path to read the bootstrap token from; **takes precedence** over `FLOWPLANE_BOOTSTRAP_TOKEN`. File delivery is safer than env. |
 | `FLOWPLANE_ALLOW_LOGGED_BOOTSTRAP_TOKEN` | server | — | no | Local-only escape hatch: the exact value `yes-this-is-local-only` re-enables generating and **logging** a token. Never set in production. |
@@ -96,5 +97,5 @@ api_addr            xds_addr             database_url        db_max_connections
 api_tls_cert        api_tls_key          xds_tls_cert        xds_tls_key
 xds_tls_client_ca   api_insecure         dev_mode            oidc_issuer
 oidc_audience       oidc_jwks_uri        log_format          log_filter
-otlp_endpoint
+otlp_endpoint        dev_token_path
 ```


### PR DESCRIPTION
## Summary

Epic #161's load-bearing root slice for the no-clone evaluator bundle. The per-boot dev bearer token was emitted **only** to the tracing log (`serve.rs:335`), so a compose `init`/sibling container had no machine-readable way to obtain it (it can't read another container's stdout).

Adds an **opt-in, dev-mode-only** file sink:

- **fp-core config:** `ServerConfig`/`FileConfig` gain `dev_token_path`, resolved from env `FLOWPLANE_DEV_TOKEN_PATH` over the TOML key (env > file).
- **serve:** threads the path into both cfg variants of `setup_dev_mode`; when set, a new `write_dev_token` helper writes the raw minted token via `std::fs::write(...).with_context(...)` (no `unwrap`/`expect`/`panic`). The existing log line is unchanged.
- **docs:** documents the env var + TOML key in `docs/reference/configuration.md`.

## Behaviour

| Condition | Result |
|---|---|
| var set + dev mode | token logged **and** written (byte-identical, validates through normal dev auth path) |
| var unset | unchanged — still logged, no file |
| non-dev / `--no-default-features` build | stub errors before any file logic |

Default `None` preserves current behaviour exactly.

## Tests

- Config env-over-file precedence (`fp-core`).
- `write_dev_token` persists exact bytes + errors with path context on an unwritable path (`flowplane`, gated on `dev-oidc`).

Gates green: `fmt`, `clippy --all-features` **and** `--no-default-features`, unit tests.

## Review trail

Built via the `/fix-github-issue` Codex-gated loop. Both gates **APPROVED** by Codex (independent verification against the codebase), comments on #156.

> ⚠️ **HUMAN-GATE (auth/secrets):** writes a dev bearer token to a file. Human sign-off required before merge even on green review.

Closes #156