### PR TITLE
docs: create a tenant org before a team in prod/separated onboarding (#172)

### DIFF
--- a/docs/how-to/aws-secure-deployment.md
+++ b/docs/how-to/aws-secure-deployment.md
@@ -119,6 +119,11 @@ flowplane auth whoami
 
 ## Local Dataplane Smoke
 
+A dataplane is registered under a team, so a **tenant org and team must already exist**
+(the platform org cannot host one). If you have only bootstrapped the platform admin,
+first [create a tenant org and a team](create-tenant-org-and-team.md), then use that
+org+team below.
+
 Create the dataplane and issue a one-time cert response:
 
 ```bash

--- a/docs/how-to/bootstrap-platform.md
+++ b/docs/how-to/bootstrap-platform.md
@@ -65,6 +65,10 @@ A success response returns the new `org_id` and `admin_user_id`. The token is no
 - Re-running the same `POST /api/v1/bootstrap/initialize` returns a conflict — the instance is initialized.
 - Your admin can now authenticate through your OIDC issuer and reach authenticated endpoints.
 
+## Next step
+
+Bootstrap creates only the **platform org** (governance only — it cannot host tenant teams or dataplanes). To stand up actual gateway config, create a **tenant org and a team**: [create a tenant org and a team](create-tenant-org-and-team.md).
+
 ## Troubleshooting
 
 - **Server won't start, "no bootstrap token was supplied":** the instance is uninitialized and you set neither `FLOWPLANE_BOOTSTRAP_TOKEN` nor `FLOWPLANE_BOOTSTRAP_TOKEN_FILE`. Set one and restart.

--- a/docs/how-to/create-tenant-org-and-team.md
+++ b/docs/how-to/create-tenant-org-and-team.md
@@ -1,0 +1,99 @@
+# How-to: create a tenant org and a team
+
+> Audience: operators · Status: stable
+
+A freshly bootstrapped control plane has exactly one organization — the **platform
+org** — and one platform admin. The platform org is for **governance only**: it
+**cannot host tenant teams, dataplanes, or gateway config**. Before you can register
+a dataplane or define any gateway resource, you create a **tenant org** and a **team**
+inside it.
+
+This page takes you from "platform admin, nothing else" to "a team you can create
+dataplanes under." Every value you need is here.
+
+## Prerequisites
+
+- The control plane is initialized and you are logged in as the **platform admin**
+  (see [bootstrap the first platform admin](bootstrap-platform.md)). Confirm with:
+
+  ```bash
+  flowplane auth whoami      # platform_admin: true
+  ```
+
+- Your CLI points at the control plane (`--server` / `FLOWPLANE_SERVER` / a saved
+  context — see [CLI auth and contexts](cli-auth-and-contexts.md)).
+
+## 1. Create the tenant org
+
+Only a platform admin can create an organization. `name` is the immutable handle;
+`--display-name` is an optional label.
+
+```bash
+flowplane org create edgeco --display-name "EdgeCo"
+```
+
+This calls `POST /api/v1/orgs`. Creating the org does **not** make you a member of it
+— org membership is a separate, explicit step.
+
+## 2. Add the org's first owner
+
+A tenant org needs an **owner** before anyone can administer it. A platform admin may
+add the **first** member of an org (and only while the org still has no owner); after
+that, the org's own owners/admins manage membership.
+
+Identify the user by their immutable OIDC subject (preferred), or by email:
+
+```bash
+flowplane org member add edgeco --role owner --subject "auth0|6650f0..."
+# or:  flowplane org member add edgeco --role owner --email you@example.com
+```
+
+This calls `POST /api/v1/orgs/{org}/members`. Pass exactly one of `--subject`,
+`--email`, or `--user-id`.
+
+> **Running everything yourself locally?** Add **your own** subject as the owner. You
+> are then both the platform admin *and* the owner of `edgeco`; the team step below
+> authorizes through your `edgeco` org membership, not your platform role — the
+> platform role never grants tenant access.
+
+## 3. Create a team in the tenant org
+
+Teams own gateway resources. Create one while **selecting the tenant org** with the
+global `--org` flag (it is sent as the `X-Flowplane-Org` request context):
+
+```bash
+flowplane team create payments --org edgeco --display-name "Payments"
+```
+
+This calls `POST /api/v1/teams` in the `edgeco` org context. `--org` is a **global**
+flag — it selects the active org for the request; there is no per-command `--org` on
+`team create`.
+
+## 4. Verify
+
+```bash
+flowplane team list --org edgeco        # payments is listed
+```
+
+You can now create dataplanes and gateway config under `edgeco` / `payments` — for
+example [register a dataplane and connect its agent over mTLS](register-dataplane-mtls.md).
+
+## Why `--org platform` is rejected
+
+If you try to host a team in the platform org — `--org platform`, or no org selector
+when you only belong to the platform org — the request fails closed:
+
+```text
+HTTP 400  org_selector_required
+```
+
+This is intentional ([D-014](../../DECISIONS.md)). The platform org is **never** a
+selectable tenant context, and the platform admin role is governance-only — it cannot
+see inside or host tenant resources. The same error appears when you belong to several
+tenant orgs and send no selector; the fix is the same: name the tenant org with
+`--org <org>` (or set an active context).
+
+## Next step
+
+- [Register a dataplane and connect its agent over mTLS](register-dataplane-mtls.md)
+  — create a dataplane under the `edgeco` / `payments` org+team you just made.

--- a/docs/how-to/register-dataplane-mtls.md
+++ b/docs/how-to/register-dataplane-mtls.md
@@ -10,6 +10,8 @@ It assumes the control plane is already running with xDS mTLS configured. The xD
 
 The control plane is up with the xDS mTLS triad set (`FLOWPLANE_XDS_TLS_CERT` / `_KEY` / `_CLIENT_CA`), and — for the `issue` step below — the cert-issuer triad `FLOWPLANE_CERT_ISSUER_CA_CERT_PATH` and `FLOWPLANE_CERT_ISSUER_CA_KEY_PATH` (optionally `FLOWPLANE_CERT_ISSUER_TRUST_DOMAIN`, default `flowplane.local`) is set **on the control-plane process**. See the [configuration reference](../reference/configuration.md).
 
+A **tenant org and a team must already exist** — a dataplane is registered under a team (`--team payments` below), and the platform org cannot host one. If you have only just bootstrapped the platform admin, first [create a tenant org and a team](create-tenant-org-and-team.md). Note that selecting the platform org for a tenant operation (`--org platform`) is rejected with `org_selector_required` (D-014): use your tenant org.
+
 ## 1. Register the dataplane
 
 A dataplane is a named record under a team. The only required field is the name; `description` is optional.

--- a/internal/auth0-local-runbook.md
+++ b/internal/auth0-local-runbook.md
@@ -137,7 +137,7 @@ flowplane auth whoami
 
 - `auth login` completes (device approved) and stores the token.
 - `whoami` returns your identity — the Auth0 ID token validated against the CP, and because `admin_subject` matched your `sub`, you are the platform admin.
-- A governance call works, e.g. `flowplane org list` / `flowplane team create <name> --org platform`.
+- A platform-admin governance call works, e.g. `flowplane org list` or `flowplane org create <tenant>`. (Do **not** use `team create … --org platform` as a smoke check — teams cannot be hosted in the platform org, so it fails closed with `org_selector_required`. To stand up a team, [create a tenant org and a team](../docs/how-to/create-tenant-org-and-team.md).)
 
 ## Troubleshooting
 

--- a/internal/prod-local-runbook.md
+++ b/internal/prod-local-runbook.md
@@ -245,6 +245,34 @@ Pass signals:
 - `auth whoami` returns your user and `platform_admin: true`.
 - `org list` succeeds.
 
+## Step F - Create a tenant org and team
+
+Bootstrap created only the **platform org**, which is governance-only and **cannot
+host tenant teams or dataplanes**. To stand up gateway config you create a tenant org
+and a team inside it. See [create a tenant org and a team](../docs/how-to/create-tenant-org-and-team.md)
+for the full reference; the local single-human flow is:
+
+```bash
+# 1. Platform admin creates the tenant org.
+./target/release/flowplane org create edgeco --display-name "EdgeCo"
+
+# 2. Platform admin seeds the org's first owner — add YOUR OWN subject so the same
+#    human is both platform admin and edgeco owner (only the first owner can be added
+#    this way, while the org has no owner yet). Use the same OIDC sub you bootstrapped.
+./target/release/flowplane org member add edgeco --role owner --subject "auth0|6650f0..."
+
+# 3. Create a team, selecting the tenant org with the global --org flag.
+./target/release/flowplane team create payments --org edgeco --display-name "Payments"
+
+# Verify.
+./target/release/flowplane team list --org edgeco        # payments is listed
+```
+
+`--org` is a **global** selector (sent as `X-Flowplane-Org`); there is no per-command
+`--org` on `team create`. Selecting the platform org (`--org platform`) for a tenant
+operation is rejected with `org_selector_required` — the platform org is never a
+tenant context. You can now create dataplanes under `edgeco` / `payments`.
+
 ## Optional - API TLS instead of local plaintext
 
 If you want to test the HTTPS API listener locally:
@@ -293,7 +321,7 @@ Use this only when you are testing Envoy or `fp-agent`. For API/auth/governance 
 | `invalid issuer` | exact `iss` mismatch | copy the issuer from the token/discovery document, including trailing slash if present |
 | `invalid audience` | token `aud` does not match server audience | set `FLOWPLANE_OIDC_AUDIENCE` to the audience in the token the CLI sends |
 | login succeeds but `org list` is denied | bootstrap admin subject does not match token `sub` | reinitialize a fresh DB or add the correct user through an existing platform admin |
-| tenant commands fail with `org_selector_required` | user belongs to multiple non-platform orgs | pass `--org <org>` or configure an active CLI context |
+| tenant commands fail with `org_selector_required` | the active org resolved to the platform org or none — you have no tenant org yet, selected `--org platform`, or belong to multiple non-platform orgs | create a tenant org + membership first (Step F), then pass `--org <tenant-org>` or configure an active CLI context. The platform org is never a tenant context. |
 | xDS does not listen in prod mode | xDS mTLS vars are absent | set all three `FLOWPLANE_XDS_TLS_CERT`, `FLOWPLANE_XDS_TLS_KEY`, `FLOWPLANE_XDS_TLS_CLIENT_CA` |
 
 ## Clean reset


### PR DESCRIPTION
Fixes #172.

Docs-only fix (vault release 1.0.1). Prod/separated CP-DP onboarding docs jumped to `team create` without first creating a tenant org, so a fresh-bootstrap reader hit a fail-closed `org_selector_required`, and the naive `--org platform` workaround is denied (D-014: the platform org is never a selectable tenant context).

## What changed (3 slices)

- **S1 `1cfc308`** — NEW canonical `docs/how-to/create-tenant-org-and-team.md`: the tenant-org → first-owner → team sequence, the own-subject single-human variant, and why `--org platform` is rejected. Standalone, Audience/Status banner.
- **S2 `41a3abb`** — public link-ins: `bootstrap-platform.md` Next-step pointer; `register-dataplane-mtls.md` + `aws-secure-deployment.md` state the tenant-org+team prerequisite and link the canonical page (`register-dataplane-mtls` also notes `--org platform` is rejected). Public→public links only.
- **S3 `b37eb4d`** — internal runbook fixes: `prod-local-runbook.md` Step F + corrected `org_selector_required` troubleshooting row; `auth0-local-runbook.md` replaces the wrong `team create … --org platform` smoke check (which fails closed) with a real platform-admin governance call.

## Verification

- `scripts/ci/check-docs-boundary.py` → `docs boundary OK` (exit 0).
- Independent author audited every command/flag/endpoint/error on the new page against the real CLI+API → all confirmed, no discrepancies.
- `git diff` touches only `docs/**` + `internal/**` — no code/schema/API/authz change.

## HUMAN-GATE — required before merge

The two security-model slices (S1, S3) need a live fresh-CP smoke before merge: run `org create` → `org member add --role owner --subject …` → `team create payments --org edgeco` and confirm no `org_selector_required`, plus the replaced auth0 governance check. The agent could not run a live CP.

## Follow-up (not in this PR)

`docs/reference/errors.md:38` has older generic `org_selector_required` wording — outside the approved 6-file scope; tracked as a separate docs follow-up.

aidf: `fpv2-o53` · design `releases/1.0.1/features/2026-06-tenant-org-onboarding-docs/10-design.md` (Codex-approved).
