### PR TITLE
docs: update repo-name references after flowplane-v2 → flowplane rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,4 +83,4 @@ xDS/SDS is the config channel, and all product mutations flow through `fp-core` 
 - Certified at Tier 0 for S1–S10 with the live suite green across 5 consecutive runs and
   zero open critical/major defects.
 
-[1.0.0]: https://github.com/rajeevramani/flowplane-v2/releases/tag/v1.0.0
+[1.0.0]: https://github.com/rajeevramani/flowplane/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flowplane
 
-[![CI](https://github.com/rajeevramani/flowplane-v2/actions/workflows/ci.yml/badge.svg)](https://github.com/rajeevramani/flowplane-v2/actions/workflows/ci.yml)
+[![CI](https://github.com/rajeevramani/flowplane/actions/workflows/ci.yml/badge.svg)](https://github.com/rajeevramani/flowplane/actions/workflows/ci.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.94.1-orange.svg)](https://www.rust-lang.org/)
 

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -2,7 +2,7 @@
 
 # HTTP Filter Catalogue
 
-Reference for the closed set of HTTP filters flowplane-v2 accepts in a listener filter chain, the per-scope overrides each supports, the Envoy filter URI each maps to, and the filters Flowplane injects automatically.
+Reference for the closed set of HTTP filters Flowplane accepts in a listener filter chain, the per-scope overrides each supports, the Envoy filter URI each maps to, and the filters Flowplane injects automatically.
 
 ## Filter chain model
 


### PR DESCRIPTION
## Summary

The repo was renamed `flowplane-v2` → `flowplane`. This updates the stale repo-name references in user-facing docs. GitHub redirects keep the old URLs working, but they should point at the canonical name.

- **README** CI badge → `github.com/rajeevramani/flowplane`
- **CHANGELOG** 1.0.0 release link → `github.com/rajeevramani/flowplane`
- **docs/reference/filters.md** prose `flowplane-v2` → `Flowplane`

## Left unchanged (intentional)

- Internal identifiers — `FPV2` ADR prefix, `fpv2` bead prefix, `mempalace_wing` — are stable IDs; renaming would orphan existing beads/ADRs.
- Historical refs — the `docs/flowplane-v2` branch name in the review log, and the `FPV2-DEC` ADR-naming note in DECISIONS.md.
- `.aidf.yml` vault path was also corrected (`../flowplane-private-vault`) but that file is gitignored (local-only per-project config), so it's not part of this PR.

Docs-only; no code change.