### PR TITLE
chore(ci): adopt cargo-nextest as the test runner

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,24 @@
+# cargo-nextest configuration. See https://nexte.st/docs/configuration/
+#
+# The default profile is used for local `cargo nextest run`. The `ci` profile is
+# selected in CI with `--profile ci` (see .github/workflows/ci.yml).
+#
+# Concurrency note: the integration tests share one PostgreSQL database
+# (FLOWPLANE_TEST_DATABASE_URL) and each opens a small per-test pool (mostly 4–8,
+# one 16). nextest schedules every test across all binaries in one global pool, so
+# `test-threads` caps how many test pools can be live at once and keeps the total
+# well under the server's `max_connections` (stock 100). A local 12-thread run of
+# the full suite was clean; 8 is a pragmatic guard that keeps most of the speedup
+# while leaving headroom for larger runners.
+
+[profile.ci]
+# Run the whole suite for complete diagnostics rather than stopping at the first failure.
+fail-fast = false
+# Flakes should surface as real bugs, not be retried away.
+retries = 0
+# Cap global concurrency to bound concurrent DB pools (see note above).
+test-threads = 8
+# A test that runs too long is killed (SIGTERM, then SIGKILL after the grace period).
+slow-timeout = { period = "120s", terminate-after = 2, grace-period = "10s" }
+# Fail a test that leaks a child process holding a port/handle past this window.
+leak-timeout = { period = "500ms", result = "fail" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,14 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Clippy (release artifact shape, no dev-oidc)
         run: cargo clippy -p flowplane --no-default-features --all-targets -- -D warnings
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9
       - name: Tests (unit + integration against local PostgreSQL)
-        run: cargo test --workspace --all-features
+        run: cargo nextest run --workspace --all-features --profile ci
+      - name: Doc tests (nextest does not run these)
+        run: cargo test --workspace --all-features --doc
       - name: Boot smoke (fresh DB, plaintext opt-in, health + request-id checks)
         env:
           FLOWPLANE_DATABASE_URL: postgres://postgres:postgres@localhost:5432/flowplane_test

--- a/README.md
+++ b/README.md
@@ -170,11 +170,18 @@ Run tests for the main binary:
 cargo test -p flowplane
 ```
 
-Run the full workspace suite with PostgreSQL-backed tests enabled:
+Run the full workspace suite with PostgreSQL-backed tests enabled. CI uses
+[`cargo nextest`](https://nexte.st) (faster; the same suite); install it with
+`cargo install cargo-nextest --locked` or `cargo binstall cargo-nextest`:
 
 ```bash
-FLOWPLANE_TEST_DATABASE_URL=postgres://postgres:postgres@localhost:5432/flowplane_dev \
-  cargo test --workspace --all-features
+export FLOWPLANE_TEST_DATABASE_URL=postgres://postgres:postgres@localhost:5432/flowplane_dev
+
+cargo nextest run --workspace --all-features   # what CI runs (via the `ci` profile)
+cargo test --workspace --all-features --doc    # doctests — nextest does not run these
+
+# plain cargo test still works and additionally runs doctests inline:
+cargo test --workspace --all-features
 ```
 
 Print the generated REST contract:


### PR DESCRIPTION
Switch CI to [`cargo nextest`](https://nexte.st) for faster test runs. Analysis + a local spike were reviewed and approved by an independent Codex (gpt-5.5) pass.

## Why
`cargo test` runs each test binary serially (threads parallelize only within a binary). nextest schedules all tests across all binaries in one global pool. Local full-suite spike (12-core, real Postgres):

| runner | result | wall |
|---|---|---|
| `cargo test --workspace --all-features` | 347 passed | ~43s |
| `cargo nextest run` (default) | 347 passed | ~19s |
| `cargo nextest run --profile ci` (this PR) | 347 passed | ~22s |

## Changes
- **`.config/nextest.toml`** — `ci` profile: `test-threads = 8` (guard), `fail-fast = false` (full diagnostics), `retries = 0` (flakes surface as bugs), slow/leak timeouts.
- **`.github/workflows/ci.yml`** — install nextest (`taiki-e/install-action@v2`), run `cargo nextest run --workspace --all-features --profile ci`, plus a separate `cargo test --doc` step (nextest doesn't run doctests; the workspace has none today — kept as insurance).
- **`README.md`** — test instructions.

## Safety
The integration tests share one Postgres (`FLOWPLANE_TEST_DATABASE_URL`) with small per-test pools (mostly 4–8, one 16). Risk was connection exhaustion under nextest's higher concurrency; the spike saw **zero** connection-pool errors even unguarded at 12 threads (pools don't pre-open their full max), and the `test-threads = 8` cap leaves headroom under the stock `max_connections = 100`. GitHub runners (~4 vCPU) sit below that anyway.

No production code changes.