### PR TITLE
chore(release): prepare 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ upgrade of an earlier Flowplane line — there is no in-place migration path fro
 version. `1.0.0` is its first stable release and the point at which the public REST API,
 CLI surface, and configuration contract become subject to semantic versioning.
 
+## [1.0.1] - 2026-06-24
+
+Patch release. Fixes defects found during the v1.0.0 separated CP/DP end-to-end
+(GHCR-extracted binaries, real Envoy 1.37, mTLS xDS). No REST, CLI, or MCP surface
+change; one additive, optional, backward-compatible configuration env var.
+
+### Added
+
+- `FLOWPLANE_OIDC_CA_BUNDLE` — an operator-supplied PEM bundle the control plane
+  trusts **in addition to** its bundled webpki roots when fetching OIDC discovery +
+  JWKS. Needed when the IdP is reachable only through a TLS-intercepting egress proxy
+  (the outbound fetch otherwise fails `invalid peer certificate: UnknownIssuer`).
+  Optional and default-off — unset behavior is unchanged. A set-but-unreadable,
+  non-PEM, or zero-certificate bundle **fails server startup closed** (`invalid_config`)
+  rather than silently weakening trust. (#171)
+
+### Fixed
+
+- `fp-agent` heartbeat: `/stats?format=json` from Envoy 1.37 returns histogram
+  elements without the `{name, value}` shape, which broke strict deserialization so
+  `last_heartbeat_at` was never populated. The parser now tolerates non-`{name,value}`
+  elements. (#170)
+
+### Documentation
+
+- New how-to: **create a tenant org and a team**. The prod/separated onboarding docs
+  jumped straight to `team create`, but a freshly bootstrapped control plane has only
+  the governance-only platform org, so the step failed closed with
+  `org_selector_required` (D-014). The onboarding path now documents the
+  tenant-org → first-owner → team sequence and why `--org platform` is rejected. (#172)
+- `docs/reference/errors.md`: the `org_selector_required` row now also names the
+  platform-org-selector and no-tenant-org-yet causes.
+
 ## [1.0.0] - 2026-06-22
 
 First stable release. PostgreSQL is the source of truth, Envoy is the only dataplane,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,7 +762,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flowplane"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "fp-agent"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "fp-api"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "axum",
  "chrono",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "fp-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "fp-domain"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base64",
  "chrono",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "fp-storage"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "fp-domain",
  "metrics",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "fp-xds"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.92"
 license = "Apache-2.0"


### PR DESCRIPTION
Release-prep PR for **1.0.1** (LIFECYCLE §4.1 steps 2–4).

- Workspace version `1.0.0 → 1.0.1` (all 7 crates inherit via `version.workspace = true`); `Cargo.lock` refreshed.
- `CHANGELOG.md` `[1.0.1] - 2026-06-24`.

**Bump = PATCH.** Surface review (§4.1.1) vs `v1.0.0`: REST routes + CLI commands unchanged (empty diffs); MCP unchanged; one **additive, optional, default-off** config env `FLOWPLANE_OIDC_CA_BUNDLE` (#171); no deprecations/removals. Full sign-off + justification recorded in the private vault release MOC.

Contents: #170 (fp-agent stats parse), #171 (OIDC CA bundle), #172 (tenant-org onboarding docs).

After merge: annotated `v1.0.1` tag → `release.yml` builds the gated RC digest → `/aidf:test-release` → approve publish HUMAN-GATE (§4.2, no publish-then-test).