### PR TITLE
feat(release): add flowplane:<ver>-eval OCI image with dev-oidc (#157)

### DIFF
--- a/Containerfile.eval
+++ b/Containerfile.eval
@@ -1,0 +1,23 @@
+# Evaluation image: keeps the default `dev-oidc` feature so dev mode works (in-process OIDC
+# issuer + seeded resources). NEVER an operator/production base — tagged `:<ver>-eval` only,
+# never `:latest`. The hardened, publishable image is `Containerfile.release` (built
+# `--no-default-features`, which refuses dev mode). See DECISIONS.md D-022.
+#
+# The ONLY difference from Containerfile.release is the absence of `--no-default-features` on
+# the flowplane build below, so keep the two files in sync for everything else.
+FROM rust:1.94.1-bookworm AS build
+WORKDIR /src
+COPY . .
+RUN cargo build --release --locked -p flowplane --bin flowplane \
+    && cargo build --release --locked -p fp-agent --bin fp-agent
+
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=build /src/target/release/flowplane /usr/local/bin/flowplane
+COPY --from=build /src/target/release/fp-agent /usr/local/bin/fp-agent
+USER 65532:65532
+EXPOSE 8080 18000
+ENTRYPOINT ["/usr/local/bin/flowplane"]
+CMD ["serve"]

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -575,3 +575,23 @@ The mechanism left open in D-014 is now decided (founder, 2026-06-13):
   Recording the DoD here keeps the release bar legible and prevents a green checkbox from papering
   over an unrun verification.
 - **Status:** decided for S12a / #87.
+
+## D-022: Two-image split — hardened `flowplane:<ver>` vs eval `flowplane:<ver>-eval`
+
+- **Context:** The no-clone evaluator bundle (epic #161) needs to run dev mode (in-process OIDC
+  issuer + seeded resources + the per-boot dev token file from #156). The only publishable image,
+  `Containerfile.release`, is built `--no-default-features`, so `dev-oidc` is compiled out and dev
+  mode fails closed (`crates/flowplane/src/serve.rs` `#[cfg(not(feature = "dev-oidc"))]` stub). A
+  single image cannot be both hardened-by-default and dev-capable without weakening the default.
+  (Records the decision behind issue #157; the issue text proposed an `FPV2-DEC-NNNN` id, but this
+  log's source-of-truth scheme is `D-NNN`, so it is filed as D-022.)
+- **Decision:** Ship two images from two Containerfiles. `Containerfile.release` stays exactly as
+  is — hardened, `--no-default-features`, refuses dev mode — and remains the only image eligible
+  for `:latest` / operator use. A new `Containerfile.eval` differs **only** by dropping
+  `--no-default-features` (default `dev-oidc` on) and is tagged `:<ver>-eval` exclusively, **never**
+  `:latest`. Its build is opt-in (`FLOWPLANE_PACKAGE_EVAL_IMAGE=1` in `scripts/release/package-release.sh`).
+  The eval image is bound to loopback by the compose bundle (#158) and is never an operator base.
+- **Why better:** Keeping the hardened default literally untouched means the split cannot regress
+  production posture — the dev-identity surface lives only in a distinctly named, unpublished,
+  never-`latest` artifact, while evaluators still get a frictionless dev-mode image.
+- **Status:** decided for #157 (epic #161). HUMAN-GATE (auth) slice.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -25,7 +25,7 @@ You need:
 
   Dev mode requires a binary built **with the `dev-oidc` feature**. That feature is on by default, so a plain `cargo build --bin flowplane` (or `cargo run`) includes it — both debug and local release builds (`cargo build --release`) are fine. The commands below use `./target/debug/flowplane`.
 
-  The published release container (`Containerfile.release`) is built `--no-default-features`, so it does **not** include `dev-oidc` and rejects dev mode entirely. Dev mode is for local builds only.
+  The published release container (`Containerfile.release`) is built `--no-default-features`, so it does **not** include `dev-oidc` and rejects dev mode entirely. Dev mode is for local builds only. A separate, **unpublished** evaluation image (`Containerfile.eval`, tagged `flowplane:<ver>-eval` — never `latest`) keeps `dev-oidc` on for the no-clone evaluator bundle; it is for local evaluation only and is never an operator base.
 
 ---
 

--- a/scripts/release/package-release.sh
+++ b/scripts/release/package-release.sh
@@ -12,6 +12,9 @@ ARTIFACT="flowplane-$VERSION-$HOST"
 ARTIFACT_DIR="$ROOT/$ARTIFACT"
 IMAGE_TAG=${FLOWPLANE_IMAGE_TAG:-"flowplane:$VERSION"}
 PACKAGE_IMAGE=${FLOWPLANE_PACKAGE_IMAGE:-0}
+# Evaluation image (dev-oidc on): opt-in, separately tagged, NEVER aliased to :latest (D-022).
+EVAL_IMAGE_TAG=${FLOWPLANE_EVAL_IMAGE_TAG:-"flowplane:$VERSION-eval"}
+PACKAGE_EVAL_IMAGE=${FLOWPLANE_PACKAGE_EVAL_IMAGE:-0}
 
 rm -rf "$ARTIFACT_DIR"
 mkdir -p "$ARTIFACT_DIR/bin" "$ARTIFACT_DIR/dataplane" "$ROOT"
@@ -101,6 +104,15 @@ if [ "$PACKAGE_IMAGE" = "1" ]; then
   "$ENGINE" info >/dev/null 2>&1 || { echo "$ENGINE is installed but not usable" >&2; exit 1; }
   "$ENGINE" build -f Containerfile.release -t "$IMAGE_TAG" .
   "$ENGINE" save -o "$ROOT/flowplane-$VERSION.oci.tar" "$IMAGE_TAG"
+fi
+
+# Evaluation image keeps dev-oidc (Containerfile.eval). Opt-in and tagged `:<ver>-eval` only —
+# never `:latest` — so it can never be mistaken for the hardened operator base (D-022).
+if [ "$PACKAGE_EVAL_IMAGE" = "1" ]; then
+  [ -n "$ENGINE" ] || { echo "FLOWPLANE_PACKAGE_EVAL_IMAGE=1 requires docker or podman" >&2; exit 1; }
+  "$ENGINE" info >/dev/null 2>&1 || { echo "$ENGINE is installed but not usable" >&2; exit 1; }
+  "$ENGINE" build -f Containerfile.eval -t "$EVAL_IMAGE_TAG" .
+  "$ENGINE" save -o "$ROOT/flowplane-$VERSION-eval.oci.tar" "$EVAL_IMAGE_TAG"
 fi
 
 (


### PR DESCRIPTION
## Summary

Epic #161 slice 2. The only publishable image (`Containerfile.release`) is built `--no-default-features`, so `dev-oidc` is compiled out and dev mode fails closed. The no-clone evaluator bundle (#158) needs an image that **keeps** dev mode — in-process OIDC issuer + seeded resources + the per-boot dev token file from #156.

**Two-image split (ADR D-022):**

- **`Containerfile.eval`** (new): a clone of `Containerfile.release` differing **only** by dropping `--no-default-features` on the flowplane build → default `dev-oidc` present. Same hardened runtime base (non-root `65532`, slim, ca-certificates + libssl3).
- **`Containerfile.release`** stays **byte-identical** — the hardened default is not weakened.
- **`package-release.sh`**: opt-in eval build behind `FLOWPLANE_PACKAGE_EVAL_IMAGE=1`, tagged `flowplane:<ver>-eval` only, **never `:latest`**. Default packaging path unchanged.
- **`DECISIONS.md`**: records the split as **D-022** (repo ADR scheme is `D-NNN`, not the issue's `FPV2-DEC-NNNN` — Codex concurred). One sentence added to `getting-started.md`.

## Acceptance

| Criterion | Result |
|---|---|
| Image builds | ✅ `podman build -f Containerfile.eval` |
| Smoke: eval `serve` dev mode writes token file | ✅ booted, wrote 621-char JWT, log `dev bearer token also written to file` — exercises #156 across the image boundary |
| Regression: hardened image fails closed on dev mode | ✅ `Error: ...built without the dev-oidc feature (release artifact)` |
| Tag `:<ver>-eval`, no `:latest` | ✅ |

No Rust / Cargo / schema / API change.

## Review trail

Built via the `/fix-github-issue` Codex-gated loop. Both gates **APPROVED** by Codex (independent verification — confirmed `Containerfile.release` byte-identical via `cmp`, eval block default-off, no `:latest`). Comments on #157.

> ⚠️ **HUMAN-GATE (auth):** ships the dev-oidc auth/dev-identity artifact split. Human sign-off required before merge.

Closes #157