### PR TITLE
chore(release): prepare 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ upgrade of an earlier Flowplane line — there is no in-place migration path fro
 version. `1.0.0` is its first stable release and the point at which the public REST API,
 CLI surface, and configuration contract become subject to semantic versioning.
 
-## [Unreleased]
+## [1.1.0] - 2026-06-26
 
-Minor release in progress. Two features that close gaps the gateway advertised but did
-not yet ship. Additive only — no REST/CLI/config/MCP removals (semver MINOR).
+Minor release. Two features that close gaps the gateway advertised but did not yet ship.
+Additive only — no REST/CLI/config/MCP removals (semver MINOR).
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,7 +762,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flowplane"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "flowplane-rls"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "axum",
  "envoy-types",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "fp-agent"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "fp-api"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "axum",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "fp-core"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "fp-domain"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "base64",
  "chrono",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "fp-storage"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "fp-domain",
  "metrics",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "fp-xds"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.92"
 license = "Apache-2.0"


### PR DESCRIPTION
Release-cut PR for **1.1.0** (LIFECYCLE §4.1). Features already landed via #188.

## Changes
- Bump workspace version `1.0.1` → `1.1.0` (`Cargo.toml` + `Cargo.lock`).
- Roll `CHANGELOG.md` `[Unreleased]` → `[1.1.0] - 2026-06-26`.

## API-surface review (§4.1 / §1.1 compensating control)
**Verdict: NO BREAKING CHANGE — MINOR bump justified.** Reviewed `v1.0.1..HEAD` by Claude + Codex (Reviewer B). Full sign-off recorded in the vault: `releases/1.1.0/_release.md`.
- **REST** — added rate-limit endpoints (domains/policies/overrides CRUD, `admin/rls/force-repush`); publish-imported reuses the existing publish path. None removed/renamed.
- **CLI** — added `rate-limit` command tree; `api spec publish` shape unchanged (now also accepts imported specs); `api create` advisory hint. None removed.
- **Config** — added `FLOWPLANE_RLS_*` + `FLOWPLANE_DATAPLANE_TLS_*`, all optional/default-off. Existing configs load unchanged.
- **MCP** — no tool-param schema change.
- **Schema** — migration `0030_rate_limit.sql` adds new tables; reserves the `rate_limit_*` cluster prefix (`_` was already rejected for public cluster names in 1.0.1).
- Deprecations/removals: none.

## After merge
Tag `v1.1.0` (annotated) → `release.yml` builds the gated multi-arch GHCR images. Per LIFECYCLE §4.2, `/aidf:test-release` runs against the gated pre-publish digest **before** approving the human-gate that makes the images public.