### PR TITLE
feat(eval): docker compose evaluator bundle + init/demo path (#158)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -625,3 +625,46 @@ The mechanism left open in D-014 is now decided (founder, 2026-06-13):
   hard-to-debug failure. Failing the boot surfaces the misconfiguration immediately.
 - **Status:** decided for #156 (epic #161). HUMAN-GATE (auth/secrets) slice; recorded
   retroactively at founder request after the slice merged.
+
+## D-024: Compose evaluator bundle (`compose.eval.yml`) — design decisions
+
+- **Context:** Epic #161 slice #158 ("the heart") needs one `docker compose up` to stand up the
+  whole gateway and route a request, reproducing the host-network E2E dev-mode flow
+  (`scripts/e2e/lib.sh:192-242`) across containers. Several wiring decisions were made while
+  building and testing it (recorded as they happened, per founder instruction).
+- **Build-vs-pull (acceptance #1 "no checkout"):** `compose.eval.yml` references
+  `image: ${FLOWPLANE_EVAL_IMAGE:-flowplane:eval-local}` **with** a `build:` from
+  `Containerfile.eval`, so it works from a checkout today. The eval image is **not published until
+  #159**, so the literal "clean machine, no checkout" acceptance is an **epic-level** outcome
+  realized by #159 (GHCR publish) + #160 (docs point at the published ref via
+  `FLOWPLANE_EVAL_IMAGE=ghcr.io/<org>/flowplane:<ver>-eval`), **not** by #158 alone. The compose
+  header comment states this explicitly so nobody mistakes the local build for the final path.
+- **Loopback-only host bindings:** every published port is `127.0.0.1`-only (API `8080`, gateway
+  `10000`). xDS (`18000`) and Postgres are **not** host-exposed — Envoy and the CLI reach the
+  control plane over the compose network. Keeps the dev-identity surface off all external
+  interfaces (consistent with D-022's eval posture).
+- **Shared-volume token/bootstrap handoff + non-root permission fix:** the dev token (#156/D-023)
+  crosses containers through a named volume at `/shared/dev-token`; the init container writes the
+  rendered Envoy bootstrap to `/shared/envoy.yaml`. A named volume mounts root-owned `0755`, but
+  the eval image runs as non-root `65532` (D-022). Rather than run the control plane or init as
+  root, a single one-shot `shared-init` service does `chmod 0777 /shared` as root, so every
+  long-running container stays non-root.
+- **Service-name xDS:** the generated bootstrap's `xds_cluster` is `type: LOGICAL_DNS`
+  (`dataplanes_api.rs:665`), so `dataplane bootstrap --xds-host flowplane-eval` resolves the
+  control plane by compose-DNS name — no static IP wiring needed.
+- **CLI-binary readiness probe (no curl/wget):** the slim eval image ships only the `flowplane`
+  binary, so `flowplane-eval`'s healthcheck uses `flowplane auth whoami` (with the on-disk token)
+  — it passes only once the API is up *and* the token validates, which is exactly the signal the
+  init container needs. (Found during testing: an HTTP healthcheck would have needed a client the
+  image does not carry.)
+- **Envoy entrypoint bypass:** the bundle sets `entrypoint: ["envoy"]` to skip the
+  `envoyproxy/envoy` image's `docker-entrypoint.sh`, whose `chown /dev/stdout` fails (and kills
+  the container) under rootless container engines. (Found during testing under rootless Podman.)
+- **Idempotent init:** the one-shot `init` skips its work when `/shared/envoy.yaml` already exists,
+  so a repeated `up` (without `down -v`) does not fail on "dataplane already exists".
+- **Demo upstream + Envoy pin:** `hashicorp/http-echo` returns a deterministic 200 body for the
+  curl assertion; Envoy is pinned to `v1.37-latest`, matching the E2E suite (`lib.sh:32`).
+- **Verification:** built + run end to end under rootless Podman (`docker`→podman, docker-compose
+  v5 provider): `init` exits 0; `auth whoami` via `exec` succeeds; `curl http://127.0.0.1:10000/`
+  returns `200` with the demo body; the gateway port binds `127.0.0.1` only.
+- **Status:** decided for #158 (epic #161).

--- a/compose.eval.yml
+++ b/compose.eval.yml
@@ -1,0 +1,138 @@
+# Flowplane v2 — evaluation bundle (epic #161 / slice #158). One `docker compose up` stands up
+# Postgres + the dev-mode control plane + a demo upstream + Envoy, wires them with the flowplane
+# CLI, and routes a real request — no manual steps.
+#
+# EVALUATION ONLY. Dev mode (in-process OIDC issuer + seeded resources + a dev bearer token on
+# disk, see DECISIONS.md D-022/D-023/D-024) is never an operator/production setup. Every host
+# port is bound to 127.0.0.1.
+#
+# This file BUILDS the eval image from Containerfile.eval, so it needs the repo checkout today.
+# The true "clean machine, no checkout" path (acceptance #1) is an EPIC-LEVEL outcome completed by
+# #159 (publish the image to GHCR) + #160 (docs). Once the image is published, point this bundle at
+# it with no source tree:  FLOWPLANE_EVAL_IMAGE=ghcr.io/<org>/flowplane:<ver>-eval docker compose -f compose.eval.yml up
+#
+# Quick start:
+#   docker compose -f compose.eval.yml up -d --build
+#   curl http://127.0.0.1:10000/        # -> the demo-upstream body, routed through Envoy
+#   docker compose -f compose.eval.yml exec flowplane-eval \
+#     sh -c 'FLOWPLANE_TOKEN=$(cat /shared/dev-token) flowplane auth whoami'
+#   docker compose -f compose.eval.yml down -v
+
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: flowplane
+    # No host port: only the control plane (same compose network) needs the database.
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d flowplane"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  # One-shot: make the shared volume writable by the non-root (65532) eval image, which must create
+  # /shared/dev-token (control plane) and /shared/envoy.yaml (init). Runs as root ONLY for this
+  # chmod so every long-running container stays non-root (DECISIONS.md D-024).
+  shared-init:
+    image: ${FLOWPLANE_EVAL_IMAGE:-flowplane:eval-local}
+    build:
+      context: .
+      dockerfile: Containerfile.eval
+    user: "0:0"
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["chmod 0777 /shared"]
+    volumes:
+      - shared:/shared
+
+  flowplane-eval:
+    image: ${FLOWPLANE_EVAL_IMAGE:-flowplane:eval-local}
+    # The build here tags the image; shared-init and init reuse the same tag without rebuilding.
+    build:
+      context: .
+      dockerfile: Containerfile.eval
+    command: ["serve"]
+    environment:
+      FLOWPLANE_DATABASE_URL: postgres://postgres:postgres@postgres:5432/flowplane
+      FLOWPLANE_DEV_MODE: "true"
+      FLOWPLANE_DEV_MODE_ACK: yes-this-is-not-production
+      FLOWPLANE_API_INSECURE: "true"
+      FLOWPLANE_DEV_TOKEN_PATH: /shared/dev-token
+      FLOWPLANE_API_ADDR: 0.0.0.0:8080
+      FLOWPLANE_XDS_ADDR: 0.0.0.0:18000
+      # Dev-only constant key (32 chars). Never a real secret.
+      FLOWPLANE_SECRET_ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef
+    ports:
+      - "127.0.0.1:8080:8080"   # REST/MCP API, loopback only. xDS (18000) is NOT host-exposed —
+                                # Envoy reaches it over the compose network.
+    # The slim eval image ships only the flowplane binary (no curl/wget), so readiness is probed
+    # with the binary itself: `auth whoami` succeeds only once the API listener is up AND the dev
+    # token (written by setup_dev_mode at startup) validates — exactly the signal init needs.
+    healthcheck:
+      test: ["CMD-SHELL", "FLOWPLANE_SERVER=http://127.0.0.1:8080 FLOWPLANE_TOKEN=$(cat /shared/dev-token 2>/dev/null) flowplane auth whoami >/dev/null 2>&1"]
+      interval: 2s
+      timeout: 5s
+      retries: 60
+    depends_on:
+      postgres:
+        condition: service_healthy
+      shared-init:
+        condition: service_completed_successfully
+    volumes:
+      - shared:/shared
+
+  demo-upstream:
+    image: hashicorp/http-echo
+    command: ["-text=hello from the flowplane eval demo upstream", "-listen=:5678"]
+    # No host port: only Envoy (same compose network) routes to it.
+
+  # One-shot: read the dev token, then drive the same CLI flow the E2E harness uses
+  # (scripts/e2e/lib.sh:192-228) — create a dataplane, expose the demo upstream, and render the
+  # Envoy bootstrap to the shared volume.
+  init:
+    image: ${FLOWPLANE_EVAL_IMAGE:-flowplane:eval-local}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        if [ -s /shared/envoy.yaml ]; then echo "already initialized; nothing to do"; exit 0; fi
+        echo "waiting for dev token..."
+        for i in $$(seq 1 60); do [ -s /shared/dev-token ] && break; sleep 1; done
+        [ -s /shared/dev-token ] || { echo "dev token never appeared"; exit 1; }
+        export FLOWPLANE_SERVER=http://flowplane-eval:8080
+        export FLOWPLANE_TOKEN="$$(cat /shared/dev-token)"
+        export FLOWPLANE_ORG=dev-org
+        export FLOWPLANE_TEAM=default
+        flowplane dataplane create dp-eval --description "eval dataplane"
+        flowplane expose "http://demo-upstream:5678" --name demo --path / --port 10000 --public-base-url "http://127.0.0.1:10000"
+        flowplane --out /shared/envoy.yaml dataplane bootstrap dp-eval --mode dev --xds-host flowplane-eval --xds-port 18000 --admin-port 9901
+        echo "init complete: dataplane + expose + bootstrap done"
+    depends_on:
+      flowplane-eval:
+        condition: service_healthy
+      demo-upstream:
+        condition: service_started
+      shared-init:
+        condition: service_completed_successfully
+    volumes:
+      - shared:/shared
+
+  envoy:
+    image: envoyproxy/envoy:v1.37-latest
+    # Run the envoy binary directly, bypassing the image's docker-entrypoint.sh: under rootless
+    # container engines that wrapper's `chown /dev/stdout` fails and kills the container.
+    entrypoint: ["envoy"]
+    command: ["-c", "/shared/envoy.yaml", "--log-level", "info"]
+    ports:
+      - "127.0.0.1:10000:10000"   # the evaluator's gateway; loopback only.
+    depends_on:
+      init:
+        condition: service_completed_successfully
+    volumes:
+      - shared:/shared
+
+volumes:
+  shared: {}
+  pgdata: {}


### PR DESCRIPTION
## Summary

Epic #161 slice 3 — **the heart**. One `docker compose -f compose.eval.yml up` stands up Postgres + the dev-mode eval control plane + a demo upstream + Envoy, wires them with the `flowplane` CLI, and routes a real request through the gateway — no manual steps.

**Bundle (`compose.eval.yml`):**
- **postgres:16** — healthcheck-gated
- **shared-init** — one-shot root `chmod 0777 /shared` so the non-root (65532) eval image can write the dev token + bootstrap to the shared volume, keeping every long-running container non-root
- **flowplane-eval** — the eval image (#157) in dev mode, writing the per-boot token to `/shared/dev-token` (`FLOWPLANE_DEV_TOKEN_PATH`, #156); readiness probed with `flowplane auth whoami` since the slim image ships no curl/wget
- **demo-upstream** — `hashicorp/http-echo` with a fixed body
- **init** — one-shot: read token → `dataplane create` → `expose` the demo upstream → `dataplane bootstrap --mode dev --out /shared/envoy.yaml`, pointing Envoy at the CP by compose-DNS name (`xds_cluster` is `LOGICAL_DNS`)
- **envoy** — `v1.37-latest`, `-c /shared/envoy.yaml`; `entrypoint: [envoy]` to skip the image's chown-on-`/dev/stdout` wrapper that fails under rootless engines

All host ports bound `127.0.0.1` only. `init` is idempotent when the bootstrap already exists. Design recorded as **D-024**.

## Acceptance — verified end to end under rootless Podman

| Criterion | Result |
|---|---|
| `compose up` brings up all services + init completes | ✅ init exit 0 |
| #1: `exec flowplane-eval ... flowplane auth whoami` | ✅ prints identity |
| #2: `curl` through Envoy `:10000` → 200 + demo body | ✅ `HTTP 200` / `hello from the flowplane eval demo upstream` |
| Ports localhost-only | ✅ `10000/tcp -> 127.0.0.1:10000` |

No Rust / Cargo / Containerfile / script change — additive (`compose.eval.yml` + a D-024 record).

## Note on "no checkout"

The bundle **builds** the eval image from `Containerfile.eval`, so it needs the checkout today. The literal "clean machine, no checkout" acceptance is an **epic-level** outcome completed by **#159** (publish to GHCR) + **#160** (docs) — point the bundle at the published ref via `FLOWPLANE_EVAL_IMAGE=ghcr.io/<org>/flowplane:<ver>-eval`. Stated in the compose header and D-024.

## Review trail

Built via the `/fix-github-issue` Codex-gated loop. Both gates **APPROVED** — GATE 2 independently ran `docker-compose config` (loopback ports confirmed) + `cargo test -p flowplane` (32 passed) and accepted the live Podman run. Comments on #158.

Closes #158