### PR TITLE
ci: fix docs-only skip (paths-filter predicate-quantifier: every)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          # 'every': a changed file counts as `code` only if it matches ALL patterns
+          # — i.e. it is some path AND is not Markdown / docs/** / internal/**. Without
+          # this, paths-filter ORs the patterns and '**' alone matches every file, so
+          # docs-only changes still flagged code=true (the bug this fixes).
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'


### PR DESCRIPTION
Follow-up to #182. The `code` filter used `'**'` + `'!'` excludes, but `dorny/paths-filter` ORs patterns by default — `'**'` matches every file, so docs-only PRs still ran `quality` + `supply-chain` (confirmed on a throwaway PR #183).

Fix: `predicate-quantifier: 'every'` — a changed file counts as `code` only if it matches **all** patterns (is a path AND not Markdown / docs/** / internal/**). Mixed PRs still run the full suite; code/.github/scripts/Cargo.* still do.

This PR edits `.github/**`, so it runs the full suite (correct). Will re-verify a docs-only PR skips after merge.