### PR TITLE
ci(release): multi-arch GHCR publish workflow + no-clone docs (#161, #160)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,254 @@
+name: Release
+
+# Publishes multi-arch (linux/amd64 + linux/arm64) GHCR images for the hardened
+# (`flowplane:<ver>`) and evaluation (`flowplane:<ver>-eval`) images. Each architecture is built
+# NATIVELY on a free public-repo hosted runner — amd64 on `ubuntu-latest`, arm64 on
+# `ubuntu-24.04-arm` — then the per-arch digests are joined into one manifest list with
+# `docker buildx imagetools create`. No QEMU, no self-hosted runner (DECISIONS.md D-025).
+#
+# The eval image is NEVER tagged `:latest` (D-022). The first public push is a HUMAN-GATE:
+# the build/manifest jobs run in the `release` GitHub Environment, so a human reviewer (configured
+# in repo Settings → Environments → release) must approve before anything reaches GHCR.
+#
+# Both run paths build from the immutable `v<version>` tag commit:
+#   - tag push  (`v1.2.3`)            → version from the ref
+#   - workflow_dispatch(version=1.2.3) → version from the validated input; the `v1.2.3` tag must exist
+# so the published image, its OCI source label, and the `v<ver>/compose.eval.yml` the docs fetch all
+# come from the same tagged commit.
+
+on:
+  push:
+    tags: ['v*.*.*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version to publish (semver X.Y.Z, no leading v). A matching v<version> tag must already exist.'
+        required: true
+        type: string
+
+# Least-privilege default; jobs widen only what they need.
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  resolve-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      image: ${{ steps.v.outputs.image }}
+    steps:
+      - name: Resolve and validate version
+        id: v
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="${REF_NAME#v}"
+          fi
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::resolved version '$VERSION' is not semver X.Y.Z"; exit 1
+          fi
+          OWNER_LC="$(printf '%s' "$OWNER" | tr '[:upper:]' '[:lower:]')"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "image=${REGISTRY}/${OWNER_LC}/flowplane" >> "$GITHUB_OUTPUT"
+          echo "Resolved version=$VERSION image=${REGISTRY}/${OWNER_LC}/flowplane"
+
+      - name: Verify the v<version> tag exists (fail loudly if missing)
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/v${{ steps.v.outputs.version }}
+          fetch-depth: 0
+
+  build:
+    needs: resolve-version
+    # HUMAN-GATE: first public artifact push. Requires an approver on the `release` environment.
+    environment: release
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout the tagged commit
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/v${{ needs.resolve-version.outputs.version }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # --- Pre-push gates (native, on the just-built single-arch image, loaded locally) ---
+
+      - name: Build eval image (load) for the image-only compose smoke
+        run: |
+          docker buildx build --platform ${{ matrix.platform }} \
+            -f Containerfile.eval -t flowplane:eval-smoke --load .
+
+      - name: Image-only evaluator smoke (no --build; uses the built eval image)
+        run: |
+          set -euo pipefail
+          export FLOWPLANE_EVAL_IMAGE=flowplane:eval-smoke
+          docker compose -f compose.eval.yml up -d --no-build
+          ok=
+          for _ in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:10000/ | grep -q "hello from the flowplane eval demo upstream"; then
+              ok=1; break
+            fi
+            sleep 2
+          done
+          docker compose -f compose.eval.yml logs --no-color > compose-smoke.log 2>&1 || true
+          docker compose -f compose.eval.yml down -v
+          [ -n "$ok" ] || { echo "::error::eval image smoke did not return the demo body"; exit 1; }
+
+      - name: Build hardened image (load) for the sanity gate
+        run: |
+          docker buildx build --platform ${{ matrix.platform }} \
+            -f Containerfile.release -t flowplane:hardened-smoke --load .
+
+      - name: Hardened image sanity (binary runs in the slim image)
+        run: |
+          docker run --rm --entrypoint /usr/local/bin/flowplane flowplane:hardened-smoke --help >/dev/null
+
+      # --- Push each image by digest (cached layers from the load builds above) ---
+
+      - name: Push eval image by digest
+        id: eval
+        env:
+          IMAGE: ${{ needs.resolve-version.outputs.image }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker buildx build --platform ${{ matrix.platform }} \
+            -f Containerfile.eval \
+            --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
+            --label "org.opencontainers.image.version=${VERSION}" \
+            --label "org.opencontainers.image.revision=${{ github.sha }}" \
+            --output "type=image,name=${IMAGE},push-by-digest=true,name-canonical=true,push=true" \
+            --metadata-file eval-meta.json .
+          echo "digest=$(jq -r '."containerimage.digest"' eval-meta.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Push hardened image by digest
+        id: hardened
+        env:
+          IMAGE: ${{ needs.resolve-version.outputs.image }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker buildx build --platform ${{ matrix.platform }} \
+            -f Containerfile.release \
+            --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
+            --label "org.opencontainers.image.version=${VERSION}" \
+            --label "org.opencontainers.image.revision=${{ github.sha }}" \
+            --output "type=image,name=${IMAGE},push-by-digest=true,name-canonical=true,push=true" \
+            --metadata-file hardened-meta.json .
+          echo "digest=$(jq -r '."containerimage.digest"' hardened-meta.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Record per-arch digests
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          echo "${{ steps.eval.outputs.digest }}"     > "${{ runner.temp }}/digests/eval-${{ matrix.arch }}"
+          echo "${{ steps.hardened.outputs.digest }}" > "${{ runner.temp }}/digests/hardened-${{ matrix.arch }}"
+
+      - name: Upload digests
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+
+  manifest:
+    needs: [resolve-version, build]
+    environment: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout the tagged commit
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/v${{ needs.resolve-version.outputs.version }}
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download per-arch digests
+        uses: actions/download-artifact@v4
+        with:
+          path: digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Create + verify multi-arch manifest lists
+        env:
+          IMAGE: ${{ needs.resolve-version.outputs.image }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Hardened: flowplane:<ver>  (no :latest in this MVP)
+          docker buildx imagetools create -t "${IMAGE}:${VERSION}" \
+            "${IMAGE}@$(cat digests/hardened-amd64)" \
+            "${IMAGE}@$(cat digests/hardened-arm64)"
+          # Eval: flowplane:<ver>-eval  (NEVER :latest — D-022)
+          docker buildx imagetools create -t "${IMAGE}:${VERSION}-eval" \
+            "${IMAGE}@$(cat digests/eval-amd64)" \
+            "${IMAGE}@$(cat digests/eval-arm64)"
+          docker buildx imagetools inspect "${IMAGE}:${VERSION}"
+          docker buildx imagetools inspect "${IMAGE}:${VERSION}-eval"
+
+  verify-publish:
+    needs: [resolve-version, manifest]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # attach compose.eval.yml as a release asset
+      packages: read
+    steps:
+      - name: Checkout the tagged commit
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/v${{ needs.resolve-version.outputs.version }}
+      - name: Assert both tags are multi-arch (amd64 + arm64)
+        env:
+          IMAGE: ${{ needs.resolve-version.outputs.image }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          for ref in "${IMAGE}:${VERSION}" "${IMAGE}:${VERSION}-eval"; do
+            echo "== $ref =="
+            out="$(docker buildx imagetools inspect "$ref")"
+            echo "$out"
+            echo "$out" | grep -q "linux/amd64" || { echo "::error::$ref missing linux/amd64"; exit 1; }
+            echo "$out" | grep -q "linux/arm64" || { echo "::error::$ref missing linux/arm64"; exit 1; }
+          done
+      - name: Attach compose.eval.yml as a release asset (stable no-clone download URL)
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.resolve-version.outputs.version }}
+          files: compose.eval.yml
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -10,9 +10,45 @@ Publish your APIs through a multi-tenant control plane and get governance (OIDC 
 
 > A ground-up Rust/PostgreSQL rebuild. PostgreSQL is the source of truth, Envoy is the only data plane, xDS/SDS is the config channel, and every product mutation goes through `fp-core` services.
 
-## Quick Start
+## Quick Start (no clone, no Rust toolchain)
 
-This is the short version of the [Getting Started tutorial](docs/tutorials/getting-started.md) — start the control plane in **dev mode**, expose one upstream, connect a local Envoy, and `curl` through the gateway.
+Evaluate Flowplane on a clean machine with only a container engine (Docker or Podman). This pulls the
+published **evaluation** image and stands up the whole stack — Postgres, the dev-mode control plane, a
+demo upstream, and Envoy — then routes a real request through the gateway. No repo checkout, no
+`cargo build`.
+
+> Set `VER` to the release you want (e.g. `1.0.0`). The image is **multi-arch**: a plain `docker pull`
+> resolves the native `linux/amd64` or `linux/arm64` variant — no `--platform` flag, no emulation.
+
+```bash
+VER=1.0.0
+
+# 1. Fetch the evaluator bundle at the matching release tag (the only file you need)
+curl -fsSLO https://raw.githubusercontent.com/rajeevramani/flowplane/v${VER}/compose.eval.yml
+
+# 2. Bring up the whole stack against the published eval image (no --build)
+FLOWPLANE_EVAL_IMAGE=ghcr.io/rajeevramani/flowplane:${VER}-eval \
+  docker compose -f compose.eval.yml up -d --no-build
+
+# 3. A request flows through Envoy (:10000) to the demo upstream
+curl http://127.0.0.1:10000/        # -> hello from the flowplane eval demo upstream
+
+# 4. (optional) confirm authentication from inside the control-plane container
+docker compose -f compose.eval.yml exec flowplane-eval \
+  sh -c 'FLOWPLANE_TOKEN=$(cat /shared/dev-token) flowplane auth whoami'
+
+# Tear down
+docker compose -f compose.eval.yml down -v
+```
+
+> The `:${VER}-eval` image is **for evaluation only** — it runs dev mode (in-process OIDC issuer +
+> seeded resources + a dev bearer token on disk) and binds every port to `127.0.0.1`. It is **never**
+> an operator/production base and is never tagged `:latest`. The hardened, publishable image is
+> `ghcr.io/rajeevramani/flowplane:${VER}` (built `--no-default-features`, which refuses dev mode).
+
+## Build from source (contributors)
+
+Working on Flowplane itself? Build the binary and run the control plane directly.
 
 > **Toolchain:** build through [rustup](https://rustup.rs) so the `rust-toolchain.toml` pin (1.94.1) is applied automatically. A distro-packaged `cargo` may be too old to read this repo's version-4 `Cargo.lock`.
 >

--- a/compose.eval.yml
+++ b/compose.eval.yml
@@ -6,17 +6,18 @@
 # disk, see DECISIONS.md D-022/D-023/D-024) is never an operator/production setup. Every host
 # port is bound to 127.0.0.1.
 #
-# This file BUILDS the eval image from Containerfile.eval, so it needs the repo checkout today.
-# The true "clean machine, no checkout" path (acceptance #1) is an EPIC-LEVEL outcome completed by
-# #159 (publish the image to GHCR) + #160 (docs). Once the image is published, point this bundle at
-# it with no source tree:  FLOWPLANE_EVAL_IMAGE=ghcr.io/<org>/flowplane:<ver>-eval docker compose -f compose.eval.yml up
-#
-# Quick start:
-#   docker compose -f compose.eval.yml up -d --build
+# No-clone path (published image — the canonical evaluator quick start): fetch this file at the
+# release tag, then point the bundle at the published multi-arch GHCR image (no source tree, no
+# `--build`). A plain `docker pull` resolves the right arch (amd64/arm64 are both native, D-025):
+#   curl -fsSLO https://raw.githubusercontent.com/<org>/flowplane/v<ver>/compose.eval.yml
+#   FLOWPLANE_EVAL_IMAGE=ghcr.io/<org>/flowplane:<ver>-eval docker compose -f compose.eval.yml up -d --no-build
 #   curl http://127.0.0.1:10000/        # -> the demo-upstream body, routed through Envoy
 #   docker compose -f compose.eval.yml exec flowplane-eval \
 #     sh -c 'FLOWPLANE_TOKEN=$(cat /shared/dev-token) flowplane auth whoami'
 #   docker compose -f compose.eval.yml down -v
+#
+# From-source path (contributors, repo checkout): build the eval image from Containerfile.eval:
+#   docker compose -f compose.eval.yml up -d --build
 
 services:
   postgres:
@@ -84,7 +85,7 @@ services:
       - shared:/shared
 
   demo-upstream:
-    image: hashicorp/http-echo
+    image: hashicorp/http-echo:1.0.0
     command: ["-text=hello from the flowplane eval demo upstream", "-listen=:5678"]
     # No host port: only Envoy (same compose network) routes to it.
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -8,6 +8,12 @@ Follow the steps in order. Every command here is copy-pasteable.
 
 Dev mode runs an in-process identity issuer, seeds local resources, and serves the API and xDS over plaintext. It is for local exploration only — never production.
 
+> **Just want to try Flowplane?** You don't need this tutorial. The fastest path uses the published
+> evaluation image and a single `docker compose` file — no clone, no Rust toolchain — and routes a
+> real request in four commands. See **[Quick Start (no clone)](../../README.md#quick-start-no-clone-no-rust-toolchain)**.
+> This tutorial is the **from-source / contributor** path: build the binary yourself and drive the
+> control plane directly, which is what you want when hacking on Flowplane itself.
+
 ---
 
 ## 1. Prerequisites
@@ -25,7 +31,7 @@ You need:
 
   Dev mode requires a binary built **with the `dev-oidc` feature**. That feature is on by default, so a plain `cargo build --bin flowplane` (or `cargo run`) includes it — both debug and local release builds (`cargo build --release`) are fine. The commands below use `./target/debug/flowplane`.
 
-  The published release container (`Containerfile.release`) is built `--no-default-features`, so it does **not** include `dev-oidc` and rejects dev mode entirely. Dev mode is for local builds only. A separate, **unpublished** evaluation image (`Containerfile.eval`, tagged `flowplane:<ver>-eval` — never `latest`) keeps `dev-oidc` on for the no-clone evaluator bundle; it is for local evaluation only and is never an operator base.
+  The published release container (`Containerfile.release`) is built `--no-default-features`, so it does **not** include `dev-oidc` and rejects dev mode entirely. Dev mode is for local builds only. A separate evaluation image (`Containerfile.eval`, published to GHCR as `ghcr.io/rajeevramani/flowplane:<ver>-eval` — never `latest`) keeps `dev-oidc` on for the no-clone evaluator bundle; it is for local evaluation only and is never an operator base.
 
 ---
 

--- a/internal/PROGRESS.md
+++ b/internal/PROGRESS.md
@@ -570,6 +570,11 @@ Resumable state for the rewrite. On session start: read this file, continue the 
         requires explicit release approval. Q-006 is resolved (Apache-2.0); public distribution is
         no longer license-gated.
 
+- [ ] S13 Global rate-limit service — Flowplane ships only the Envoy RLS *client*
+      (`global_rate_limit` filter → `service_cluster`); no rate-limit service exists yet. Build a
+      first-party RLS gRPC service so global rate limiting works out of the box (no user-supplied
+      external limiter).
+
 ## Known Corrections / Open Risks
 
 Cold-start handoff safety: items surfaced by review that the checklist above must not paper over. "RESOLVED" items were fixed in the same review pass (with tests); "OPEN" items are real and scheduled — read these before trusting a green checkbox.


### PR DESCRIPTION
Implements epic #161's remaining work: the GHCR publish workflow (#159's unbuilt deliverable, design **D-025**) and the **#160** no-clone docs.

## `release.yml` — multi-arch GHCR publish
- **amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`** (free public-repo hosted runners), each built **natively**; per-arch images push by digest and join into a manifest list via `docker buildx imagetools create`. **No QEMU, no self-hosted runner** (D-025).
- Publishes hardened `flowplane:<ver>` + eval `flowplane:<ver>-eval`. Eval is **never `:latest`** (D-022).
- First public push is **HUMAN-GATEd** via the `release` GitHub Environment.
- Both triggers (tag push, `workflow_dispatch`) build from the immutable `v<version>` tag commit; dispatch validates semver and **fails if the tag is missing**, so the image, its OCI source label, and the docs' versioned `compose.eval.yml` all come from one commit.
- Gates: image-only eval compose smoke + hardened binary sanity (pre-push); manifest multi-arch assertion (post-publish); `compose.eval.yml` attached as a release asset.

## Docs (#160)
- **README Quick Start now leads with the no-clone path** (fetch the versioned `compose.eval.yml` → run the published eval image); `cargo build` moved to a "Build from source (contributors)" section.
- `getting-started.md` points newcomers at the no-clone quick start; framed as the from-source contributor path.
- `compose.eval.yml`: pinned `hashicorp/http-echo:1.0.0` (pinned smoke deps); header rewritten to the no-clone invocation.

## Review trail (`/fix-github-issue`)
- Codex **GATE 1 (design)** → APPROVED (3 revs: pin http-echo, no-clone file fetch, dispatch tag-ref binding)
- Codex **GATE 2 (diff)** → APPROVED (2 revs: manifest job tag checkout)
- Local: `actionlint` 0, docs-boundary self-test + full pass, YAML parse — all green.

## ⚠️ Manual prerequisites before first publish (repo settings, not code)
1. Configure **Settings → Environments → `release`** with a required reviewer (the HUMAN-GATE).
2. Set the GHCR package **public** on first publish.

Also carries the S13 (global RLS service) `PROGRESS.md` entry.

Closes #160. Refs #161 (epic stays open for the first human-gated publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)