### PR TITLE
feat(cli): Tier-1 conformance (epic fpv2-2ge) — 2.0.0 breaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ internal/.env.auth0.example
 scripts/flowplane-dev
 scripts/flowplane-dev.py
 .beads/
+scratchpad/
 
 # internal build-journey scaffolding (agent prompts / automation notes)
 internal/dev-workflow-automation.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ upgrade of an earlier Flowplane line — there is no in-place migration path fro
 version. `1.0.0` is its first stable release and the point at which the public REST API,
 CLI surface, and configuration contract become subject to semantic versioning.
 
-## [2.0.0] - Unreleased
+## [2.0.0] - 2026-06-27
 
 Major release. CLI Tier-1 conformance: the `flowplane` CLI is brought to a documented,
 machine-consumable standard (output model, error/exit-code contract, config precedence,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,49 @@ upgrade of an earlier Flowplane line — there is no in-place migration path fro
 version. `1.0.0` is its first stable release and the point at which the public REST API,
 CLI surface, and configuration contract become subject to semantic versioning.
 
+## [2.0.0] - Unreleased
+
+Major release. CLI Tier-1 conformance: the `flowplane` CLI is brought to a documented,
+machine-consumable standard (output model, error/exit-code contract, config precedence,
+optimistic concurrency, introspection, and destructive-action safety). These are **breaking**
+changes to the CLI surface and exit-code behavior (semver MAJOR); the REST API and MCP surface
+are unchanged, and the configuration file gains only an optional `timeout` field (existing
+config files remain valid).
+
+### Added
+
+- **`flowplane schema` subcommand.** Prints the machine-readable CLI catalog (every command,
+  its flags, value types, and defaults) as the typed envelope `{schemaVersion, kind:"cliSchema",
+  data}`, with no network call — the canonical CLI contract and MCP-derivation seam (FP-DEC-0003).
+- **`--fields a,b,c` projection.** Projects reader output to only the named keys inside the
+  envelope `data` (per item for lists); `schemaVersion`/`kind` always survive, absent keys are omitted.
+- **`--token` flag** (highest-priority token source) and **`FLOWPLANE_TIMEOUT`** environment
+  variable (HTTP timeout; env tier of the precedence rule).
+- **Destructive-action confirmation.** `delete` and `unexpose` prompt `[y/N]` on an interactive
+  terminal; `--yes`/`-y` skips. On a non-interactive terminal without `--yes` they fail fast with
+  exit code `2` and never block on stdin.
+
+### Changed
+
+- **Output format default is now context-aware.** Reader output is `table` on an interactive
+  terminal and `json` when stdout is piped/redirected (so `… | jq` works without `-o json`); an
+  explicit `-o/--output` always wins. `--json` is exactly `-o json`.
+- **`-o json` success payloads are wrapped in a typed envelope** `{schemaVersion, kind, data}`
+  (e.g. `kind: "cluster"`/`"clusterList"`/`"mutationResult"`), frozen by a snapshot suite so the
+  shape cannot silently drift.
+- **Structured error contract.** Errors render a single structured envelope on stderr (empty
+  stdout) with `code`/`message`/`retryable`/`request_id` — JSON under `-o json`, YAML under
+  `-o yaml`, and a compact prose form otherwise; transport and 429/5xx are `retryable:true`,
+  4xx are `false`.
+- **Exit codes are now a defined 0–7 range** mapped from the failure class (e.g. usage `2`,
+  auth `3`, conflict `4`, connection-refused `7`) instead of a generic non-zero.
+- **Uniform configuration precedence** `flag > env > context > file > default` for *every* value
+  including the token; the token is redacted in `config show`.
+- **`update`/`delete` are optimistically concurrent.** With no `--revision`, the CLI does
+  read-modify-write (reads the current revision, sends it as `If-Match`); a stale `--revision`
+  fails with `409` naming both the attempted and the server's current revision.
+- **`--no-color`/`NO_COLOR` and `--yes` are now honored** (previously declared but inert).
+
 ## [1.1.0] - 2026-06-26
 
 Minor release. Two features that close gaps the gateway advertised but did not yet ship.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,7 +762,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flowplane"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "flowplane-rls"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "axum",
  "envoy-types",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "fp-agent"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "fp-api"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "axum",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "fp-core"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "fp-domain"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "base64",
  "chrono",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "fp-storage"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "fp-domain",
  "metrics",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "fp-xds"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.1.0"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.92"
 license = "Apache-2.0"

--- a/crates/flowplane/Cargo.toml
+++ b/crates/flowplane/Cargo.toml
@@ -47,5 +47,10 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 
+[dev-dependencies]
+axum = { workspace = true }
+tokio = { workspace = true }
+serde_json = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/flowplane/src/cli/client.rs
+++ b/crates/flowplane/src/cli/client.rs
@@ -20,7 +20,7 @@ impl RestClient {
     pub(crate) fn new(global: GlobalOptions) -> Result<Self> {
         let config = effective(&global)?;
         let http = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(global.timeout))
+            .timeout(std::time::Duration::from_secs(config.timeout))
             .build()?;
         Ok(Self {
             http,

--- a/crates/flowplane/src/cli/client.rs
+++ b/crates/flowplane/src/cli/client.rs
@@ -1,5 +1,7 @@
 use crate::cli::config::{effective, EffectiveConfig, GlobalOptions, OutputFormat};
-use crate::cli::output::{derive_kind, print_mutation_summary, render, render_error};
+use crate::cli::output::{
+    derive_kind, print_mutation_summary, render, render_error, render_transport_error,
+};
 use anyhow::{Context, Result};
 use serde_json::json;
 use serde_json::Value;
@@ -9,6 +11,9 @@ pub(crate) struct RestClient {
     http: reqwest::Client,
     config: EffectiveConfig,
     global: GlobalOptions,
+    /// When false, failed sub-requests do not print their own error envelope; the caller
+    /// (e.g. `apply`) aggregates failures into a single envelope (CLI-R-30).
+    report_errors: bool,
 }
 
 impl RestClient {
@@ -21,7 +26,15 @@ impl RestClient {
             http,
             config,
             global,
+            report_errors: true,
         })
+    }
+
+    /// Build a client whose sub-request failures are returned silently (no per-call error
+    /// envelope), for orchestrating commands that emit one aggregate error envelope.
+    pub(crate) fn quiet_errors(mut self) -> Self {
+        self.report_errors = false;
+        self
     }
 
     pub(crate) async fn request(
@@ -75,7 +88,10 @@ impl RestClient {
         let url = self.url(path);
         let mut req = self.http.request(reqwest::Method::GET, url);
         req = self.add_auth_headers(req, None);
-        let response = req.send().await.context("send request")?;
+        let response = match req.send().await {
+            Ok(response) => response,
+            Err(err) => return Err(self.transport_failure(&err)),
+        };
         let status = response.status();
         if status == reqwest::StatusCode::NOT_FOUND {
             return Ok(None);
@@ -87,7 +103,7 @@ impl RestClient {
             .map(str::to_string);
         let text = response.text().await.context("read response body")?;
         if !status.is_success() {
-            return Err(render_error(&self.global, status, request_id, &text));
+            return Err(self.http_failure(status, request_id, &text));
         }
         if text.trim().is_empty() {
             return Ok(None);
@@ -95,6 +111,30 @@ impl RestClient {
         serde_json::from_str(&text)
             .context("parse response JSON")
             .map(Some)
+    }
+
+    /// Turn a non-success HTTP response into an error: a rendered envelope normally, or a
+    /// silent message-carrying error when this client suppresses per-call errors (apply).
+    fn http_failure(
+        &self,
+        status: reqwest::StatusCode,
+        request_id: Option<String>,
+        text: &str,
+    ) -> anyhow::Error {
+        if self.report_errors {
+            render_error(&self.global, status, request_id, text)
+        } else {
+            anyhow::anyhow!("{}", crate::cli::output::error_message(status, text))
+        }
+    }
+
+    /// Transport failure as an error: rendered envelope normally, silent message otherwise.
+    fn transport_failure(&self, err: &reqwest::Error) -> anyhow::Error {
+        if self.report_errors {
+            render_transport_error(&self.global, err)
+        } else {
+            anyhow::anyhow!("{err}")
+        }
     }
 
     pub(crate) async fn request_text(&self, method: reqwest::Method, path: &str) -> Result<String> {
@@ -106,7 +146,10 @@ impl RestClient {
         let url = self.url(path);
         let mut req = self.http.request(method, url);
         req = self.add_auth_headers(req, self.global.revision);
-        let response = req.send().await.context("send request")?;
+        let response = match req.send().await {
+            Ok(response) => response,
+            Err(err) => return Err(self.transport_failure(&err)),
+        };
         let status = response.status();
         let request_id = response
             .headers()
@@ -115,7 +158,7 @@ impl RestClient {
             .map(str::to_string);
         let text = response.text().await.context("read response body")?;
         if !status.is_success() {
-            return Err(render_error(&self.global, status, request_id, &text));
+            return Err(self.http_failure(status, request_id, &text));
         }
         if let Some(out) = &self.global.out {
             fs::write(out, &text).with_context(|| format!("write {}", out.display()))?;
@@ -147,7 +190,10 @@ impl RestClient {
         if let Some(body) = body {
             req = req.json(&body);
         }
-        let response = req.send().await.context("send request")?;
+        let response = match req.send().await {
+            Ok(response) => response,
+            Err(err) => return Err(self.transport_failure(&err)),
+        };
         let status = response.status();
         let request_id = response
             .headers()
@@ -156,7 +202,7 @@ impl RestClient {
             .map(str::to_string);
         let text = response.text().await.context("read response body")?;
         if !status.is_success() {
-            return Err(render_error(&self.global, status, request_id, &text));
+            return Err(self.http_failure(status, request_id, &text));
         }
         if status == reqwest::StatusCode::NO_CONTENT || text.trim().is_empty() {
             if render_response && !self.global.quiet {

--- a/crates/flowplane/src/cli/client.rs
+++ b/crates/flowplane/src/cli/client.rs
@@ -200,6 +200,15 @@ impl RestClient {
             render(&self.global, "plan", &plan)?;
             return Ok(Some(plan));
         }
+        // CLI-R-22/26: a destructive DELETE prompts `[y/N]` on a TTY, is skipped by `--yes`,
+        // and fails fast on a non-interactive terminal — before any network call (incl. the
+        // RMW read below). Only for interactive command clients (apply uses a quiet client).
+        if method == reqwest::Method::DELETE && self.report_errors {
+            crate::cli::confirm::confirm_destructive(
+                &self.global,
+                &format!("delete {}", path.trim_start_matches('/')),
+            )?;
+        }
         let method_label = method.as_str().to_string();
         let is_get = method == reqwest::Method::GET;
         // CLI-R-47: read-modify-write. On an update/delete with no explicit `--revision`, read

--- a/crates/flowplane/src/cli/client.rs
+++ b/crates/flowplane/src/cli/client.rs
@@ -1,5 +1,5 @@
 use crate::cli::config::{effective, EffectiveConfig, GlobalOptions, OutputFormat};
-use crate::cli::output::{print_mutation_summary, render, render_error};
+use crate::cli::output::{derive_kind, print_mutation_summary, render, render_error};
 use anyhow::{Context, Result};
 use serde_json::json;
 use serde_json::Value;
@@ -55,6 +55,22 @@ impl RestClient {
             .await
     }
 
+    /// Perform a mutation without emitting any per-call output (no render, no summary).
+    ///
+    /// Used by orchestrating commands (e.g. `apply`) that aggregate several sub-requests
+    /// and render a single summary envelope themselves — emitting a per-resource envelope
+    /// here would break the one-document-per-invocation JSON contract (CLI-R-15).
+    pub(crate) async fn request_quiet(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        body: Option<Value>,
+        revision: Option<i64>,
+    ) -> Result<Option<Value>> {
+        self.request_inner(method, path, body, revision, false, false)
+            .await
+    }
+
     pub(crate) async fn get_optional(&self, path: &str) -> Result<Option<Value>> {
         let url = self.url(path);
         let mut req = self.http.request(reqwest::Method::GET, url);
@@ -84,7 +100,7 @@ impl RestClient {
     pub(crate) async fn request_text(&self, method: reqwest::Method, path: &str) -> Result<String> {
         if self.global.dry_run && method != reqwest::Method::GET {
             let plan = json!({ "method": method.as_str(), "path": path });
-            render(&self.global, &plan)?;
+            render(&self.global, "plan", &plan)?;
             return Ok(String::new());
         }
         let url = self.url(path);
@@ -120,7 +136,7 @@ impl RestClient {
     ) -> Result<Option<Value>> {
         if self.global.dry_run && method != reqwest::Method::GET {
             let plan = json!({ "method": method.as_str(), "path": path, "body": body });
-            render(&self.global, &plan)?;
+            render(&self.global, "plan", &plan)?;
             return Ok(Some(plan));
         }
         let url = self.url(path);
@@ -143,8 +159,22 @@ impl RestClient {
             return Err(render_error(&self.global, status, request_id, &text));
         }
         if status == reqwest::StatusCode::NO_CONTENT || text.trim().is_empty() {
-            if !self.global.quiet {
-                print_mutation_summary(&self.global, &method_label, path, None)?;
+            if render_response && !self.global.quiet {
+                // CLI-R-10: a body-less mutation (e.g. delete) still emits a JSON/YAML
+                // envelope under `-o json`/`-o yaml`; only human formats print prose.
+                if matches!(
+                    self.global.format(),
+                    OutputFormat::Json | OutputFormat::Yaml
+                ) {
+                    let result = json!({
+                        "result": "ok",
+                        "method": method_label,
+                        "path": path,
+                    });
+                    render(&self.global, "mutationResult", &result)?;
+                } else {
+                    print_mutation_summary(&self.global, &method_label, path, None)?;
+                }
             }
             return Ok(None);
         }
@@ -157,7 +187,7 @@ impl RestClient {
                     OutputFormat::Json | OutputFormat::Yaml
                 ))
         {
-            render(&self.global, &value)?;
+            render(&self.global, &derive_kind(path, &value), &value)?;
         } else if render_response {
             print_mutation_summary(&self.global, &method_label, path, Some(&value))?;
         }

--- a/crates/flowplane/src/cli/client.rs
+++ b/crates/flowplane/src/cli/client.rs
@@ -1,6 +1,7 @@
 use crate::cli::config::{effective, EffectiveConfig, GlobalOptions, OutputFormat};
 use crate::cli::output::{
-    derive_kind, print_mutation_summary, render, render_error, render_transport_error,
+    derive_kind, print_mutation_summary, render, render_error, render_revision_conflict,
+    render_transport_error,
 };
 use anyhow::{Context, Result};
 use serde_json::json;
@@ -128,6 +129,23 @@ impl RestClient {
         }
     }
 
+    /// Read a resource's current `revision` for read-modify-write (CLI-R-47). A quiet GET:
+    /// it neither renders nor surfaces errors (a missing/failed read just yields `None`, and
+    /// the mutation proceeds without `If-Match`, letting the server report the real failure).
+    async fn read_current_revision(&self, path: &str) -> Option<i64> {
+        let url = self.url(path);
+        let req = self.add_auth_headers(self.http.request(reqwest::Method::GET, url), None);
+        let response = req.send().await.ok()?;
+        if !response.status().is_success() {
+            return None;
+        }
+        let text = response.text().await.ok()?;
+        serde_json::from_str::<Value>(&text)
+            .ok()?
+            .get("revision")
+            .and_then(Value::as_i64)
+    }
+
     /// Transport failure as an error: rendered envelope normally, silent message otherwise.
     fn transport_failure(&self, err: &reqwest::Error) -> anyhow::Error {
         if self.report_errors {
@@ -182,9 +200,21 @@ impl RestClient {
             render(&self.global, "plan", &plan)?;
             return Ok(Some(plan));
         }
-        let url = self.url(path);
         let method_label = method.as_str().to_string();
         let is_get = method == reqwest::Method::GET;
+        // CLI-R-47: read-modify-write. On an update/delete with no explicit `--revision`, read
+        // the resource's current revision first and send it as `If-Match`, so concurrent edits
+        // are detected (a stale write loses with a 409) instead of silently last-write-wins.
+        let is_mutation = matches!(
+            method,
+            reqwest::Method::PATCH | reqwest::Method::DELETE | reqwest::Method::PUT
+        );
+        let revision = match revision {
+            Some(explicit) => Some(explicit),
+            None if is_mutation => self.read_current_revision(path).await,
+            None => None,
+        };
+        let url = self.url(path);
         let mut req = self.http.request(method, url);
         req = self.add_auth_headers(req, revision);
         if let Some(body) = body {
@@ -202,6 +232,23 @@ impl RestClient {
             .map(str::to_string);
         let text = response.text().await.context("read response body")?;
         if !status.is_success() {
+            // CLI-R-47: a revision race surfaces a 409/412 that names BOTH revisions — the one
+            // we attempted (If-Match) and the server's current one (in its message).
+            if self.report_errors
+                && revision.is_some()
+                && matches!(
+                    status,
+                    reqwest::StatusCode::CONFLICT | reqwest::StatusCode::PRECONDITION_FAILED
+                )
+            {
+                return Err(render_revision_conflict(
+                    &self.global,
+                    status,
+                    request_id,
+                    &text,
+                    revision.unwrap_or_default(),
+                ));
+            }
             return Err(self.http_failure(status, request_id, &text));
         }
         if status == reqwest::StatusCode::NO_CONTENT || text.trim().is_empty() {

--- a/crates/flowplane/src/cli/config.rs
+++ b/crates/flowplane/src/cli/config.rs
@@ -43,6 +43,10 @@ pub struct GlobalOptions {
     pub yes: bool,
     #[arg(long, global = true)]
     pub revision: Option<i64>,
+    /// Comma-separated field names to project reader output to (CLI-R-51). Applied inside
+    /// the envelope `data` (per item for lists); `schemaVersion`/`kind` always survive.
+    #[arg(long, global = true, value_delimiter = ',')]
+    pub fields: Vec<String>,
     /// HTTP timeout in seconds. Uniform precedence (CLI-R-40/41):
     /// flag > `FLOWPLANE_TIMEOUT` > context > config file > default (30).
     #[arg(long, global = true, env = "FLOWPLANE_TIMEOUT")]
@@ -323,6 +327,7 @@ mod resolve_tests {
             dry_run: false,
             yes: false,
             revision: None,
+            fields: Vec::new(),
             timeout: None,
             out: None,
         }
@@ -457,6 +462,7 @@ mod format_tests {
             dry_run: false,
             yes: false,
             revision: None,
+            fields: Vec::new(),
             timeout: None,
             out: None,
         }

--- a/crates/flowplane/src/cli/config.rs
+++ b/crates/flowplane/src/cli/config.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
 const DEFAULT_SERVER: &str = "http://127.0.0.1:8080";
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
 
 #[derive(Debug, Clone, Args)]
 pub struct GlobalOptions {
@@ -16,10 +17,14 @@ pub struct GlobalOptions {
     pub context: Option<String>,
     #[arg(long, global = true, env = "FLOWPLANE_SERVER")]
     pub server: Option<String>,
-    #[arg(long, global = true)]
+    #[arg(long, global = true, env = "FLOWPLANE_TEAM")]
     pub team: Option<String>,
-    #[arg(long, global = true)]
+    #[arg(long, global = true, env = "FLOWPLANE_ORG")]
     pub org: Option<String>,
+    /// Bearer token; highest-priority token source (CLI-R-40). Falls back to
+    /// `FLOWPLANE_TOKEN`, the selected context, the config file, then the credentials file.
+    #[arg(long, global = true, env = "FLOWPLANE_TOKEN", hide_env_values = true)]
+    pub token: Option<String>,
     #[arg(short = 'o', long, global = true, value_enum)]
     pub output: Option<OutputFormat>,
     /// Exactly equivalent to `--output json`; cannot be combined with `--output`
@@ -38,8 +43,10 @@ pub struct GlobalOptions {
     pub yes: bool,
     #[arg(long, global = true)]
     pub revision: Option<i64>,
-    #[arg(long, global = true, default_value_t = 30)]
-    pub timeout: u64,
+    /// HTTP timeout in seconds. Uniform precedence (CLI-R-40/41):
+    /// flag > `FLOWPLANE_TIMEOUT` > context > config file > default (30).
+    #[arg(long, global = true, env = "FLOWPLANE_TIMEOUT")]
+    pub timeout: Option<u64>,
     #[arg(long, global = true)]
     pub out: Option<PathBuf>,
 }
@@ -67,6 +74,8 @@ pub(crate) struct CliConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) token: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) timeout: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) oidc_issuer: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) oidc_client_id: Option<String>,
@@ -83,6 +92,8 @@ pub(crate) struct NamedContext {
     pub(crate) org: Option<String>,
     pub(crate) team: Option<String>,
     pub(crate) token: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) timeout: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -91,6 +102,7 @@ pub(crate) struct EffectiveConfig {
     pub(crate) org: Option<String>,
     pub(crate) team: Option<String>,
     pub(crate) token: Option<String>,
+    pub(crate) timeout: u64,
     pub(crate) oidc_issuer: Option<String>,
     pub(crate) oidc_client_id: Option<String>,
     pub(crate) oidc_scope: Option<String>,
@@ -223,6 +235,21 @@ fn write_private_file_contents(path: &Path, contents: &[u8]) -> Result<()> {
 
 pub(crate) fn effective(global: &GlobalOptions) -> Result<EffectiveConfig> {
     let file = read_config()?;
+    let credentials = fs::read_to_string(credentials_path())
+        .ok()
+        .map(|s| s.trim().to_string());
+    resolve(global, file, credentials)
+}
+
+/// Pure precedence resolver (CLI-R-40): `flag > env > context > file > default` for every
+/// value. The flag-or-env tier is already folded into `global.*` by clap (each arg's
+/// `env = …`); this layers context → file → credentials/default beneath it. IO-free so the
+/// precedence is unit-testable without touching process env or the filesystem.
+fn resolve(
+    global: &GlobalOptions,
+    file: CliConfig,
+    credentials: Option<String>,
+) -> Result<EffectiveConfig> {
     let selected_name = global.context.as_ref().or(file.current_context.as_ref());
     let selected =
         selected_name.and_then(|name| file.contexts.iter().find(|ctx| &ctx.name == name));
@@ -231,15 +258,12 @@ pub(crate) fn effective(global: &GlobalOptions) -> Result<EffectiveConfig> {
             anyhow::bail!("context \"{name}\" does not exist");
         }
     }
-    let token = std::env::var("FLOWPLANE_TOKEN")
-        .ok()
+    let token = global
+        .token
+        .clone()
         .or_else(|| selected.and_then(|ctx| ctx.token.clone()))
         .or_else(|| file.token.clone())
-        .or_else(|| {
-            fs::read_to_string(credentials_path())
-                .ok()
-                .map(|s| s.trim().to_string())
-        })
+        .or(credentials)
         .filter(|s| !s.is_empty());
     Ok(EffectiveConfig {
         server: global
@@ -251,16 +275,19 @@ pub(crate) fn effective(global: &GlobalOptions) -> Result<EffectiveConfig> {
         org: global
             .org
             .clone()
-            .or_else(|| std::env::var("FLOWPLANE_ORG").ok())
             .or_else(|| selected.and_then(|ctx| ctx.org.clone()))
             .or_else(|| file.org.clone()),
         team: global
             .team
             .clone()
-            .or_else(|| std::env::var("FLOWPLANE_TEAM").ok())
             .or_else(|| selected.and_then(|ctx| ctx.team.clone()))
             .or_else(|| file.team.clone()),
         token,
+        timeout: global
+            .timeout
+            .or_else(|| selected.and_then(|ctx| ctx.timeout))
+            .or(file.timeout)
+            .unwrap_or(DEFAULT_TIMEOUT_SECS),
         oidc_issuer: std::env::var("FLOWPLANE_OIDC_ISSUER")
             .ok()
             .or(file.oidc_issuer),
@@ -278,6 +305,140 @@ pub(crate) fn effective(global: &GlobalOptions) -> Result<EffectiveConfig> {
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
+mod resolve_tests {
+    use super::{resolve, CliConfig, GlobalOptions, NamedContext, DEFAULT_SERVER};
+
+    fn opts() -> GlobalOptions {
+        GlobalOptions {
+            context: None,
+            server: None,
+            team: None,
+            org: None,
+            token: None,
+            output: None,
+            json: false,
+            no_color: false,
+            quiet: false,
+            verbose: false,
+            dry_run: false,
+            yes: false,
+            revision: None,
+            timeout: None,
+            out: None,
+        }
+    }
+
+    fn ctx(name: &str) -> NamedContext {
+        NamedContext {
+            name: name.to_string(),
+            server: "https://ctx.example".to_string(),
+            org: Some("ctx-org".to_string()),
+            team: Some("ctx-team".to_string()),
+            token: Some("ctx-token".to_string()),
+            timeout: Some(11),
+        }
+    }
+
+    fn file_with_ctx() -> CliConfig {
+        CliConfig {
+            current_context: Some("prod".to_string()),
+            contexts: vec![ctx("prod")],
+            base_url: Some("https://file.example".to_string()),
+            org: Some("file-org".to_string()),
+            team: Some("file-team".to_string()),
+            token: Some("file-token".to_string()),
+            ..CliConfig::default()
+        }
+    }
+
+    #[test]
+    fn flag_or_env_tier_beats_context_file_and_credentials() {
+        // `global.*` carries the resolved flag-or-env value (clap folds env in); it wins.
+        let mut o = opts();
+        o.server = Some("https://flag.example".to_string());
+        o.org = Some("flag-org".to_string());
+        o.team = Some("flag-team".to_string());
+        o.token = Some("flag-token".to_string());
+        let eff = resolve(&o, file_with_ctx(), Some("cred-token".to_string())).unwrap();
+        assert_eq!(eff.server, "https://flag.example");
+        assert_eq!(eff.org.as_deref(), Some("flag-org"));
+        assert_eq!(eff.team.as_deref(), Some("flag-team"));
+        assert_eq!(eff.token.as_deref(), Some("flag-token"));
+    }
+
+    #[test]
+    fn context_beats_file_when_no_flag_or_env() {
+        let eff = resolve(&opts(), file_with_ctx(), Some("cred-token".to_string())).unwrap();
+        // current_context = prod, so the context values win over the bare file values.
+        assert_eq!(eff.server, "https://ctx.example");
+        assert_eq!(eff.org.as_deref(), Some("ctx-org"));
+        assert_eq!(eff.team.as_deref(), Some("ctx-team"));
+        assert_eq!(eff.token.as_deref(), Some("ctx-token"));
+    }
+
+    #[test]
+    fn file_beats_credentials_and_default_when_no_context() {
+        let file = CliConfig {
+            base_url: Some("https://file.example".to_string()),
+            org: Some("file-org".to_string()),
+            team: Some("file-team".to_string()),
+            token: Some("file-token".to_string()),
+            ..CliConfig::default()
+        };
+        let eff = resolve(&opts(), file, Some("cred-token".to_string())).unwrap();
+        assert_eq!(eff.server, "https://file.example");
+        assert_eq!(eff.token.as_deref(), Some("file-token"));
+    }
+
+    #[test]
+    fn credentials_then_default_are_the_lowest_token_and_server_tiers() {
+        let eff = resolve(
+            &opts(),
+            CliConfig::default(),
+            Some("cred-token".to_string()),
+        )
+        .unwrap();
+        assert_eq!(eff.token.as_deref(), Some("cred-token"));
+        // No server anywhere → the built-in default.
+        assert_eq!(eff.server, DEFAULT_SERVER);
+        // No token anywhere → None.
+        let eff = resolve(&opts(), CliConfig::default(), None).unwrap();
+        assert_eq!(eff.token, None);
+    }
+
+    #[test]
+    fn timeout_follows_uniform_precedence_flag_context_file_default() {
+        // flag (folded from --timeout/FLOWPLANE_TIMEOUT) wins.
+        let mut o = opts();
+        o.timeout = Some(99);
+        assert_eq!(resolve(&o, file_with_ctx(), None).unwrap().timeout, 99);
+        // no flag/env → selected context timeout (ctx sets 11).
+        assert_eq!(resolve(&opts(), file_with_ctx(), None).unwrap().timeout, 11);
+        // no flag/env/context → file timeout.
+        let file = CliConfig {
+            timeout: Some(7),
+            ..CliConfig::default()
+        };
+        assert_eq!(resolve(&opts(), file, None).unwrap().timeout, 7);
+        // nothing anywhere → default 30.
+        assert_eq!(
+            resolve(&opts(), CliConfig::default(), None)
+                .unwrap()
+                .timeout,
+            30
+        );
+    }
+
+    #[test]
+    fn unknown_explicit_context_is_an_error() {
+        let mut o = opts();
+        o.context = Some("does-not-exist".to_string());
+        assert!(resolve(&o, CliConfig::default(), None).is_err());
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod format_tests {
     use super::{GlobalOptions, OutputFormat};
 
@@ -287,6 +448,7 @@ mod format_tests {
             server: None,
             team: None,
             org: None,
+            token: None,
             output: None,
             json: false,
             no_color: false,
@@ -295,7 +457,7 @@ mod format_tests {
             dry_run: false,
             yes: false,
             revision: None,
-            timeout: 30,
+            timeout: None,
             out: None,
         }
     }

--- a/crates/flowplane/src/cli/config.rs
+++ b/crates/flowplane/src/cli/config.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use clap::{Args, ValueEnum};
 use serde::{Deserialize, Serialize};
 use std::fs::{self, OpenOptions};
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
 #[cfg(unix)]
@@ -22,7 +22,9 @@ pub struct GlobalOptions {
     pub org: Option<String>,
     #[arg(short = 'o', long, global = true, value_enum)]
     pub output: Option<OutputFormat>,
-    #[arg(long, global = true)]
+    /// Exactly equivalent to `--output json`; cannot be combined with `--output`
+    /// (CLI-R-11: `-o/--output` is the single format selector).
+    #[arg(long, global = true, conflicts_with = "output")]
     pub json: bool,
     #[arg(long, global = true)]
     pub no_color: bool,
@@ -96,12 +98,44 @@ pub(crate) struct EffectiveConfig {
 }
 
 impl GlobalOptions {
+    /// Resolve the effective output format.
+    ///
+    /// Precedence (CLI-R-11/12): `--json` is exactly `-o json`; an explicit `-o/--output`
+    /// always wins; otherwise the default is `table` on an interactive stdout and `json`
+    /// when stdout is not a TTY (so `flowplane … | jq` works without `-o json`).
     pub(crate) fn format(&self) -> OutputFormat {
+        self.format_for(std::io::stdout().is_terminal())
+    }
+
+    /// TTY-parameterized core of [`GlobalOptions::format`], split out for deterministic tests.
+    pub(crate) fn format_for(&self, stdout_is_tty: bool) -> OutputFormat {
         if self.json {
-            OutputFormat::Json
-        } else {
-            self.output.unwrap_or(OutputFormat::Table)
+            return OutputFormat::Json;
         }
+        if let Some(output) = self.output {
+            return output;
+        }
+        if stdout_is_tty {
+            OutputFormat::Table
+        } else {
+            OutputFormat::Json
+        }
+    }
+
+    /// Whether styled (ANSI) output is permitted (CLI-R-16).
+    ///
+    /// Disabled by `--no-color`, the `NO_COLOR` env var (any value), a non-TTY stdout, or
+    /// when output is redirected to a file via `--out`.
+    pub(crate) fn use_color(&self) -> bool {
+        self.use_color_for(std::io::stdout().is_terminal())
+    }
+
+    /// TTY-parameterized core of [`GlobalOptions::use_color`], split out for deterministic tests.
+    pub(crate) fn use_color_for(&self, stdout_is_tty: bool) -> bool {
+        !self.no_color
+            && self.out.is_none()
+            && stdout_is_tty
+            && std::env::var_os("NO_COLOR").is_none()
     }
 }
 
@@ -240,6 +274,68 @@ pub(crate) fn effective(global: &GlobalOptions) -> Result<EffectiveConfig> {
             .ok()
             .or(file.callback_url),
     })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod format_tests {
+    use super::{GlobalOptions, OutputFormat};
+
+    fn opts() -> GlobalOptions {
+        GlobalOptions {
+            context: None,
+            server: None,
+            team: None,
+            org: None,
+            output: None,
+            json: false,
+            no_color: false,
+            quiet: false,
+            verbose: false,
+            dry_run: false,
+            yes: false,
+            revision: None,
+            timeout: 30,
+            out: None,
+        }
+    }
+
+    #[test]
+    fn json_flag_forces_json_regardless_of_tty() {
+        let mut o = opts();
+        o.json = true;
+        assert_eq!(o.format_for(true), OutputFormat::Json);
+        assert_eq!(o.format_for(false), OutputFormat::Json);
+    }
+
+    #[test]
+    fn explicit_output_always_wins() {
+        let mut o = opts();
+        o.output = Some(OutputFormat::Yaml);
+        assert_eq!(o.format_for(true), OutputFormat::Yaml);
+        assert_eq!(o.format_for(false), OutputFormat::Yaml);
+    }
+
+    #[test]
+    fn default_is_table_on_tty_json_off_tty() {
+        let o = opts();
+        assert_eq!(o.format_for(true), OutputFormat::Table);
+        assert_eq!(o.format_for(false), OutputFormat::Json);
+    }
+
+    #[test]
+    fn color_disabled_by_flag_file_or_non_tty() {
+        let mut o = opts();
+        o.no_color = true;
+        assert!(!o.use_color_for(true), "--no-color disables color");
+
+        let mut o = opts();
+        o.out = Some(std::path::PathBuf::from("/tmp/x"));
+        assert!(!o.use_color_for(true), "--out disables color");
+
+        let o = opts();
+        assert!(!o.use_color_for(false), "non-TTY disables color");
+    }
 }
 
 #[cfg(test)]

--- a/crates/flowplane/src/cli/confirm.rs
+++ b/crates/flowplane/src/cli/confirm.rs
@@ -1,0 +1,100 @@
+//! Destructive-action confirmation (CLI-R-22/26).
+//!
+//! A destructive command (`delete`, `unexpose`) prompts `[y/N]` on an interactive terminal;
+//! `--yes` skips the prompt; on a non-interactive terminal **without** `--yes` it fails fast
+//! (exit 2) and never blocks reading stdin. The decision is split from the IO so every branch
+//! is unit-testable. (`apply` is additive-only and `apply --prune` is rejected as unsupported,
+//! so there is no prune surface to confirm.)
+
+use crate::cli::config::GlobalOptions;
+use crate::cli::output::CliError;
+use anyhow::Result;
+use std::io::{IsTerminal, Write};
+
+/// What to do for a destructive action, given the flags, terminal state, and the answer.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ConfirmOutcome {
+    /// `--yes`, or the user typed yes at the prompt.
+    Proceed,
+    /// Interactive, user declined (the safe default for a bare Enter / anything but yes).
+    Declined,
+    /// Non-interactive and no `--yes`: refuse without ever reading stdin (CLI-R-26).
+    NonInteractive,
+}
+
+/// Pure confirmation decision (CLI-R-22/26). `answer` is the line read from stdin, only when
+/// interactive; `None` when non-interactive (it must NOT be read in that case).
+pub(crate) fn decide(yes: bool, stdin_is_tty: bool, answer: Option<&str>) -> ConfirmOutcome {
+    if yes {
+        return ConfirmOutcome::Proceed;
+    }
+    if !stdin_is_tty {
+        return ConfirmOutcome::NonInteractive;
+    }
+    match answer.map(|a| a.trim().to_ascii_lowercase()) {
+        Some(a) if a == "y" || a == "yes" => ConfirmOutcome::Proceed,
+        _ => ConfirmOutcome::Declined,
+    }
+}
+
+/// Confirm a destructive `action` (e.g. `delete clusters/alpha`). Returns `Ok(())` to proceed;
+/// otherwise an already-reported [`CliError`] with the right exit code (declined → 1,
+/// non-interactive without `--yes` → 2 usage). Reads stdin only when interactive.
+pub(crate) fn confirm_destructive(global: &GlobalOptions, action: &str) -> Result<()> {
+    let stdin_is_tty = std::io::stdin().is_terminal();
+    // Decide first WITHOUT reading stdin for the trivial cases (CLI-R-26: never block on a
+    // non-interactive terminal).
+    if global.yes {
+        return Ok(());
+    }
+    if !stdin_is_tty {
+        eprintln!(
+            "error (confirmation_required): refusing to {action} without --yes on a \
+             non-interactive terminal; pass --yes to confirm"
+        );
+        return Err(anyhow::Error::new(CliError::new(2)));
+    }
+    eprint!("{action}? [y/N]: ");
+    let _ = std::io::stderr().flush();
+    let mut line = String::new();
+    std::io::stdin().read_line(&mut line)?;
+    match decide(false, true, Some(&line)) {
+        ConfirmOutcome::Proceed => Ok(()),
+        _ => {
+            eprintln!("aborted");
+            Err(anyhow::Error::new(CliError::new(1)))
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yes_flag_proceeds_regardless_of_tty_or_answer() {
+        assert_eq!(decide(true, true, Some("n")), ConfirmOutcome::Proceed);
+        assert_eq!(decide(true, false, None), ConfirmOutcome::Proceed);
+    }
+
+    #[test]
+    fn non_interactive_without_yes_is_fail_fast_never_reads() {
+        // answer is None — the IO layer must not have read stdin.
+        assert_eq!(decide(false, false, None), ConfirmOutcome::NonInteractive);
+    }
+
+    #[test]
+    fn interactive_prompt_yes_no_and_default() {
+        assert_eq!(decide(false, true, Some("y\n")), ConfirmOutcome::Proceed);
+        assert_eq!(decide(false, true, Some("yes\n")), ConfirmOutcome::Proceed);
+        assert_eq!(decide(false, true, Some("Y")), ConfirmOutcome::Proceed);
+        // bare Enter / anything else → declined (safe default N).
+        assert_eq!(decide(false, true, Some("\n")), ConfirmOutcome::Declined);
+        assert_eq!(decide(false, true, Some("n")), ConfirmOutcome::Declined);
+        assert_eq!(
+            decide(false, true, Some("nonsense")),
+            ConfirmOutcome::Declined
+        );
+    }
+}

--- a/crates/flowplane/src/cli/mod.rs
+++ b/crates/flowplane/src/cli/mod.rs
@@ -1853,6 +1853,7 @@ pub async fn run_dataplane(global: GlobalOptions, command: DataplaneCommand) -> 
             if dry_run_global.dry_run {
                 render(
                     &dry_run_global,
+                    "plan",
                     &json!({"method": reqwest::Method::GET.as_str(), "path": path}),
                 )?;
             } else {
@@ -2056,7 +2057,13 @@ pub async fn run_apply(global: GlobalOptions, command: ApplyCommand) -> Result<(
             println!("{text}");
         }
     } else if !global.quiet {
-        print_apply_summary(&outcomes);
+        // CLI-R-10: `apply` honours `-o json`/`-o yaml` like every other command; the
+        // prose summary is only the human (table/wide) rendering.
+        if matches!(global.format(), OutputFormat::Json | OutputFormat::Yaml) {
+            output::render(&global, "applyResult", &apply_outcomes_value(&outcomes))?;
+        } else {
+            print_apply_summary(&outcomes);
+        }
     }
     let failures = outcomes.iter().filter(|outcome| outcome.failed).count();
     if failures > 0 {
@@ -2071,10 +2078,11 @@ async fn create_apply_target(
     target: &ApplyTarget,
 ) -> Result<ApplyAction> {
     client
-        .request(
+        .request_quiet(
             reqwest::Method::POST,
             &format!("/api/v1/teams/{team}/{}", target.kind.segment()),
             Some(target.create_body.clone()),
+            None,
         )
         .await?;
     Ok(ApplyAction::Created)
@@ -2093,7 +2101,7 @@ async fn apply_existing(
             }
             let revision = existing.get("revision").and_then(Value::as_i64);
             client
-                .request_with_revision(
+                .request_quiet(
                     reqwest::Method::PATCH,
                     path,
                     Some(target.update_body()?),
@@ -2110,7 +2118,7 @@ async fn apply_existing(
             }
             let revision = existing.get("revision").and_then(Value::as_i64);
             client
-                .request_with_revision(
+                .request_quiet(
                     reqwest::Method::POST,
                     &format!("{path}/rotate"),
                     Some(target.update_body()?),
@@ -2212,6 +2220,24 @@ impl ApplyOutcome {
             failed: true,
         }
     }
+}
+
+/// Machine-readable apply summary for `-o json`/`-o yaml` (CLI-R-10/15). Wrapped by
+/// `render()` in the typed envelope as `kind: "applyResult"`.
+fn apply_outcomes_value(outcomes: &[ApplyOutcome]) -> Value {
+    let items = outcomes
+        .iter()
+        .map(|outcome| {
+            json!({
+                "kind": outcome.kind.label(),
+                "name": outcome.name,
+                "action": outcome.action,
+                "detail": outcome.detail,
+                "failed": outcome.failed,
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({ "items": items })
 }
 
 fn print_apply_summary(outcomes: &[ApplyOutcome]) {

--- a/crates/flowplane/src/cli/mod.rs
+++ b/crates/flowplane/src/cli/mod.rs
@@ -2,6 +2,7 @@ mod client;
 mod commands;
 mod config;
 pub(crate) mod output;
+pub(crate) mod schema;
 
 use anyhow::{Context, Result};
 use base64::Engine as _;

--- a/crates/flowplane/src/cli/mod.rs
+++ b/crates/flowplane/src/cli/mod.rs
@@ -209,7 +209,7 @@ async fn device_login(
     })?;
     let scope = config.oidc_scope.unwrap_or(scope);
     let http = reqwest::Client::builder()
-        .timeout(Duration::from_secs(global.timeout))
+        .timeout(Duration::from_secs(global.timeout.unwrap_or(30)))
         .build()?;
     let discovery_url = format!(
         "{}/.well-known/openid-configuration",
@@ -325,7 +325,7 @@ async fn pkce_login(
         .unwrap_or_else(|| "http://127.0.0.1:8976/callback".to_string());
     let callback = CallbackUrl::parse(&callback_url)?;
     let http = reqwest::Client::builder()
-        .timeout(Duration::from_secs(global.timeout))
+        .timeout(Duration::from_secs(global.timeout.unwrap_or(30)))
         .build()?;
     let discovery_url = format!(
         "{}/.well-known/openid-configuration",
@@ -544,10 +544,27 @@ fn percent_decode(value: &str) -> Result<String> {
     String::from_utf8(out).context("percent decoded value is not UTF-8")
 }
 
+/// Replace a stored token with a fixed redaction marker so `config show` never reveals it
+/// (CLI-R-43). A `None` token is left as-is.
+fn redact_token(token: &mut Option<String>) {
+    if token.is_some() {
+        *token = Some("***redacted***".to_string());
+    }
+}
+
 pub fn run_config(_global: GlobalOptions, command: ConfigCommand) -> Result<()> {
     match command {
         ConfigCommand::Path => println!("{}", config_path().display()),
-        ConfigCommand::Show => println!("{}", toml::to_string_pretty(&read_config()?)?),
+        ConfigCommand::Show => {
+            // CLI-R-43: never print token material. Redact the file token and any
+            // per-context tokens before serializing the config.
+            let mut config = read_config()?;
+            redact_token(&mut config.token);
+            for ctx in &mut config.contexts {
+                redact_token(&mut ctx.token);
+            }
+            println!("{}", toml::to_string_pretty(&config)?);
+        }
         ConfigCommand::SetContext {
             name,
             server,
@@ -571,6 +588,7 @@ pub fn run_config(_global: GlobalOptions, command: ConfigCommand) -> Result<()> 
                 } else {
                     token
                 },
+                timeout: None,
             });
             config.current_context.get_or_insert(name);
             write_config(&config)?;

--- a/crates/flowplane/src/cli/mod.rs
+++ b/crates/flowplane/src/cli/mod.rs
@@ -2020,7 +2020,9 @@ pub async fn run_apply(global: GlobalOptions, command: ApplyCommand) -> Result<(
         );
     }
     let targets = ordered_apply_targets(read_apply_manifests(&command.file)?)?;
-    let client = RestClient::new(global.clone())?;
+    // Sub-request failures are suppressed per-call and aggregated into one error envelope
+    // below (CLI-R-30), instead of each printing its own.
+    let client = RestClient::new(global.clone())?.quiet_errors();
     let mut diff_lines = Vec::new();
     let mut outcomes = Vec::new();
     for target in targets {
@@ -2056,20 +2058,36 @@ pub async fn run_apply(global: GlobalOptions, command: ApplyCommand) -> Result<(
         } else if !global.quiet {
             println!("{text}");
         }
-    } else if !global.quiet {
-        // CLI-R-10: `apply` honours `-o json`/`-o yaml` like every other command; the
-        // prose summary is only the human (table/wide) rendering.
-        if matches!(global.format(), OutputFormat::Json | OutputFormat::Yaml) {
-            output::render(&global, "applyResult", &apply_outcomes_value(&outcomes))?;
-        } else {
-            print_apply_summary(&outcomes);
+        return Ok(());
+    }
+
+    let failures: Vec<&ApplyOutcome> = outcomes.iter().filter(|o| o.failed).collect();
+    if failures.is_empty() {
+        // Success: the apply result is the command's stdout payload (CLI-R-10/15).
+        if !global.quiet {
+            if matches!(global.format(), OutputFormat::Json | OutputFormat::Yaml) {
+                output::render(&global, "applyResult", &apply_outcomes_value(&outcomes))?;
+            } else {
+                print_apply_summary(&outcomes);
+            }
         }
+        return Ok(());
     }
-    let failures = outcomes.iter().filter(|outcome| outcome.failed).count();
-    if failures > 0 {
-        anyhow::bail!("apply failed for {failures} resource(s); see summary above");
-    }
-    Ok(())
+
+    // CLI-R-30: a partial/total failure is reported as ONE structured error envelope on
+    // stderr (no per-subrequest prints, no applyResult on stdout, no raw `{err:?}` trailer).
+    let failure_items = failures
+        .iter()
+        .map(|o| {
+            json!({
+                "kind": o.kind.label(),
+                "name": o.name,
+                "error": o.detail,
+            })
+        })
+        .collect::<Vec<_>>();
+    output::emit_error_envelope(&global, &output::apply_error_envelope(failure_items));
+    Err(anyhow::Error::new(output::CliError::new(1)))
 }
 
 async fn create_apply_target(

--- a/crates/flowplane/src/cli/mod.rs
+++ b/crates/flowplane/src/cli/mod.rs
@@ -1,6 +1,7 @@
 mod client;
 mod commands;
 mod config;
+pub(crate) mod confirm;
 pub(crate) mod output;
 pub(crate) mod schema;
 

--- a/crates/flowplane/src/cli/output.rs
+++ b/crates/flowplane/src/cli/output.rs
@@ -44,6 +44,45 @@ pub(crate) fn render_error(
     anyhow::Error::new(CliError::new(exit_code_for_status(status)))
 }
 
+/// Render a revision conflict (CLI-R-47): the same structured error envelope as any HTTP
+/// failure, enriched so it names BOTH the revision the client attempted (`attempted_revision`)
+/// and the server's current one (carried in the server `message`), plus a recovery hint.
+pub(crate) fn render_revision_conflict(
+    global: &GlobalOptions,
+    status: StatusCode,
+    request_id: Option<String>,
+    text: &str,
+    attempted: i64,
+) -> anyhow::Error {
+    let env = revision_conflict_envelope(status, request_id, text, attempted);
+    emit_error_envelope(global, &env);
+    anyhow::Error::new(CliError::new(exit_code_for_status(status)))
+}
+
+/// Pure builder for the revision-conflict envelope (CLI-R-47): the standard error envelope
+/// plus `attempted_revision` and a recovery hint. The server's current revision rides along
+/// in the existing `message`/body.
+fn revision_conflict_envelope(
+    status: StatusCode,
+    request_id: Option<String>,
+    text: &str,
+    attempted: i64,
+) -> Value {
+    let mut env = error_envelope(status, request_id, text);
+    if let Value::Object(obj) = &mut env {
+        obj.insert("attempted_revision".into(), Value::Number(attempted.into()));
+        obj.insert(
+            "hint".into(),
+            Value::String(format!(
+                "stale revision: you sent revision {attempted}, but the resource has since \
+                 changed (see message for the current revision); re-read it, or omit \
+                 --revision to let the CLI read-modify-write"
+            )),
+        );
+    }
+    env
+}
+
 /// Render a transport/network failure (connection refused, DNS, TLS, timeout) through the
 /// same structured envelope as HTTP errors (CLI-R-30): no raw `eprintln!("{err:?}")`.
 /// Transport failures are always `retryable: true` and exit `7` (CLI-R-31/32).
@@ -796,6 +835,33 @@ mod tests {
             assert!(value.get("code").is_some());
             assert!(value.get("message").is_some());
         }
+    }
+
+    #[test]
+    fn revision_conflict_envelope_names_both_revisions() {
+        // Server 409 body carries the current revision in its message; the CLI adds the
+        // attempted revision + a recovery hint (CLI-R-47).
+        let env = revision_conflict_envelope(
+            StatusCode::CONFLICT,
+            Some("req-9".into()),
+            r#"{"code":"conflict","message":"revision mismatch: current revision is 5"}"#,
+            3,
+        );
+        assert_eq!(env["status"], 409);
+        assert_eq!(env["attempted_revision"], 3);
+        assert!(
+            env["message"]
+                .as_str()
+                .unwrap()
+                .contains("current revision is 5"),
+            "server's current revision must survive in the message: {env}"
+        );
+        assert!(
+            env["hint"].as_str().unwrap().contains("revision 3"),
+            "hint must name the attempted revision: {env}"
+        );
+        // 409 maps to exit 4 (not-found/conflict/precondition).
+        assert_eq!(exit_code_for_status(StatusCode::CONFLICT), 4);
     }
 
     #[test]

--- a/crates/flowplane/src/cli/output.rs
+++ b/crates/flowplane/src/cli/output.rs
@@ -111,11 +111,91 @@ pub(crate) fn exit_code_for_status(status: StatusCode) -> i32 {
     }
 }
 
-pub(crate) fn render(global: &GlobalOptions, value: &Value) -> Result<()> {
+/// JSON output-contract version (CLI-R-15). Integer, independent of the product semver;
+/// bumped only on a breaking change to the `-o json`/`-o yaml` envelope shape.
+pub(crate) const SCHEMA_VERSION: u64 = 1;
+
+/// Wrap a payload in the Option-A typed envelope `{ schemaVersion, kind, data }` (CLI-R-15).
+pub(crate) fn envelope(kind: &str, data: &Value) -> Value {
+    serde_json::json!({
+        "schemaVersion": SCHEMA_VERSION,
+        "kind": kind,
+        "data": data,
+    })
+}
+
+/// Derive a stable envelope `kind` from the REST path and response shape (CLI-R-15).
+/// Singular for an object (`cluster`), `…List` for a collection (`clusterList`).
+///
+/// Any `?query` is stripped first. For a list the collection is the trailing path segment.
+/// For an object the noun is the nearest-to-the-end *plural* segment (the governing
+/// collection) — so item reads (`…/clusters/{name}`), creates (`POST …/clusters`), and
+/// action sub-routes (`POST …/clusters/{name}/rotate`) all resolve to `cluster` rather than
+/// to an id or a verb. If no plural segment exists the trailing segment is used as-is.
+pub(crate) fn derive_kind(path: &str, value: &Value) -> String {
+    let path = path.split(['?', '#']).next().unwrap_or(path);
+    let mut segments: Vec<&str> = path
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .skip_while(|s| matches!(*s, "api" | "v1"))
+        .collect();
+    // Drop a leading `teams/{team}` or `orgs/{org}` scoping pair when a resource follows it,
+    // so the (plural) scope segment is never mistaken for the resource noun.
+    if segments.len() > 2 && matches!(segments[0], "teams" | "orgs") {
+        segments.drain(0..2);
+    }
+    let is_list = value.is_array() || value.get("items").map(Value::is_array).unwrap_or(false);
+    if is_list {
+        let noun = segments.last().copied().unwrap_or("result");
+        return format!("{}List", singularize(noun));
+    }
+    // Object: prefer the nearest-to-end plural (collection) segment; else the trailing segment.
+    let mut noun = segments.last().copied().unwrap_or("result");
+    for seg in segments.iter().rev() {
+        if singularize(seg).as_str() != *seg {
+            noun = *seg;
+            break;
+        }
+    }
+    singularize(noun)
+}
+
+/// Convert a plural resource segment to a camelCase singular kind (`route-configs` →
+/// `routeConfig`, `policies` → `policy`).
+fn singularize(segment: &str) -> String {
+    let camel = to_lower_camel(segment);
+    if let Some(stem) = camel.strip_suffix("ies") {
+        format!("{stem}y")
+    } else if camel.ends_with("ss") {
+        camel
+    } else if let Some(stem) = camel.strip_suffix('s') {
+        stem.to_string()
+    } else {
+        camel
+    }
+}
+
+fn to_lower_camel(segment: &str) -> String {
+    let mut out = String::with_capacity(segment.len());
+    let mut upper_next = false;
+    for ch in segment.chars() {
+        if ch == '-' || ch == '_' {
+            upper_next = true;
+        } else if upper_next {
+            out.extend(ch.to_uppercase());
+            upper_next = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+pub(crate) fn render(global: &GlobalOptions, kind: &str, value: &Value) -> Result<()> {
     let text = match global.format() {
-        OutputFormat::Json => serde_json::to_string_pretty(value)?,
-        OutputFormat::Yaml => yaml_like(value, 0),
-        OutputFormat::Table | OutputFormat::Wide => table(value),
+        OutputFormat::Json => serde_json::to_string_pretty(&envelope(kind, value))?,
+        OutputFormat::Yaml => yaml_like(&envelope(kind, value), 0),
+        OutputFormat::Table | OutputFormat::Wide => table_styled(value, global.use_color()),
     };
     if let Some(out) = &global.out {
         fs::write(out, text).with_context(|| format!("write {}", out.display()))?;
@@ -125,18 +205,23 @@ pub(crate) fn render(global: &GlobalOptions, value: &Value) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
 pub(crate) fn table(value: &Value) -> String {
+    table_styled(value, false)
+}
+
+pub(crate) fn table_styled(value: &Value, color: bool) -> String {
     if let Some(flattened) = flatten_xds_status(value) {
-        return table(&flattened);
+        return table_styled(&flattened, color);
     }
     if let Some(flattened) = flatten_ops_trace(value) {
-        return table(&flattened);
+        return table_styled(&flattened, color);
     }
     if let Some(flattened) = flatten_expose(value) {
-        return table(&flattened);
+        return table_styled(&flattened, color);
     }
     if let Some(flattened) = flatten_status_row(value) {
-        return table(&flattened);
+        return table_styled(&flattened, color);
     }
     let rows = if let Some(items) = value.get("items").and_then(Value::as_array) {
         items.clone()
@@ -186,7 +271,12 @@ pub(crate) fn table(value: &Value) -> String {
                 .unwrap_or(0)
         })
         .collect::<Vec<_>>();
-    let mut out = format_row(&headers, &widths);
+    let header_row = format_row(&headers, &widths);
+    let mut out = if color {
+        format!("\x1b[1m{header_row}\x1b[0m")
+    } else {
+        header_row
+    };
     for row in matrix {
         out.push('\n');
         out.push_str(&format_row(&row, &widths));
@@ -545,6 +635,7 @@ fn resource_label(value: &Value) -> Option<String> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -589,5 +680,89 @@ mod tests {
         assert_eq!(value["code"], "502");
         assert_eq!(value["message"], "upstream unavailable");
         assert_eq!(value["status"], 502);
+    }
+
+    #[test]
+    fn envelope_wraps_payload_with_integer_schema_version_and_kind() {
+        let data = serde_json::json!({ "name": "demo", "revision": 3 });
+        let env = envelope("cluster", &data);
+        assert_eq!(env["schemaVersion"], Value::Number(SCHEMA_VERSION.into()));
+        assert!(
+            env["schemaVersion"].is_u64(),
+            "schemaVersion must be an integer"
+        );
+        assert_eq!(env["kind"], "cluster");
+        assert_eq!(env["data"], data);
+        // Exactly the three contract keys, nothing leaked at the top level.
+        let keys: BTreeSet<&str> = env
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(keys, BTreeSet::from(["schemaVersion", "kind", "data"]));
+    }
+
+    #[test]
+    fn derive_kind_singular_for_object_list_for_collection() {
+        let obj = serde_json::json!({ "name": "c1" });
+        let arr = serde_json::json!([{ "name": "c1" }]);
+        let items = serde_json::json!({ "items": [{ "name": "c1" }] });
+
+        // item read: trailing id ignored, collection precedes it.
+        assert_eq!(
+            derive_kind("/api/v1/teams/payments/clusters/c1", &obj),
+            "cluster"
+        );
+        // collection list / create.
+        assert_eq!(
+            derive_kind("/api/v1/teams/payments/clusters", &arr),
+            "clusterList"
+        );
+        assert_eq!(
+            derive_kind("/api/v1/teams/payments/clusters", &items),
+            "clusterList"
+        );
+        assert_eq!(
+            derive_kind("/api/v1/teams/payments/clusters", &obj),
+            "cluster"
+        );
+        // top-level collections.
+        assert_eq!(derive_kind("/api/v1/orgs/acme/teams", &arr), "teamList");
+        assert_eq!(derive_kind("/api/v1/orgs", &arr), "orgList");
+        assert_eq!(derive_kind("/api/v1/orgs/acme", &obj), "org");
+        // hyphenated/`ies` plurals singularize to camelCase.
+        assert_eq!(
+            derive_kind("/api/v1/teams/p/route-configs/r1", &obj),
+            "routeConfig"
+        );
+        assert_eq!(
+            derive_kind("/api/v1/teams/p/rate-limit/d/policies", &arr),
+            "policyList"
+        );
+        // query strings are stripped, not leaked into the kind.
+        assert_eq!(
+            derive_kind("/api/v1/teams/p/ai/usage?from=2026-01-01", &obj),
+            "usage"
+        );
+        assert_eq!(
+            derive_kind("/api/v1/teams/p/learning-sessions?status=active", &arr),
+            "learningSessionList"
+        );
+        // action sub-routes resolve to the governing collection, not the verb.
+        assert_eq!(
+            derive_kind("/api/v1/teams/p/secrets/s1/rotate", &obj),
+            "secret"
+        );
+    }
+
+    #[test]
+    fn table_styled_emits_no_ansi_when_color_disabled() {
+        let value = serde_json::json!([{ "name": "demo", "revision": 1 }]);
+        let plain = table_styled(&value, false);
+        assert!(!plain.contains('\x1b'), "no-color table must be ANSI-free");
+        let colored = table_styled(&value, true);
+        assert!(colored.contains("\x1b[1m"), "colored header should be bold");
+        assert!(colored.contains("\x1b[0m"), "colored header should reset");
     }
 }

--- a/crates/flowplane/src/cli/output.rs
+++ b/crates/flowplane/src/cli/output.rs
@@ -6,24 +6,32 @@ use std::collections::BTreeSet;
 use std::fmt;
 use std::fs;
 
+/// A CLI error whose structured envelope has already been rendered to stderr (CLI-R-30).
+///
+/// It carries only the resolved process exit code (CLI-R-31); `main` downcasts to this type
+/// and exits with `exit_code()` without re-printing, so no raw `{err:?}` trailer leaks.
 #[derive(Debug)]
-pub(crate) struct CliHttpError {
-    status: StatusCode,
+pub(crate) struct CliError {
+    exit_code: i32,
 }
 
-impl CliHttpError {
+impl CliError {
+    pub(crate) fn new(exit_code: i32) -> Self {
+        Self { exit_code }
+    }
+
     pub(crate) fn exit_code(&self) -> i32 {
-        exit_code_for_status(self.status)
+        self.exit_code
     }
 }
 
-impl fmt::Display for CliHttpError {
+impl fmt::Display for CliError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "request failed with status {}", self.status)
+        write!(f, "command failed (exit {})", self.exit_code)
     }
 }
 
-impl std::error::Error for CliHttpError {}
+impl std::error::Error for CliError {}
 
 pub(crate) fn render_error(
     global: &GlobalOptions,
@@ -31,30 +39,65 @@ pub(crate) fn render_error(
     request_id: Option<String>,
     text: &str,
 ) -> anyhow::Error {
-    let (envelope, code, message, hint, request_id) = error_envelope(status, request_id, text);
-    if matches!(global.format(), OutputFormat::Json) {
-        match serde_json::to_string_pretty(&envelope) {
-            Ok(json) => eprintln!("{json}"),
-            Err(_) => eprintln!("{}", envelope),
-        }
-    } else {
-        eprintln!("error ({code}): {message}");
-        if let Some(hint) = hint {
-            eprintln!("  -> {hint}");
-        }
-        if let Some(rid) = request_id {
-            eprintln!("  request id: {rid}");
-        }
-    }
-    anyhow::Error::new(CliHttpError { status })
+    let env = error_envelope(status, request_id, text);
+    emit_error_envelope(global, &env);
+    anyhow::Error::new(CliError::new(exit_code_for_status(status)))
 }
 
-fn error_envelope(
-    status: StatusCode,
-    request_id: Option<String>,
-    text: &str,
-) -> (Value, String, String, Option<String>, Option<String>) {
-    let parsed = serde_json::from_str::<Value>(text).ok();
+/// Render a transport/network failure (connection refused, DNS, TLS, timeout) through the
+/// same structured envelope as HTTP errors (CLI-R-30): no raw `eprintln!("{err:?}")`.
+/// Transport failures are always `retryable: true` and exit `7` (CLI-R-31/32).
+pub(crate) fn render_transport_error(
+    global: &GlobalOptions,
+    err: &reqwest::Error,
+) -> anyhow::Error {
+    let code = if err.is_timeout() {
+        "timeout"
+    } else if err.is_connect() {
+        "connection_failed"
+    } else {
+        "transport_error"
+    };
+    let env = serde_json::json!({
+        "code": code,
+        "message": err.to_string(),
+        "retryable": true,
+    });
+    emit_error_envelope(global, &env);
+    anyhow::Error::new(CliError::new(7))
+}
+
+/// Print an already-built error envelope to **stderr** (CLI-R-30): JSON under `-o json`,
+/// YAML under `-o yaml`, otherwise a compact prose form. stdout is left untouched.
+pub(crate) fn emit_error_envelope(global: &GlobalOptions, env: &Value) {
+    match global.format() {
+        OutputFormat::Json => match serde_json::to_string_pretty(env) {
+            Ok(json) => eprintln!("{json}"),
+            Err(_) => eprintln!("{env}"),
+        },
+        OutputFormat::Yaml => eprintln!("{}", yaml_like(env, 0)),
+        OutputFormat::Table | OutputFormat::Wide => {
+            let field = |key: &str| env.get(key).and_then(Value::as_str);
+            let code = field("code").unwrap_or("error");
+            let message = field("message").unwrap_or("request failed");
+            eprintln!("error ({code}): {message}");
+            if let Some(hint) = field("hint") {
+                eprintln!("  -> {hint}");
+            }
+            if let Some(rid) = field("request_id") {
+                eprintln!("  request id: {rid}");
+            }
+        }
+    }
+}
+
+fn error_envelope(status: StatusCode, request_id: Option<String>, text: &str) -> Value {
+    // Only a JSON *object* error body is adopted as the envelope base; a string/array/number
+    // (or non-JSON text) body falls back to a freshly-built object so the contract shape
+    // (CLI-R-30) holds for every HTTP error regardless of what the server/proxy returned.
+    let parsed = serde_json::from_str::<Value>(text)
+        .ok()
+        .filter(Value::is_object);
     let code = parsed
         .as_ref()
         .and_then(|v| v.get("code"))
@@ -67,11 +110,17 @@ fn error_envelope(
         .and_then(Value::as_str)
         .unwrap_or(text)
         .to_string();
+    // CLI-R-33: synthesize the login hint on 401 when the server omits one; 403 keeps the
+    // server-supplied hint (which already names the (resource, action) via deny_to_error).
     let hint = parsed
         .as_ref()
         .and_then(|v| v.get("hint"))
         .and_then(Value::as_str)
-        .map(str::to_string);
+        .map(str::to_string)
+        .or_else(|| {
+            (status == StatusCode::UNAUTHORIZED)
+                .then(|| "run `flowplane auth login` to authenticate".to_string())
+        });
     let request_id = request_id.or_else(|| {
         parsed
             .as_ref()
@@ -80,33 +129,71 @@ fn error_envelope(
             .map(str::to_string)
     });
 
-    let mut envelope = parsed.unwrap_or_else(|| {
-        serde_json::json!({
-            "code": code,
-            "message": message,
-        })
-    });
+    let mut envelope = parsed.unwrap_or_else(|| serde_json::json!({}));
     if let Value::Object(obj) = &mut envelope {
         obj.entry("code").or_insert(Value::String(code.clone()));
         obj.entry("message")
             .or_insert(Value::String(message.clone()));
         obj.entry("status")
             .or_insert(Value::Number(status.as_u16().into()));
+        // CLI-R-32: classify transient (429/5xx) vs terminal failures.
+        obj.insert("retryable".into(), Value::Bool(is_retryable(status)));
+        if let Some(hint) = &hint {
+            obj.entry("hint").or_insert(Value::String(hint.clone()));
+        }
         if let Some(rid) = &request_id {
             obj.entry("request_id")
                 .or_insert(Value::String(rid.clone()));
         }
     }
-    (envelope, code, message, hint, request_id)
+    envelope
 }
 
+/// The human message for a non-success HTTP response (object `message`, else the body text,
+/// else the status), for callers that aggregate failures instead of rendering each one.
+pub(crate) fn error_message(status: StatusCode, text: &str) -> String {
+    serde_json::from_str::<Value>(text)
+        .ok()
+        .filter(Value::is_object)
+        .and_then(|v| v.get("message").and_then(Value::as_str).map(str::to_string))
+        .unwrap_or_else(|| {
+            if text.trim().is_empty() {
+                status.to_string()
+            } else {
+                text.to_string()
+            }
+        })
+}
+
+/// Build the aggregate error envelope for an `apply` partial/total failure (CLI-R-30): one
+/// structured document on stderr listing each failed resource, instead of per-subrequest
+/// prints or a raw `{err:?}` trailer.
+pub(crate) fn apply_error_envelope(failures: Vec<Value>) -> Value {
+    serde_json::json!({
+        "code": "apply_failed",
+        "message": format!("{} resource(s) failed to apply", failures.len()),
+        "retryable": false,
+        "failures": failures,
+    })
+}
+
+/// Whether a failed HTTP status is worth retrying (CLI-R-32): rate-limit and server errors
+/// are transient; 4xx terminal. Transport failures are handled in `render_transport_error`.
+pub(crate) fn is_retryable(status: StatusCode) -> bool {
+    status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
+}
+
+/// Map an HTTP status to the CLI's scriptable exit code (CLI-R-31): `3` auth (401/403),
+/// `4` not-found/conflict/precondition (404/409/412), `5` validation (400/422), `6`
+/// rate-limited (429), `7` server (5xx), `1` otherwise. Usage errors (`2`) are clap-native;
+/// transport failures (`7`) are assigned in `render_transport_error`.
 pub(crate) fn exit_code_for_status(status: StatusCode) -> i32 {
     match status {
-        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => 2,
-        StatusCode::NOT_FOUND | StatusCode::CONFLICT | StatusCode::PRECONDITION_FAILED => 3,
-        StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY => 4,
-        StatusCode::TOO_MANY_REQUESTS => 5,
-        s if s.is_server_error() => 6,
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => 3,
+        StatusCode::NOT_FOUND | StatusCode::CONFLICT | StatusCode::PRECONDITION_FAILED => 4,
+        StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY => 5,
+        StatusCode::TOO_MANY_REQUESTS => 6,
+        s if s.is_server_error() => 7,
         _ => 1,
     }
 }
@@ -641,45 +728,90 @@ mod tests {
 
     #[test]
     fn http_statuses_map_to_scriptable_exit_codes() {
-        assert_eq!(exit_code_for_status(StatusCode::UNAUTHORIZED), 2);
-        assert_eq!(exit_code_for_status(StatusCode::FORBIDDEN), 2);
-        assert_eq!(exit_code_for_status(StatusCode::NOT_FOUND), 3);
-        assert_eq!(exit_code_for_status(StatusCode::CONFLICT), 3);
-        assert_eq!(exit_code_for_status(StatusCode::BAD_REQUEST), 4);
-        assert_eq!(exit_code_for_status(StatusCode::TOO_MANY_REQUESTS), 5);
-        assert_eq!(exit_code_for_status(StatusCode::INTERNAL_SERVER_ERROR), 6);
+        // CLI-R-31 0–7 table: auth=3, not-found/conflict/precondition=4, validation=5,
+        // rate-limited=6, server=7, generic=1.
+        assert_eq!(exit_code_for_status(StatusCode::UNAUTHORIZED), 3);
+        assert_eq!(exit_code_for_status(StatusCode::FORBIDDEN), 3);
+        assert_eq!(exit_code_for_status(StatusCode::NOT_FOUND), 4);
+        assert_eq!(exit_code_for_status(StatusCode::CONFLICT), 4);
+        assert_eq!(exit_code_for_status(StatusCode::PRECONDITION_FAILED), 4);
+        assert_eq!(exit_code_for_status(StatusCode::BAD_REQUEST), 5);
+        assert_eq!(exit_code_for_status(StatusCode::UNPROCESSABLE_ENTITY), 5);
+        assert_eq!(exit_code_for_status(StatusCode::TOO_MANY_REQUESTS), 6);
+        assert_eq!(exit_code_for_status(StatusCode::INTERNAL_SERVER_ERROR), 7);
+        assert_eq!(exit_code_for_status(StatusCode::BAD_GATEWAY), 7);
+        assert_eq!(exit_code_for_status(StatusCode::IM_A_TEAPOT), 1);
+    }
+
+    #[test]
+    fn retryable_classifies_transient_vs_terminal() {
+        assert!(is_retryable(StatusCode::TOO_MANY_REQUESTS));
+        assert!(is_retryable(StatusCode::SERVICE_UNAVAILABLE));
+        assert!(is_retryable(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(!is_retryable(StatusCode::NOT_FOUND));
+        assert!(!is_retryable(StatusCode::BAD_REQUEST));
+        assert!(!is_retryable(StatusCode::UNAUTHORIZED));
     }
 
     #[test]
     fn error_envelope_preserves_server_json_and_request_id_header() {
-        let (value, code, message, hint, request_id) = error_envelope(
+        let value = error_envelope(
             StatusCode::NOT_FOUND,
             Some("req-1".into()),
             r#"{"code":"not_found","message":"missing","hint":"check name"}"#,
         );
 
-        assert_eq!(code, "not_found");
-        assert_eq!(message, "missing");
-        assert_eq!(hint.as_deref(), Some("check name"));
-        assert_eq!(request_id.as_deref(), Some("req-1"));
         assert_eq!(value["code"], "not_found");
         assert_eq!(value["message"], "missing");
+        assert_eq!(value["hint"], "check name");
         assert_eq!(value["status"], 404);
         assert_eq!(value["request_id"], "req-1");
+        assert_eq!(value["retryable"], false);
     }
 
     #[test]
-    fn error_envelope_wraps_plain_text_failures() {
-        let (value, code, message, hint, request_id) =
-            error_envelope(StatusCode::BAD_GATEWAY, None, "upstream unavailable");
+    fn error_envelope_wraps_plain_text_failures_as_retryable_server_error() {
+        let value = error_envelope(StatusCode::BAD_GATEWAY, None, "upstream unavailable");
 
-        assert_eq!(code, "502");
-        assert_eq!(message, "upstream unavailable");
-        assert_eq!(hint, None);
-        assert_eq!(request_id, None);
         assert_eq!(value["code"], "502");
         assert_eq!(value["message"], "upstream unavailable");
         assert_eq!(value["status"], 502);
+        assert_eq!(value["retryable"], true);
+        assert!(value.get("hint").is_none());
+        assert!(value.get("request_id").is_none());
+    }
+
+    #[test]
+    fn error_envelope_wraps_non_object_json_body_in_a_fresh_object() {
+        // A server/proxy returning a JSON array/string/number must still yield the contract
+        // object shape, not the raw value (CLI-R-30).
+        for body in [r#"["boom"]"#, r#""boom""#, "42", "true"] {
+            let value = error_envelope(StatusCode::BAD_GATEWAY, None, body);
+            assert!(
+                value.is_object(),
+                "body {body:?} must produce an object envelope"
+            );
+            assert_eq!(value["status"], 502);
+            assert_eq!(value["retryable"], true);
+            assert!(value.get("code").is_some());
+            assert!(value.get("message").is_some());
+        }
+    }
+
+    #[test]
+    fn error_envelope_synthesizes_login_hint_on_401_without_server_hint() {
+        let value = error_envelope(StatusCode::UNAUTHORIZED, None, "unauthorized");
+        assert_eq!(value["status"], 401);
+        assert_eq!(value["retryable"], false);
+        assert_eq!(value["hint"], "run `flowplane auth login` to authenticate");
+
+        // A server-supplied hint is preserved, not overwritten.
+        let value = error_envelope(
+            StatusCode::UNAUTHORIZED,
+            None,
+            r#"{"message":"nope","hint":"use a fresh token"}"#,
+        );
+        assert_eq!(value["hint"], "use a fresh token");
     }
 
     #[test]

--- a/crates/flowplane/src/cli/output.rs
+++ b/crates/flowplane/src/cli/output.rs
@@ -250,6 +250,39 @@ pub(crate) fn envelope(kind: &str, data: &Value) -> Value {
     })
 }
 
+/// Project a payload to only the requested field names (CLI-R-51). Applied to the resource
+/// data: a list (array, or an object wrapping an `items` array) projects every item; a
+/// single object keeps only the requested keys; scalars are returned unchanged.
+pub(crate) fn project_fields(value: &Value, fields: &[String]) -> Value {
+    match value {
+        Value::Array(items) => Value::Array(items.iter().map(|v| project_one(v, fields)).collect()),
+        Value::Object(map) if map.get("items").map(Value::is_array).unwrap_or(false) => {
+            let mut out = map.clone();
+            if let Some(Value::Array(items)) = out.get_mut("items") {
+                *items = items.iter().map(|v| project_one(v, fields)).collect();
+            }
+            Value::Object(out)
+        }
+        Value::Object(_) => project_one(value, fields),
+        other => other.clone(),
+    }
+}
+
+fn project_one(value: &Value, fields: &[String]) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut out = serde_json::Map::new();
+            for key in fields {
+                if let Some(v) = map.get(key) {
+                    out.insert(key.clone(), v.clone());
+                }
+            }
+            Value::Object(out)
+        }
+        other => other.clone(),
+    }
+}
+
 /// Derive a stable envelope `kind` from the REST path and response shape (CLI-R-15).
 /// Singular for an object (`cluster`), `…List` for a collection (`clusterList`).
 ///
@@ -318,6 +351,15 @@ fn to_lower_camel(segment: &str) -> String {
 }
 
 pub(crate) fn render(global: &GlobalOptions, kind: &str, value: &Value) -> Result<()> {
+    // CLI-R-51: `--fields` projects inside `data` (per item for lists); the envelope
+    // metadata (schemaVersion/kind) is added afterwards and always survives.
+    let projected;
+    let value = if global.fields.is_empty() {
+        value
+    } else {
+        projected = project_fields(value, &global.fields);
+        &projected
+    };
     let text = match global.format() {
         OutputFormat::Json => serde_json::to_string_pretty(&envelope(kind, value))?,
         OutputFormat::Yaml => yaml_like(&envelope(kind, value), 0),
@@ -952,6 +994,37 @@ mod tests {
             derive_kind("/api/v1/teams/p/secrets/s1/rotate", &obj),
             "secret"
         );
+    }
+
+    #[test]
+    fn project_fields_keeps_only_requested_keys_inside_data() {
+        let fields = vec!["name".to_string(), "revision".to_string()];
+        // single object
+        let obj = serde_json::json!({ "name": "c1", "revision": 3, "service_name": "svc" });
+        assert_eq!(
+            project_fields(&obj, &fields),
+            serde_json::json!({ "name": "c1", "revision": 3 })
+        );
+        // array (per item)
+        let arr = serde_json::json!([
+            { "name": "a", "revision": 1, "x": 9 },
+            { "name": "b", "revision": 2, "x": 8 }
+        ]);
+        assert_eq!(
+            project_fields(&arr, &fields),
+            serde_json::json!([{ "name": "a", "revision": 1 }, { "name": "b", "revision": 2 }])
+        );
+        // object wrapping an `items` array
+        let items =
+            serde_json::json!({ "items": [{ "name": "a", "revision": 1, "x": 9 }], "total": 1 });
+        let projected = project_fields(&items, &fields);
+        assert_eq!(
+            projected["items"],
+            serde_json::json!([{ "name": "a", "revision": 1 }])
+        );
+        // a requested key that is absent is simply omitted (no null injected)
+        let missing = project_fields(&obj, &["name".to_string(), "nope".to_string()]);
+        assert_eq!(missing, serde_json::json!({ "name": "c1" }));
     }
 
     #[test]

--- a/crates/flowplane/src/cli/schema.rs
+++ b/crates/flowplane/src/cli/schema.rs
@@ -1,0 +1,162 @@
+//! Machine-readable CLI catalog (CLI-R-50).
+//!
+//! `flowplane schema` serializes the whole clap command tree to JSON so generated consumers
+//! (shell completion, the future MCP tool catalog, docs) derive the CLI contract from one
+//! source instead of scraping `--help`. See ADR FP-DEC-0003.
+
+use clap::{ArgAction, Command};
+use serde_json::{json, Value};
+
+/// Catalog-format version carried *inside* `data` (distinct from the outer envelope's
+/// `schemaVersion`). Bumped only on a breaking change to this schema's shape.
+pub(crate) const CATALOG_VERSION: u64 = 1;
+
+/// Build the `data` payload for `flowplane schema`: `{ catalogVersion, command }` where
+/// `command` is the recursively-serialized root command tree.
+pub(crate) fn cli_schema(root: &Command) -> Value {
+    json!({
+        "catalogVersion": CATALOG_VERSION,
+        "command": command_to_value(root),
+    })
+}
+
+fn command_to_value(cmd: &Command) -> Value {
+    let args = cmd.get_arguments().map(arg_to_value).collect::<Vec<_>>();
+    let subcommands = cmd
+        .get_subcommands()
+        .map(command_to_value)
+        .collect::<Vec<_>>();
+    json!({
+        "name": cmd.get_name(),
+        "about": cmd.get_about().map(|s| s.to_string()),
+        "args": args,
+        "subcommands": subcommands,
+    })
+}
+
+fn arg_to_value(arg: &clap::Arg) -> Value {
+    // A flag is a boolean switch; anything that takes a value reports its placeholder names.
+    let takes_value = !matches!(
+        arg.get_action(),
+        ArgAction::SetTrue | ArgAction::SetFalse | ArgAction::Help | ArgAction::Version
+    );
+    let possible_values = arg
+        .get_possible_values()
+        .iter()
+        .map(|pv| pv.get_name().to_string())
+        .collect::<Vec<_>>();
+    let defaults = arg
+        .get_default_values()
+        .iter()
+        .map(|v| v.to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+    let value_names = arg
+        .get_value_names()
+        .map(|names| names.iter().map(|n| n.to_string()).collect::<Vec<_>>())
+        .unwrap_or_default();
+    json!({
+        "name": arg.get_id().as_str(),
+        "long": arg.get_long(),
+        "short": arg.get_short().map(|c| c.to_string()),
+        "help": arg.get_help().map(|s| s.to_string()),
+        "required": arg.is_required_set(),
+        "global": arg.is_global_set(),
+        "takesValue": takes_value,
+        "type": value_type(arg, takes_value, !possible_values.is_empty()),
+        "valueNames": value_names,
+        "possibleValues": possible_values,
+        "defaults": defaults,
+    })
+}
+
+/// A coarse value-type label for an argument (CLI-R-50: "types/enums"). A flag is `boolean`;
+/// an arg with possible values is `enum`; otherwise the value-parser's `TypeId` is matched
+/// against the known scalar types (this comparison is reliable in release builds, unlike the
+/// parser's debug-only type name). Unknown parsers fall back to `string`.
+fn value_type(arg: &clap::Arg, takes_value: bool, is_enum: bool) -> &'static str {
+    if !takes_value {
+        return "boolean";
+    }
+    if is_enum {
+        return "enum";
+    }
+    let tid = arg.get_value_parser().type_id();
+    for (label, parser) in known_value_parsers() {
+        if tid == parser.type_id() {
+            return label;
+        }
+    }
+    "string"
+}
+
+#[allow(clippy::useless_conversion)] // `.into()` is needed for the typed parsers; identity for the rest.
+fn known_value_parsers() -> Vec<(&'static str, clap::builder::ValueParser)> {
+    use clap::value_parser;
+    vec![
+        ("integer", value_parser!(i64).into()),
+        ("integer", value_parser!(i32).into()),
+        ("integer", value_parser!(u64).into()),
+        ("integer", value_parser!(u32).into()),
+        ("integer", value_parser!(u16).into()),
+        ("integer", value_parser!(u8).into()),
+        ("number", value_parser!(f64).into()),
+        ("boolean", value_parser!(bool).into()),
+        ("path", value_parser!(std::path::PathBuf).into()),
+        ("string", value_parser!(String).into()),
+    ]
+}
+
+/// The set of top-level subcommand names in the schema, for the drift guard.
+#[cfg(test)]
+pub(crate) fn top_level_command_names(schema: &Value) -> Vec<String> {
+    schema["command"]["subcommands"]
+        .as_array()
+        .map(|subs| {
+            subs.iter()
+                .filter_map(|s| s["name"].as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use clap::{value_parser, Arg, ArgAction, Command};
+
+    #[test]
+    fn arg_value_types_distinguish_string_integer_bool_enum() {
+        let cmd = Command::new("t")
+            .arg(Arg::new("name"))
+            .arg(
+                Arg::new("count")
+                    .long("count")
+                    .value_parser(value_parser!(i64)),
+            )
+            .arg(
+                Arg::new("port")
+                    .long("port")
+                    .value_parser(value_parser!(u16)),
+            )
+            .arg(Arg::new("flag").long("flag").action(ArgAction::SetTrue))
+            .arg(Arg::new("mode").long("mode").value_parser(["dev", "mtls"]));
+        let schema = cli_schema(&cmd);
+        let args = schema["command"]["args"].as_array().unwrap();
+        let ty = |name: &str| {
+            args.iter()
+                .find(|a| a["name"] == name)
+                .and_then(|a| a["type"].as_str())
+                .unwrap()
+                .to_string()
+        };
+        assert_eq!(ty("name"), "string");
+        assert_eq!(ty("count"), "integer");
+        assert_eq!(ty("port"), "integer");
+        assert_eq!(ty("flag"), "boolean");
+        assert_eq!(ty("mode"), "enum");
+        // enum values are still enumerated under possibleValues.
+        let mode = args.iter().find(|a| a["name"] == "mode").unwrap();
+        assert_eq!(mode["possibleValues"], serde_json::json!(["dev", "mtls"]));
+    }
+}

--- a/crates/flowplane/src/main.rs
+++ b/crates/flowplane/src/main.rs
@@ -227,6 +227,33 @@ mod tests {
     }
 
     #[test]
+    fn revision_is_a_global_option_on_every_update_and_delete() {
+        // CLI-R-47: `--revision` must be uniform across every update/delete. It is a global
+        // arg, so it is accepted on every subcommand by construction — assert that invariant.
+        let cmd = Cli::command();
+        let revision = cmd
+            .get_arguments()
+            .find(|a| a.get_id() == "revision")
+            .expect("--revision global arg must exist");
+        assert!(
+            revision.is_global_set(),
+            "--revision must be global so it is present on every update/delete"
+        );
+        // And it actually parses on representative update + delete forms.
+        Cli::try_parse_from([
+            "flowplane",
+            "--revision",
+            "3",
+            "cluster",
+            "delete",
+            "x",
+            "--team",
+            "t",
+        ])
+        .expect("--revision parses on delete");
+    }
+
+    #[test]
     fn json_flag_conflicts_with_explicit_output() {
         // CLI-R-11: `-o/--output` is the single format selector; `--json` is an alias for
         // `-o json` and must not be combined with an explicit `-o`.

--- a/crates/flowplane/src/main.rs
+++ b/crates/flowplane/src/main.rs
@@ -148,9 +148,12 @@ enum DbCommand {
 
 fn main() {
     if let Err(err) = run() {
-        if let Some(http) = err.downcast_ref::<cli::output::CliHttpError>() {
-            std::process::exit(http.exit_code());
+        // A CliError has already rendered its structured envelope to stderr (CLI-R-30);
+        // exit with its resolved code (CLI-R-31) without re-printing.
+        if let Some(cli_err) = err.downcast_ref::<cli::output::CliError>() {
+            std::process::exit(cli_err.exit_code());
         }
+        // Fallback: an unclassified internal/local error → generic exit 1 (CLI-R-31).
         eprintln!("Error: {err:?}");
         std::process::exit(1);
     }

--- a/crates/flowplane/src/main.rs
+++ b/crates/flowplane/src/main.rs
@@ -205,10 +205,11 @@ fn run() -> anyhow::Result<()> {
             clap_complete::generate(shell, &mut command, "flowplane", &mut std::io::stdout());
             Ok(())
         }
-        Command::Version => {
-            println!("{VERSION}");
-            Ok(())
-        }
+        Command::Version => cli::output::render(
+            &cli.client,
+            "version",
+            &serde_json::json!({ "version": VERSION }),
+        ),
     }
 }
 
@@ -220,6 +221,23 @@ mod tests {
     #[test]
     fn command_tree_builds() {
         Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn json_flag_conflicts_with_explicit_output() {
+        // CLI-R-11: `-o/--output` is the single format selector; `--json` is an alias for
+        // `-o json` and must not be combined with an explicit `-o`.
+        let result = Cli::try_parse_from(["flowplane", "-o", "table", "--json", "version"]);
+        assert!(
+            result.is_err(),
+            "--json with explicit -o must be a usage error"
+        );
+        if let Err(err) = result {
+            assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+        }
+        // Either alone parses fine.
+        Cli::try_parse_from(["flowplane", "--json", "version"]).expect("--json alone parses");
+        Cli::try_parse_from(["flowplane", "-o", "json", "version"]).expect("-o json alone parses");
     }
 
     #[test]

--- a/crates/flowplane/src/main.rs
+++ b/crates/flowplane/src/main.rs
@@ -138,6 +138,8 @@ enum Command {
     Completion { shell: Shell },
     /// Print version.
     Version,
+    /// Print the machine-readable CLI schema (the canonical CLI contract; the MCP-derivation seam).
+    Schema,
 }
 
 #[derive(Subcommand)]
@@ -213,6 +215,13 @@ fn run() -> anyhow::Result<()> {
             "version",
             &serde_json::json!({ "version": VERSION }),
         ),
+        // CLI-R-50: short-circuit before any network call — the schema is the CLI's own
+        // structure, serialized from the clap tree.
+        Command::Schema => cli::output::render(
+            &cli.client,
+            "cliSchema",
+            &cli::schema::cli_schema(&Cli::command()),
+        ),
     }
 }
 
@@ -224,6 +233,53 @@ mod tests {
     #[test]
     fn command_tree_builds() {
         Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn schema_has_no_drift_from_the_clap_tree() {
+        // CLI-R-50: the schema is generated FROM Cli::command(); the drift guard asserts every
+        // real top-level command appears in the schema (a future hardcoded list would break).
+        let cmd = Cli::command();
+        let expected: std::collections::BTreeSet<String> = cmd
+            .get_subcommands()
+            .map(|c| c.get_name().to_string())
+            .collect();
+        let schema = cli::schema::cli_schema(&cmd);
+        let actual: std::collections::BTreeSet<String> =
+            cli::schema::top_level_command_names(&schema)
+                .into_iter()
+                .collect();
+        assert_eq!(
+            actual, expected,
+            "flowplane schema drifted from the clap command tree"
+        );
+        // The new `schema` command must itself be in the catalog (not accidentally exempt).
+        assert!(
+            actual.contains("schema"),
+            "`schema` command missing from the catalog"
+        );
+        // Catalog carries its own version distinct from the envelope schemaVersion.
+        assert_eq!(schema["catalogVersion"], cli::schema::CATALOG_VERSION);
+        // Every arg, recursively, carries the documented type/enums/defaults fields (CLI-R-50).
+        fn assert_arg_fields(node: &serde_json::Value) {
+            for arg in node["args"].as_array().expect("args array") {
+                for key in [
+                    "name",
+                    "type",
+                    "required",
+                    "global",
+                    "takesValue",
+                    "possibleValues",
+                    "defaults",
+                ] {
+                    assert!(arg.get(key).is_some(), "arg missing `{key}`: {arg}");
+                }
+            }
+            for sub in node["subcommands"].as_array().expect("subcommands array") {
+                assert_arg_fields(sub);
+            }
+        }
+        assert_arg_fields(&schema["command"]);
     }
 
     #[test]

--- a/crates/flowplane/tests/cli_s1_conformance.rs
+++ b/crates/flowplane/tests/cli_s1_conformance.rs
@@ -298,7 +298,7 @@ async fn delete_json_envelope() {
         .env("FLOWPLANE_SERVER", mock.base_url())
         .env("FLOWPLANE_TOKEN", "t")
         .args([
-            "cluster", "delete", "alpha", "--team", "payments", "-o", "json",
+            "cluster", "delete", "alpha", "--team", "payments", "--yes", "-o", "json",
         ])
         .output()
         .expect("run cluster delete -o json");

--- a/crates/flowplane/tests/cli_s1_conformance.rs
+++ b/crates/flowplane/tests/cli_s1_conformance.rs
@@ -1,0 +1,355 @@
+//! S1 — CLI output-model conformance (black-box).
+//!
+//! These tests drive the *built* `flowplane` binary as a subprocess and assert only against
+//! the documented output contract (CLI-R-10/11/12/15/16). They never look at CLI internals:
+//! every assertion is derived from the acceptance criteria, not the implementation.
+//!
+//! Contract under test:
+//!   * Every `-o json` success payload is exactly `{schemaVersion, kind, data}` (CLI-R-15).
+//!   * `version`, `cluster delete`, `cluster list`, and `apply` all honour `-o json`.
+//!   * `--json` is byte-for-byte identical to `-o json` for the same command (CLI-R-10/11).
+//!   * Under a captured (non-TTY) subprocess and no `-o`, reader output is the JSON envelope;
+//!     an explicit `-o table` overrides that with non-JSON text (CLI-R-12).
+//!   * Table output carries zero ANSI escape bytes under `NO_COLOR=1` / `--no-color` (CLI-R-16).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod common;
+
+use std::path::Path;
+use std::process::Output;
+
+use serde_json::Value;
+
+/// Assert the payload is a JSON object with *exactly* the three envelope keys and nothing else.
+/// Returns the parsed value for further inspection.
+fn assert_exact_envelope(stdout: &[u8]) -> Value {
+    let v: Value = serde_json::from_slice(stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout is not valid JSON ({e}): {:?}",
+            String::from_utf8_lossy(stdout)
+        )
+    });
+    let obj = v
+        .as_object()
+        .unwrap_or_else(|| panic!("envelope is not a JSON object: {v}"));
+    let keys: std::collections::BTreeSet<&str> = obj.keys().map(String::as_str).collect();
+    let expected: std::collections::BTreeSet<&str> =
+        ["schemaVersion", "kind", "data"].into_iter().collect();
+    assert_eq!(
+        keys, expected,
+        "envelope must have EXACTLY {{schemaVersion, kind, data}}, got keys: {keys:?}"
+    );
+    assert!(
+        obj["schemaVersion"].is_i64() || obj["schemaVersion"].is_u64(),
+        "schemaVersion must be an integer, got {}",
+        obj["schemaVersion"]
+    );
+    assert!(
+        obj["kind"].is_string(),
+        "kind must be a string, got {}",
+        obj["kind"]
+    );
+    v
+}
+
+/// Loosely assert envelope shape (three keys present, integer schemaVersion, string kind) without
+/// forbidding extra keys. Used where the contract only requires the keys to be present.
+fn assert_envelope_present(stdout: &[u8]) -> Value {
+    let v: Value = serde_json::from_slice(stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout is not valid JSON ({e}): {:?}",
+            String::from_utf8_lossy(stdout)
+        )
+    });
+    let obj = v
+        .as_object()
+        .unwrap_or_else(|| panic!("envelope is not a JSON object: {v}"));
+    for k in ["schemaVersion", "kind", "data"] {
+        assert!(obj.contains_key(k), "envelope missing key `{k}`: {v}");
+    }
+    assert!(
+        obj["schemaVersion"].is_i64() || obj["schemaVersion"].is_u64(),
+        "schemaVersion must be an integer, got {}",
+        obj["schemaVersion"]
+    );
+    assert!(
+        obj["kind"].is_string(),
+        "kind must be a string, got {}",
+        obj["kind"]
+    );
+    v
+}
+
+fn assert_ok(out: &Output, ctx: &str) {
+    assert!(
+        out.status.success(),
+        "{ctx}: expected exit 0, got {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        !out.stdout.is_empty(),
+        "{ctx}: expected non-empty stdout\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+fn write_cluster_manifest(home: &Path) -> std::path::PathBuf {
+    let path = home.join("alpha.json");
+    let manifest = serde_json::json!({
+        "kind": "cluster",
+        "name": "alpha",
+        "team": "payments",
+        "spec": { "endpoints": [ { "host": "example.com", "port": 80 } ] }
+    });
+    std::fs::write(&path, serde_json::to_vec_pretty(&manifest).unwrap())
+        .expect("write apply manifest");
+    path
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 1 + 2: typed JSON envelope, exact three keys, for `cluster list -o json`.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cluster_list_json_is_exact_typed_envelope() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args(["-o", "json", "cluster", "list", "--team", "payments"])
+        .output()
+        .expect("run cluster list -o json");
+
+    assert_ok(&out, "cluster list -o json");
+    let v = assert_exact_envelope(&out.stdout);
+
+    // Collection kind ends in `List`; data is (or contains) the array.
+    let kind = v["kind"].as_str().unwrap();
+    assert!(
+        kind.ends_with("List"),
+        "collection kind must end in `List`, got `{kind}`"
+    );
+    let data = &v["data"];
+    let has_list = data.is_array()
+        || data
+            .as_object()
+            .map(|o| o.values().any(Value::is_array))
+            .unwrap_or(false);
+    assert!(
+        has_list,
+        "list envelope `data` must be (or contain) an array, got {data}"
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 2: `--json` is byte-for-byte identical to `-o json`.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn json_flag_is_byte_identical_to_output_json() {
+    let mock = common::start_mock().await;
+
+    let home_a = common::unique_tempdir();
+    let out_dasho = common::flowplane_cmd(&home_a)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args(["-o", "json", "cluster", "list", "--team", "payments"])
+        .output()
+        .expect("run -o json");
+
+    let home_b = common::unique_tempdir();
+    let out_json = common::flowplane_cmd(&home_b)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args(["--json", "cluster", "list", "--team", "payments"])
+        .output()
+        .expect("run --json");
+
+    assert_ok(&out_dasho, "-o json");
+    assert_ok(&out_json, "--json");
+    assert_eq!(
+        out_dasho.stdout, out_json.stdout,
+        "`--json` stdout must be byte-for-byte identical to `-o json`\n  -o json: {}\n  --json : {}",
+        String::from_utf8_lossy(&out_dasho.stdout),
+        String::from_utf8_lossy(&out_json.stdout),
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 3 + 8: non-TTY default → JSON envelope; explicit `-o table` overrides → non-JSON.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn non_tty_default_is_json_and_table_flag_overrides() {
+    let mock = common::start_mock().await;
+
+    // No `-o` flag: captured subprocess stdout is NOT a TTY, so default is the JSON envelope.
+    let home_default = common::unique_tempdir();
+    let out_default = common::flowplane_cmd(&home_default)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args(["cluster", "list", "--team", "payments"])
+        .output()
+        .expect("run cluster list (no -o)");
+    assert_ok(&out_default, "cluster list (no -o)");
+    assert_envelope_present(&out_default.stdout);
+
+    // Explicit `-o table` must override the non-TTY default and produce non-JSON table text.
+    let home_table = common::unique_tempdir();
+    let out_table = common::flowplane_cmd(&home_table)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args(["-o", "table", "cluster", "list", "--team", "payments"])
+        .output()
+        .expect("run cluster list -o table");
+    assert_ok(&out_table, "cluster list -o table");
+    assert!(
+        serde_json::from_slice::<Value>(&out_table.stdout).is_err(),
+        "`-o table` must produce non-JSON text, but it parsed as JSON: {}",
+        String::from_utf8_lossy(&out_table.stdout)
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 4: color off — zero ANSI escape bytes with NO_COLOR=1 and with --no-color.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn table_output_has_no_ansi_escapes() {
+    let mock = common::start_mock().await;
+
+    // NO_COLOR=1 set.
+    let home_nc = common::unique_tempdir();
+    let out_nc = common::flowplane_cmd(&home_nc)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .env("NO_COLOR", "1")
+        .args(["-o", "table", "cluster", "list", "--team", "payments"])
+        .output()
+        .expect("run cluster list -o table (NO_COLOR=1)");
+    assert_ok(&out_nc, "cluster list -o table (NO_COLOR=1)");
+    assert!(
+        !out_nc.stdout.contains(&0x1b),
+        "NO_COLOR=1 table output must contain zero ESC (0x1b) bytes: {:?}",
+        String::from_utf8_lossy(&out_nc.stdout)
+    );
+
+    // --no-color flag.
+    let home_flag = common::unique_tempdir();
+    let out_flag = common::flowplane_cmd(&home_flag)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args([
+            "--no-color",
+            "-o",
+            "table",
+            "cluster",
+            "list",
+            "--team",
+            "payments",
+        ])
+        .output()
+        .expect("run cluster list -o table --no-color");
+    assert_ok(&out_flag, "cluster list -o table --no-color");
+    assert!(
+        !out_flag.stdout.contains(&0x1b),
+        "--no-color table output must contain zero ESC (0x1b) bytes: {:?}",
+        String::from_utf8_lossy(&out_flag.stdout)
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 5: `version -o json` → {schemaVersion, kind:"version", data:{version:"<...>"}}.
+// No server needed.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn version_json_envelope() {
+    let home = common::unique_tempdir();
+    let out = common::flowplane_cmd(&home)
+        .args(["version", "-o", "json"])
+        .output()
+        .expect("run version -o json");
+
+    assert_ok(&out, "version -o json");
+    let v = assert_exact_envelope(&out.stdout);
+    assert_eq!(
+        v["kind"], "version",
+        "version envelope kind must be \"version\""
+    );
+    let version = v["data"]["version"]
+        .as_str()
+        .unwrap_or_else(|| panic!("version envelope data.version must be a string: {v}"));
+    assert!(
+        !version.is_empty(),
+        "data.version must be a non-empty string"
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 6: `cluster delete alpha --team payments -o json` → JSON envelope (mock returns 204).
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delete_json_envelope() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args([
+            "cluster", "delete", "alpha", "--team", "payments", "-o", "json",
+        ])
+        .output()
+        .expect("run cluster delete -o json");
+
+    assert_ok(&out, "cluster delete -o json");
+    // Even though the server returns 204 No Content, the CLI must emit a JSON envelope, not prose.
+    assert_envelope_present(&out.stdout);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 7: `apply -f <manifest> -o json` → applyResult envelope with data.items array.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn apply_json_envelope() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+    let manifest = write_cluster_manifest(&home);
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args(["apply", "-f"])
+        .arg(&manifest)
+        .args(["-o", "json"])
+        .output()
+        .expect("run apply -f <manifest> -o json");
+
+    assert_ok(&out, "apply -o json");
+
+    // CLI-R-15: a `-o json` success payload is a SINGLE envelope; stdout must be one parseable
+    // JSON document. (If apply also streams per-resource envelopes to stdout, this fails — and it
+    // should, because a machine consumer piping stdout into a JSON parser would choke.)
+    let mut de = serde_json::Deserializer::from_slice(&out.stdout).into_iter::<Value>();
+    let first = de
+        .next()
+        .expect("apply -o json must emit a JSON envelope")
+        .expect("apply -o json stdout must be valid JSON");
+    assert!(
+        de.next().is_none(),
+        "apply -o json must emit exactly ONE JSON envelope on stdout, but found more than one \
+         document: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    let v = assert_envelope_present(serde_json::to_vec(&first).unwrap().as_slice());
+    assert_eq!(
+        v["kind"], "applyResult",
+        "apply envelope kind must be \"applyResult\""
+    );
+    assert!(
+        v["data"]["items"].is_array(),
+        "apply envelope data.items must be an array: {v}"
+    );
+}

--- a/crates/flowplane/tests/cli_s2_error_model.rs
+++ b/crates/flowplane/tests/cli_s2_error_model.rs
@@ -1,0 +1,335 @@
+//! S2 — CLI error-model conformance (black-box).
+//!
+//! These tests drive the *built* `flowplane` binary as a subprocess and assert only against
+//! the documented error contract (CLI-R-30/31/32/33). They never look at CLI internals: every
+//! assertion is derived from the acceptance criteria, not the implementation.
+//!
+//! Contract under test:
+//!   * Every error renders as a structured JSON envelope on **stderr** (never raw `Error: ...`),
+//!     and stdout stays empty (CLI-R-30, CLI-R-5/empty-stdout).
+//!   * The envelope carries at least `code`, `message`, `retryable` (bool). HTTP errors also
+//!     carry the integer `status`; a server-supplied request id surfaces as `request_id`.
+//!   * `retryable` classifier (CLI-R-32): 429/503/5xx and transport failures → true;
+//!     404 and 400/validation → false.
+//!   * Auth hint (CLI-R-33): a 401 with no server `hint` still yields a `hint` mentioning
+//!     `flowplane auth login`; a 403 server `hint` naming resource/action survives.
+//!   * Exit-code table (CLI-R-31), full 0–7 range: 0 ok, 2 clap usage, 3 auth (401/403),
+//!     4 not-found/conflict (404), 5 validation (400), 6 rate-limited (429),
+//!     7 server error (503) and transport/connection-refused.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod common;
+
+use std::process::Output;
+
+use serde_json::Value;
+
+/// Run `flowplane cluster get <name> --team payments -o json` against `server`, isolated env.
+fn run_cluster_get(server: &str, name: &str) -> Output {
+    let home = common::unique_tempdir();
+    common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", server)
+        .env("FLOWPLANE_TOKEN", "t")
+        .args(["cluster", "get", name, "--team", "payments", "-o", "json"])
+        .output()
+        .unwrap_or_else(|e| panic!("run cluster get {name}: {e}"))
+}
+
+/// Run `flowplane cluster delete <name> --team payments -o json` against `server`, isolated env.
+fn run_cluster_delete(server: &str, name: &str) -> Output {
+    let home = common::unique_tempdir();
+    common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", server)
+        .env("FLOWPLANE_TOKEN", "t")
+        .args([
+            "cluster", "delete", name, "--team", "payments", "-o", "json",
+        ])
+        .output()
+        .unwrap_or_else(|e| panic!("run cluster delete {name}: {e}"))
+}
+
+fn exit_code(out: &Output) -> i32 {
+    out.status
+        .code()
+        .unwrap_or_else(|| panic!("process terminated without an exit code (killed by signal?)"))
+}
+
+/// Parse stderr as a single JSON error envelope, asserting nothing leaked onto stdout.
+fn parse_error_envelope(out: &Output, ctx: &str) -> Value {
+    assert!(
+        out.stdout.is_empty(),
+        "{ctx}: stdout MUST be empty on error (all error output goes to stderr), got: {:?}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    let v: Value = serde_json::from_slice(&out.stderr).unwrap_or_else(|e| {
+        panic!(
+            "{ctx}: stderr is not a JSON error envelope ({e}): {:?}",
+            String::from_utf8_lossy(&out.stderr)
+        )
+    });
+    let obj = v
+        .as_object()
+        .unwrap_or_else(|| panic!("{ctx}: error envelope is not a JSON object: {v}"));
+    // CLI-R-30: at least `code`, `message`, `retryable` (bool).
+    assert!(
+        obj.get("code").map(Value::is_string).unwrap_or(false),
+        "{ctx}: envelope `code` must be a string: {v}"
+    );
+    assert!(
+        obj.get("message").map(Value::is_string).unwrap_or(false),
+        "{ctx}: envelope `message` must be a string: {v}"
+    );
+    assert!(
+        obj.get("retryable").map(Value::is_boolean).unwrap_or(false),
+        "{ctx}: envelope `retryable` must be a bool: {v}"
+    );
+    v
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 1: structured error envelope on stderr, empty stdout, with HTTP `status` (CLI-R-30).
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn http_error_is_structured_envelope_on_stderr_empty_stdout() {
+    let mock = common::start_mock().await;
+    let out = run_cluster_get(mock.base_url(), "err-404");
+
+    // No raw `Error: ...` prose — must be parseable JSON, on stderr, stdout empty.
+    let v = parse_error_envelope(&out, "cluster get err-404");
+
+    // HTTP errors carry the integer HTTP status.
+    let status = v["status"]
+        .as_i64()
+        .unwrap_or_else(|| panic!("HTTP error envelope must carry integer `status`: {v}"));
+    assert_eq!(status, 404, "status must mirror the HTTP status code: {v}");
+
+    // Sanity: the prose form must NOT be how the error surfaces.
+    assert!(
+        !String::from_utf8_lossy(&out.stderr).starts_with("Error:"),
+        "errors must render as a structured envelope, not a raw `Error: ...` line: {:?}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 2: retryable classifier (CLI-R-32) — 429/503 → true, 404/400 → false, transport → true.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn retryable_classifier_per_status_class() {
+    let mock = common::start_mock().await;
+
+    // (err-name, expected retryable)
+    let http_cases: &[(&str, bool)] = &[
+        ("err-429", true),  // rate-limited → retryable
+        ("err-503", true),  // 5xx → retryable
+        ("err-404", false), // not-found → not retryable
+        ("err-400", false), // validation → not retryable
+    ];
+    for (name, want_retryable) in http_cases {
+        let out = run_cluster_get(mock.base_url(), name);
+        let v = parse_error_envelope(&out, name);
+        assert_eq!(
+            v["retryable"].as_bool().unwrap(),
+            *want_retryable,
+            "{name}: retryable must be {want_retryable}: {v}"
+        );
+    }
+
+    // Transport/connection-refused failure → retryable true (no HTTP status).
+    let out = run_cluster_get(&common::dead_base_url(), "anything");
+    let v = parse_error_envelope(&out, "transport (connection refused)");
+    assert!(
+        v["retryable"].as_bool().unwrap(),
+        "transport/connection failures must be retryable: {v}"
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 3a: a 401 with no server hint still synthesizes a `flowplane auth login` hint.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unauthorized_401_synthesizes_login_hint() {
+    let mock = common::start_mock().await;
+    let out = run_cluster_get(mock.base_url(), "err-401");
+    let v = parse_error_envelope(&out, "cluster get err-401");
+
+    let hint = v["hint"]
+        .as_str()
+        .unwrap_or_else(|| panic!("401 envelope must carry a synthesized `hint`: {v}"));
+    assert!(
+        hint.contains("flowplane auth login"),
+        "401 hint must point the user at `flowplane auth login`, got: {hint:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 3b: a 403 server hint naming the resource/action survives into the envelope.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn forbidden_403_server_hint_survives() {
+    let mock = common::start_mock().await;
+    let out = run_cluster_delete(mock.base_url(), "err-403");
+    let v = parse_error_envelope(&out, "cluster delete err-403");
+
+    let hint = v["hint"]
+        .as_str()
+        .unwrap_or_else(|| panic!("403 envelope must carry the server-supplied `hint`: {v}"));
+    assert!(
+        hint.contains("clusters") && hint.contains("delete"),
+        "403 server hint naming resource/action must survive, got: {hint:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 4: exit-code table (CLI-R-31), the full 0–7 range, adversarially per status class.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exit_code_table_covers_full_range() {
+    let mock = common::start_mock().await;
+
+    // HTTP status class → exit code. Use delete for 403 (its server hint names action=delete).
+    assert_eq!(
+        exit_code(&run_cluster_get(mock.base_url(), "err-404")),
+        4,
+        "404 not-found/conflict/precondition → exit 4"
+    );
+    assert_eq!(
+        exit_code(&run_cluster_get(mock.base_url(), "err-400")),
+        5,
+        "400 validation → exit 5"
+    );
+    assert_eq!(
+        exit_code(&run_cluster_get(mock.base_url(), "err-429")),
+        6,
+        "429 rate-limited → exit 6"
+    );
+    assert_eq!(
+        exit_code(&run_cluster_get(mock.base_url(), "err-503")),
+        7,
+        "503 server error → exit 7"
+    );
+    let code_401 = exit_code(&run_cluster_get(mock.base_url(), "err-401"));
+    assert_eq!(code_401, 3, "401 auth → exit 3");
+    assert_eq!(
+        exit_code(&run_cluster_delete(mock.base_url(), "err-403")),
+        3,
+        "403 auth → exit 3"
+    );
+
+    // Transport/connection-refused → exit 7 (NOT a generic 1).
+    let transport = run_cluster_get(&common::dead_base_url(), "anything");
+    let code_transport = exit_code(&transport);
+    assert_eq!(
+        code_transport, 7,
+        "connection-refused transport failure → exit 7, not 1"
+    );
+    assert_ne!(
+        code_transport, 1,
+        "transport failure must NOT collapse to the generic exit 1"
+    );
+
+    // Success → exit 0.
+    assert_eq!(
+        exit_code(&run_cluster_get(mock.base_url(), "alpha")),
+        0,
+        "a normal (200) get → exit 0"
+    );
+
+    // clap-native usage error (unknown flag) → exit 2; no server needed.
+    let home = common::unique_tempdir();
+    let usage = common::flowplane_cmd(&home)
+        .args(["cluster", "--nonexistent-flag"])
+        .output()
+        .expect("run clap usage error");
+    let code_usage = exit_code(&usage);
+    assert_eq!(code_usage, 2, "clap usage error (unknown flag) → exit 2");
+
+    // Adversarial: clap usage (2) and auth 401 (3) must be DISTINCT codes.
+    assert_ne!(
+        code_usage, code_401,
+        "a clap usage error (2) and a 401 (3) must produce different exit codes"
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 5: empty stdout on error for both the HTTP and transport error cases.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn error_paths_keep_stdout_empty() {
+    let mock = common::start_mock().await;
+
+    let http = run_cluster_get(mock.base_url(), "err-503");
+    assert!(
+        http.stdout.is_empty(),
+        "HTTP error must leave stdout empty, got: {:?}",
+        String::from_utf8_lossy(&http.stdout)
+    );
+
+    let transport = run_cluster_get(&common::dead_base_url(), "anything");
+    assert!(
+        transport.stdout.is_empty(),
+        "transport error must leave stdout empty, got: {:?}",
+        String::from_utf8_lossy(&transport.stdout)
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 1 (transport variant): connection-refused renders the same structured stderr envelope,
+// with no HTTP `status` field (there was no HTTP response). Pure transport, but runs the binary.
+// ---------------------------------------------------------------------------------------------
+#[test]
+fn transport_error_is_structured_envelope() {
+    let out = run_cluster_get(&common::dead_base_url(), "anything");
+    let v = parse_error_envelope(&out, "transport (connection refused)");
+    // A transport failure has no HTTP status to report.
+    assert!(
+        v.get("status").map(Value::is_null).unwrap_or(true),
+        "transport error has no HTTP response, so `status` must be absent/null: {v}"
+    );
+    assert_eq!(exit_code(&out), 7, "transport failure → exit 7");
+}
+
+/// CLI-R-30: an `apply` partial/total failure is reported as ONE structured error envelope
+/// on stderr (kind-tagged `failures` list), with empty stdout and a non-zero exit — not a
+/// per-subrequest pile of envelopes nor an `applyResult` document leaking onto stdout.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn apply_partial_failure_is_single_error_envelope_empty_stdout() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+    // `err-500` makes the existence check (GET) return 500, so this target fails to apply.
+    let manifest = home.join("manifest.json");
+    std::fs::write(
+        &manifest,
+        r#"{"kind":"cluster","name":"err-500","team":"payments","spec":{"endpoints":[{"host":"example.com","port":80}]}}"#,
+    )
+    .unwrap();
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args(["apply", "-f", manifest.to_str().unwrap(), "-o", "json"])
+        .output()
+        .unwrap();
+
+    assert!(
+        out.stdout.is_empty(),
+        "apply failure: stdout MUST be empty (no applyResult leak), got: {:?}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let v: Value = serde_json::from_slice(&out.stderr).unwrap_or_else(|e| {
+        panic!(
+            "apply failure: stderr must be ONE JSON error envelope ({e}): {:?}",
+            String::from_utf8_lossy(&out.stderr)
+        )
+    });
+    assert_eq!(v["code"], "apply_failed", "envelope: {v}");
+    assert!(
+        v.get("failures").and_then(Value::as_array).is_some(),
+        "envelope must list `failures`: {v}"
+    );
+    assert!(
+        !out.status.success(),
+        "apply with a failed resource must exit non-zero"
+    );
+}

--- a/crates/flowplane/tests/cli_s2_error_model.rs
+++ b/crates/flowplane/tests/cli_s2_error_model.rs
@@ -43,7 +43,7 @@ fn run_cluster_delete(server: &str, name: &str) -> Output {
         .env("FLOWPLANE_SERVER", server)
         .env("FLOWPLANE_TOKEN", "t")
         .args([
-            "cluster", "delete", name, "--team", "payments", "-o", "json",
+            "cluster", "delete", name, "--team", "payments", "--yes", "-o", "json",
         ])
         .output()
         .unwrap_or_else(|e| panic!("run cluster delete {name}: {e}"))

--- a/crates/flowplane/tests/cli_s3_config_precedence.rs
+++ b/crates/flowplane/tests/cli_s3_config_precedence.rs
@@ -1,0 +1,382 @@
+//! S3 — CLI config-precedence conformance (black-box).
+//!
+//! These tests drive the *built* `flowplane` binary as a subprocess and assert only against
+//! the documented precedence contract (CLI-R-40/41). They never look at CLI internals: every
+//! assertion is derived from the acceptance criteria, not the implementation.
+//!
+//! Contract under test (CLI-R-40/41):
+//!   * Uniform precedence for EVERY configuration value: `flag > env > context > file > default`.
+//!   * Token source ladder: `--token` flag > `FLOWPLANE_TOKEN` env > selected context token >
+//!     config-file token > `~/.flowplane/credentials` file.
+//!   * `FLOWPLANE_TIMEOUT` feeds `--timeout` (precedence flag > env > default 30).
+//!   * `server`/`org`/`team` follow the same `flag > env > context > file > default` rule.
+//!   * `config show` redacts token material (never prints a real token).
+//!
+//! Observation technique: `flowplane cluster get probe --team payments -o json` hits a mock
+//! whose `data` echoes what the server received — `data.received_authorization` (the `Bearer …`
+//! header) and `data.received_org` (the `X-Flowplane-Org` header). Setting a config value via
+//! different sources and reading the echoed header proves which source actually won. Each test
+//! is adversarial: lower-priority sources are ALSO populated, so the assertion proves the
+//! higher-priority source wins — not merely that it works in isolation.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod common;
+
+use std::path::Path;
+use std::process::Output;
+
+use serde_json::Value;
+
+/// Write `<home>/config.toml` (the path `flowplane_cmd` points `FLOWPLANE_CONFIG` at).
+fn write_config(home: &Path, contents: &str) {
+    std::fs::write(home.join("config.toml"), contents).expect("write config.toml");
+}
+
+/// Write the credentials file that lives next to the config path as `<config dir>/credentials`.
+/// With `FLOWPLANE_CONFIG=<home>/config.toml`, that is `<home>/credentials`.
+fn write_credentials(home: &Path, token: &str) {
+    std::fs::write(home.join("credentials"), token).expect("write credentials");
+}
+
+/// Parse the probe success envelope `{schemaVersion,kind,data}` from stdout, asserting exit 0.
+fn parse_probe(out: &Output, ctx: &str) -> Value {
+    assert!(
+        out.status.success(),
+        "{ctx}: probe must exit 0, got {:?}; stderr: {:?}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    serde_json::from_slice(&out.stdout).unwrap_or_else(|e| {
+        panic!(
+            "{ctx}: stdout must be a JSON envelope ({e}): {:?}",
+            String::from_utf8_lossy(&out.stdout)
+        )
+    })
+}
+
+/// The `Bearer …` authorization header the CLI actually sent, as echoed by the probe.
+fn received_authorization(out: &Output, ctx: &str) -> String {
+    let v = parse_probe(out, ctx);
+    v["data"]["received_authorization"]
+        .as_str()
+        .unwrap_or_else(|| panic!("{ctx}: probe must echo received_authorization: {v}"))
+        .to_string()
+}
+
+/// The `X-Flowplane-Org` header the CLI actually sent, as echoed by the probe (may be null).
+fn received_org(out: &Output, ctx: &str) -> Option<String> {
+    let v = parse_probe(out, ctx);
+    v["data"]["received_org"].as_str().map(str::to_string)
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 1: token precedence ladder — flag > env > context > file > credentials.
+// Each rung populates ALL lower-priority sources, so winning proves precedence, not isolation.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn token_precedence_ladder() {
+    let mock = common::start_mock().await;
+
+    // A config file that supplies BOTH a context token and a file token (and a credentials
+    // file alongside it), so every rung below the flag/env is also present.
+    let config = format!(
+        r#"base_url = "{server}"
+token = "file-tok"
+current_context = "prod"
+
+[[contexts]]
+name = "prod"
+server = "{server}"
+token = "ctx-tok"
+"#,
+        server = mock.base_url()
+    );
+
+    // Rung 1 — flag wins over env + context + file + credentials.
+    {
+        let home = common::unique_tempdir();
+        write_config(&home, &config);
+        write_credentials(&home, "cred-tok");
+        let out = common::flowplane_cmd(&home)
+            .env("FLOWPLANE_TOKEN", "env-tok")
+            .args([
+                "cluster", "get", "probe", "--team", "payments", "--token", "flag-tok", "-o",
+                "json",
+            ])
+            .output()
+            .unwrap();
+        assert_eq!(
+            received_authorization(&out, "rung1 flag"),
+            "Bearer flag-tok",
+            "the --token flag must beat env, context, file, and credentials"
+        );
+    }
+
+    // Rung 2 — env wins over context + file + credentials (no flag).
+    {
+        let home = common::unique_tempdir();
+        write_config(&home, &config);
+        write_credentials(&home, "cred-tok");
+        let out = common::flowplane_cmd(&home)
+            .env("FLOWPLANE_TOKEN", "env-tok")
+            .args([
+                "cluster", "get", "probe", "--team", "payments", "-o", "json",
+            ])
+            .output()
+            .unwrap();
+        assert_eq!(
+            received_authorization(&out, "rung2 env"),
+            "Bearer env-tok",
+            "FLOWPLANE_TOKEN must beat context, file, and credentials when no flag is set"
+        );
+    }
+
+    // Rung 3 — selected context token wins over file + credentials (no flag/env).
+    {
+        let home = common::unique_tempdir();
+        write_config(&home, &config);
+        write_credentials(&home, "cred-tok");
+        let out = common::flowplane_cmd(&home)
+            .args([
+                "cluster", "get", "probe", "--team", "payments", "-o", "json",
+            ])
+            .output()
+            .unwrap();
+        assert_eq!(
+            received_authorization(&out, "rung3 context"),
+            "Bearer ctx-tok",
+            "the selected context's token must beat the file token and credentials"
+        );
+    }
+
+    // Rung 4 — file token wins over credentials (no flag/env/context).
+    {
+        let home = common::unique_tempdir();
+        write_config(
+            &home,
+            &format!(
+                "base_url = \"{server}\"\ntoken = \"file-tok\"\n",
+                server = mock.base_url()
+            ),
+        );
+        write_credentials(&home, "cred-tok");
+        let out = common::flowplane_cmd(&home)
+            .args([
+                "cluster", "get", "probe", "--team", "payments", "-o", "json",
+            ])
+            .output()
+            .unwrap();
+        assert_eq!(
+            received_authorization(&out, "rung4 file"),
+            "Bearer file-tok",
+            "the config-file token must beat the credentials file"
+        );
+    }
+
+    // Rung 5 — credentials file only (no flag/env/context/file token).
+    {
+        let home = common::unique_tempdir();
+        write_config(
+            &home,
+            &format!("base_url = \"{server}\"\n", server = mock.base_url()),
+        );
+        write_credentials(&home, "cred-tok");
+        let out = common::flowplane_cmd(&home)
+            .args([
+                "cluster", "get", "probe", "--team", "payments", "-o", "json",
+            ])
+            .output()
+            .unwrap();
+        assert_eq!(
+            received_authorization(&out, "rung5 credentials"),
+            "Bearer cred-tok",
+            "the ~/.flowplane/credentials file is the lowest token tier and must be used last"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 3 (explicit): the `--token` flag exists and resolves flag-first over env + file.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn token_flag_resolves_flag_first() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+    write_config(
+        &home,
+        &format!(
+            "base_url = \"{server}\"\ntoken = \"file-tok\"\n",
+            server = mock.base_url()
+        ),
+    );
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_TOKEN", "env-tok")
+        .args([
+            "cluster", "get", "probe", "--team", "payments", "--token", "flag-tok", "-o", "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        received_authorization(&out, "token flag-first"),
+        "Bearer flag-tok",
+        "the --token global flag must exist and resolve flag-first"
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 2: org precedence — flag --org beats env FLOWPLANE_ORG beats file `org`.
+// Observed via the echoed X-Flowplane-Org header.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn org_precedence_flag_beats_env_beats_file() {
+    let mock = common::start_mock().await;
+
+    let config = format!(
+        "base_url = \"{server}\"\ntoken = \"file-tok\"\norg = \"file-org\"\n",
+        server = mock.base_url()
+    );
+
+    // Flag wins over env + file.
+    {
+        let home = common::unique_tempdir();
+        write_config(&home, &config);
+        let out = common::flowplane_cmd(&home)
+            .env("FLOWPLANE_ORG", "env-org")
+            .args([
+                "cluster", "get", "probe", "--team", "payments", "--org", "flag-org", "-o", "json",
+            ])
+            .output()
+            .unwrap();
+        assert_eq!(
+            received_org(&out, "org flag").as_deref(),
+            Some("flag-org"),
+            "--org must beat FLOWPLANE_ORG and the file org"
+        );
+    }
+
+    // Env wins over file (no flag).
+    {
+        let home = common::unique_tempdir();
+        write_config(&home, &config);
+        let out = common::flowplane_cmd(&home)
+            .env("FLOWPLANE_ORG", "env-org")
+            .args([
+                "cluster", "get", "probe", "--team", "payments", "-o", "json",
+            ])
+            .output()
+            .unwrap();
+        assert_eq!(
+            received_org(&out, "org env").as_deref(),
+            Some("env-org"),
+            "FLOWPLANE_ORG must beat the file org when no flag is set"
+        );
+    }
+
+    // File wins as the lowest set tier (no flag/env).
+    {
+        let home = common::unique_tempdir();
+        write_config(&home, &config);
+        let out = common::flowplane_cmd(&home)
+            .args([
+                "cluster", "get", "probe", "--team", "payments", "-o", "json",
+            ])
+            .output()
+            .unwrap();
+        assert_eq!(
+            received_org(&out, "org file").as_deref(),
+            Some("file-org"),
+            "the file org must be used when neither flag nor env is set"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 4: FLOWPLANE_TIMEOUT is accepted (feeds --timeout); a literal --timeout flag parses.
+// The timeout value isn't black-box observable, so we only prove acceptance + a valid envelope.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn timeout_env_and_flag_are_accepted() {
+    let mock = common::start_mock().await;
+
+    // Env form: FLOWPLANE_TIMEOUT=5 must be accepted and produce a clean probe envelope.
+    {
+        let home = common::unique_tempdir();
+        let out = common::flowplane_cmd(&home)
+            .env("FLOWPLANE_SERVER", mock.base_url())
+            .env("FLOWPLANE_TOKEN", "env-tok")
+            .env("FLOWPLANE_TIMEOUT", "5")
+            .args([
+                "cluster", "get", "probe", "--team", "payments", "-o", "json",
+            ])
+            .output()
+            .unwrap();
+        let v = parse_probe(&out, "FLOWPLANE_TIMEOUT env");
+        assert_eq!(
+            v["data"]["received_authorization"], "Bearer env-tok",
+            "FLOWPLANE_TIMEOUT=5 must be accepted without error and the request still go through: {v}"
+        );
+    }
+
+    // Flag form: --timeout 5 must also parse and run cleanly.
+    {
+        let home = common::unique_tempdir();
+        let out = common::flowplane_cmd(&home)
+            .env("FLOWPLANE_SERVER", mock.base_url())
+            .env("FLOWPLANE_TOKEN", "env-tok")
+            .args([
+                "cluster",
+                "get",
+                "probe",
+                "--team",
+                "payments",
+                "--timeout",
+                "5",
+                "-o",
+                "json",
+            ])
+            .output()
+            .unwrap();
+        let v = parse_probe(&out, "--timeout flag");
+        assert_eq!(
+            v["data"]["received_authorization"], "Bearer env-tok",
+            "--timeout 5 must parse and the request still go through: {v}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 5: `config show` redacts token material (never prints a real token).
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn config_show_redacts_token() {
+    let home = common::unique_tempdir();
+    write_config(
+        &home,
+        "base_url = \"http://example.invalid\"\ntoken = \"super-secret-123\"\n",
+    );
+
+    let out = common::flowplane_cmd(&home)
+        .args(["config", "show"])
+        .output()
+        .unwrap();
+
+    assert!(
+        out.status.success(),
+        "config show must exit 0, got {:?}; stderr: {:?}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stdout.contains("super-secret-123"),
+        "config show must REDACT the token, but stdout contained the raw secret: {stdout:?}"
+    );
+    assert!(
+        !stderr.contains("super-secret-123"),
+        "config show must REDACT the token everywhere, but stderr contained the raw secret: {stderr:?}"
+    );
+}

--- a/crates/flowplane/tests/cli_s4_revision_rmw.rs
+++ b/crates/flowplane/tests/cli_s4_revision_rmw.rs
@@ -214,6 +214,7 @@ async fn stale_revision_delete_conflict_names_both() {
             "payments",
             "--revision",
             "3",
+            "--yes",
             "-o",
             "json",
         ])
@@ -292,6 +293,7 @@ async fn revision_flag_accepted_on_update_and_delete() {
             "payments",
             "--revision",
             "1",
+            "--yes",
             "-o",
             "json",
         ])

--- a/crates/flowplane/tests/cli_s4_revision_rmw.rs
+++ b/crates/flowplane/tests/cli_s4_revision_rmw.rs
@@ -1,0 +1,306 @@
+//! S4 — CLI revision / read-modify-write conformance (black-box).
+//!
+//! These tests drive the *built* `flowplane` binary as a subprocess and assert only against
+//! the documented `--revision` contract (CLI-R-47). They never look at CLI internals: every
+//! assertion is derived from the acceptance criteria, not the implementation.
+//!
+//! Contract under test (CLI-R-47), `--revision` uniform on every update/delete:
+//!   1. Read-modify-write (no `--revision`): an update/delete with no explicit `--revision`
+//!      first READS the resource's current revision, then sends it as the `If-Match`
+//!      precondition — so concurrent edits are detected instead of last-write-wins.
+//!   2. Explicit `--revision N`: sent as the `If-Match` precondition directly.
+//!   3. Stale revision → 409 naming BOTH revisions: the conflict surfaces the structured error
+//!      envelope on stderr with `attempted_revision` (what the CLI sent) AND the server's
+//!      current revision (carried in the envelope `message`), exit code 4, empty stdout.
+//!
+//! Observation technique (harness mock): `cluster update <name>` succeeds with
+//! `data.applied_revision` echoing the `If-Match` the CLI actually sent (null if none). A GET
+//! of any normal cluster returns `revision: 1`. The reserved name `conflict` returns HTTP 409
+//! `{"code":"conflict","message":"revision mismatch: current revision is 7"}` regardless of the
+//! sent revision.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod common;
+
+use std::process::Output;
+
+use serde_json::Value;
+
+/// Write a minimal valid-JSON body file the mock ignores, return its path string.
+fn write_body(home: &std::path::Path) -> String {
+    let path = home.join("body.json");
+    std::fs::write(&path, r#"{"spec":{"endpoints":[]}}"#).expect("write body file");
+    path.to_str().expect("body path is utf-8").to_string()
+}
+
+fn exit_code(out: &Output) -> i32 {
+    out.status
+        .code()
+        .unwrap_or_else(|| panic!("process terminated without an exit code (killed by signal?)"))
+}
+
+/// Parse stdout as the `{schemaVersion,kind,data}` success envelope.
+fn parse_success_envelope(out: &Output, ctx: &str) -> Value {
+    assert!(
+        out.status.success(),
+        "{ctx}: expected exit 0, got {:?}; stderr: {:?}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    serde_json::from_slice(&out.stdout).unwrap_or_else(|e| {
+        panic!(
+            "{ctx}: stdout is not a JSON success envelope ({e}): {:?}",
+            String::from_utf8_lossy(&out.stdout)
+        )
+    })
+}
+
+/// Parse stderr as a single JSON error envelope, asserting nothing leaked onto stdout.
+fn parse_error_envelope(out: &Output, ctx: &str) -> Value {
+    assert!(
+        out.stdout.is_empty(),
+        "{ctx}: stdout MUST be empty on error, got: {:?}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    serde_json::from_slice(&out.stderr).unwrap_or_else(|e| {
+        panic!(
+            "{ctx}: stderr is not a JSON error envelope ({e}): {:?}",
+            String::from_utf8_lossy(&out.stderr)
+        )
+    })
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 1: read-modify-write — no `--revision` makes the CLI READ the current revision (1)
+// and send it as `If-Match`. Asserting exactly 1 proves a real GET happened, not a hardcode.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rmw_sends_current_revision_when_no_flag() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+    let body = write_body(&home);
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args([
+            "cluster", "update", "demo", "--team", "payments", "-f", &body, "-o", "json",
+        ])
+        .output()
+        .expect("run cluster update demo (rmw)");
+
+    let v = parse_success_envelope(&out, "cluster update demo (rmw)");
+    let applied = v["data"]["applied_revision"].as_i64().unwrap_or_else(|| {
+        panic!("rmw: data.applied_revision must be an integer (the read revision): {v}")
+    });
+    assert_eq!(
+        applied, 1,
+        "rmw: with no --revision the CLI must READ the current revision (1) and send it as \
+         If-Match — a hardcoded/absent precondition would not echo 1: {v}"
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 2: an explicit `--revision N` is sent verbatim as `If-Match` (no read needed).
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_revision_is_sent_as_if_match() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+    let body = write_body(&home);
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args([
+            "cluster",
+            "update",
+            "demo",
+            "--team",
+            "payments",
+            "-f",
+            &body,
+            "--revision",
+            "9",
+            "-o",
+            "json",
+        ])
+        .output()
+        .expect("run cluster update demo --revision 9");
+
+    let v = parse_success_envelope(&out, "cluster update demo --revision 9");
+    let applied = v["data"]["applied_revision"]
+        .as_i64()
+        .unwrap_or_else(|| panic!("explicit: data.applied_revision must be an integer: {v}"));
+    assert_eq!(
+        applied, 9,
+        "explicit --revision 9 must be sent verbatim as the If-Match precondition: {v}"
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 3: a stale revision on update → 409 surfacing BOTH the attempted revision (3, what
+// the CLI sent) and the server's current revision (7, in the envelope message), exit 4, empty
+// stdout. Adversarial: assert exit is exactly 4 (not 1/2), and both numbers appear.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stale_revision_update_conflict_names_both() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+    let body = write_body(&home);
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args([
+            "cluster",
+            "update",
+            "conflict",
+            "--team",
+            "payments",
+            "-f",
+            &body,
+            "--revision",
+            "3",
+            "-o",
+            "json",
+        ])
+        .output()
+        .expect("run cluster update conflict --revision 3");
+
+    assert_eq!(
+        exit_code(&out),
+        4,
+        "stale-revision conflict (409) must exit 4 (conflict/precondition), not 1/2: stderr {:?}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let v = parse_error_envelope(&out, "cluster update conflict --revision 3");
+
+    let attempted = v["attempted_revision"].as_i64().unwrap_or_else(|| {
+        panic!("conflict envelope must carry integer `attempted_revision` (what CLI sent): {v}")
+    });
+    assert_eq!(
+        attempted, 3,
+        "attempted_revision must be the revision the CLI sent (3): {v}"
+    );
+
+    let message = v["message"]
+        .as_str()
+        .unwrap_or_else(|| panic!("conflict envelope must carry a string `message`: {v}"));
+    assert!(
+        message.contains('7'),
+        "conflict message must name the server's current revision (7): {message:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 4: same stale-revision conflict semantics on `delete` (no body file needed).
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stale_revision_delete_conflict_names_both() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args([
+            "cluster",
+            "delete",
+            "conflict",
+            "--team",
+            "payments",
+            "--revision",
+            "3",
+            "-o",
+            "json",
+        ])
+        .output()
+        .expect("run cluster delete conflict --revision 3");
+
+    assert_eq!(
+        exit_code(&out),
+        4,
+        "stale-revision delete conflict (409) must exit 4, not 1/2: stderr {:?}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let v = parse_error_envelope(&out, "cluster delete conflict --revision 3");
+
+    let attempted = v["attempted_revision"].as_i64().unwrap_or_else(|| {
+        panic!("conflict envelope must carry integer `attempted_revision`: {v}")
+    });
+    assert_eq!(
+        attempted, 3,
+        "attempted_revision must be the revision the CLI sent (3): {v}"
+    );
+
+    let message = v["message"]
+        .as_str()
+        .unwrap_or_else(|| panic!("conflict envelope must carry a string `message`: {v}"));
+    assert!(
+        message.contains('7'),
+        "conflict message must name the server's current revision (7): {message:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Criterion 5: sanity — `--revision` parses and is accepted on BOTH update and delete; a normal
+// name succeeds (delete returns 204 → still exit 0).
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn revision_flag_accepted_on_update_and_delete() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+    let body = write_body(&home);
+
+    let update = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args([
+            "cluster",
+            "update",
+            "demo",
+            "--team",
+            "payments",
+            "-f",
+            &body,
+            "--revision",
+            "1",
+            "-o",
+            "json",
+        ])
+        .output()
+        .expect("run cluster update demo --revision 1");
+    assert_eq!(
+        exit_code(&update),
+        0,
+        "update with --revision 1 must parse and succeed: stderr {:?}",
+        String::from_utf8_lossy(&update.stderr)
+    );
+
+    let delete = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args([
+            "cluster",
+            "delete",
+            "demo",
+            "--team",
+            "payments",
+            "--revision",
+            "1",
+            "-o",
+            "json",
+        ])
+        .output()
+        .expect("run cluster delete demo --revision 1");
+    assert_eq!(
+        exit_code(&delete),
+        0,
+        "delete with --revision 1 must parse and succeed (204): stderr {:?}",
+        String::from_utf8_lossy(&delete.stderr)
+    );
+}

--- a/crates/flowplane/tests/cli_s5_schema_fields.rs
+++ b/crates/flowplane/tests/cli_s5_schema_fields.rs
@@ -1,0 +1,323 @@
+//! S5 — CLI introspection: `schema` subcommand + `--fields` projection (black-box).
+//!
+//! These tests drive the *built* `flowplane` binary as a subprocess and assert only against
+//! the documented output contract (CLI-R-50/51). They never look at CLI internals: every
+//! assertion is derived from the acceptance criteria, not the implementation.
+//!
+//! Contract under test:
+//!   * `flowplane schema -o json` (CLI-R-50) prints the machine-readable CLI catalog with NO
+//!     network call. Envelope is `{schemaVersion, kind, data}` with `kind == "cliSchema"`,
+//!     integer `data.catalogVersion`, and `data.command` the recursive root command tree
+//!     (`name`, `about`, `args`, `subcommands`). Each arg has the documented arg-shape keys.
+//!     The catalog contains EVERY top-level command (25 of them) including `schema` itself.
+//!   * `--fields a,b,c` (CLI-R-51) projects reader output to exactly those keys INSIDE `data`
+//!     (per item for lists). The envelope `schemaVersion`/`kind` always survive; an absent
+//!     requested key is omitted (no null injected).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod common;
+
+use std::collections::BTreeSet;
+use std::process::Output;
+
+use serde_json::Value;
+
+fn assert_ok(out: &Output, ctx: &str) {
+    assert!(
+        out.status.success(),
+        "{ctx}: expected exit 0, got {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+fn parse_envelope(stdout: &[u8]) -> Value {
+    serde_json::from_slice(stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout is not valid JSON ({e}): {:?}",
+            String::from_utf8_lossy(stdout)
+        )
+    })
+}
+
+fn key_set(v: &Value) -> BTreeSet<String> {
+    v.as_object()
+        .unwrap_or_else(|| panic!("expected a JSON object, got {v}"))
+        .keys()
+        .cloned()
+        .collect()
+}
+
+// ---------------------------------------------------------------------------------------------
+// CLI-R-50: `flowplane schema -o json` — machine-readable catalog, no network call.
+// ---------------------------------------------------------------------------------------------
+#[test]
+fn schema_is_valid_cli_schema_envelope_no_network() {
+    // No mock, and deliberately NO `FLOWPLANE_SERVER`/token: schema must make no network call.
+    let home = common::unique_tempdir();
+    let out = common::flowplane_cmd(&home)
+        .args(["schema", "-o", "json"])
+        .output()
+        .expect("run schema -o json");
+
+    assert_ok(&out, "schema -o json");
+    // No server is configured, so any attempt to reach the network would surface as an error.
+    assert!(
+        out.stderr.is_empty(),
+        "schema must produce no stderr (no network, no error): {:?}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let v = parse_envelope(&out.stdout);
+    let obj = v
+        .as_object()
+        .unwrap_or_else(|| panic!("envelope is not a JSON object: {v}"));
+
+    // Standard envelope keys present, with integer schemaVersion + string kind.
+    for k in ["schemaVersion", "kind", "data"] {
+        assert!(obj.contains_key(k), "envelope missing key `{k}`: {v}");
+    }
+    assert!(
+        obj["schemaVersion"].is_i64() || obj["schemaVersion"].is_u64(),
+        "schemaVersion must be an integer, got {}",
+        obj["schemaVersion"]
+    );
+    assert_eq!(
+        v["kind"], "cliSchema",
+        "schema envelope kind must be \"cliSchema\""
+    );
+
+    let data = &v["data"];
+
+    // catalogVersion is an integer, and distinct field from the envelope schemaVersion.
+    assert!(
+        data["catalogVersion"].is_i64() || data["catalogVersion"].is_u64(),
+        "data.catalogVersion must be an integer, got {}",
+        data["catalogVersion"]
+    );
+
+    // data.command is the root command tree: name/about/args/subcommands.
+    let command = &data["command"];
+    for k in ["name", "about", "args", "subcommands"] {
+        assert!(
+            command.get(k).is_some(),
+            "data.command must have `{k}`: {command}"
+        );
+    }
+    assert!(
+        command["args"].is_array(),
+        "data.command.args must be an array, got {}",
+        command["args"]
+    );
+    assert!(
+        command["subcommands"].is_array(),
+        "data.command.subcommands must be an array, got {}",
+        command["subcommands"]
+    );
+
+    // The catalog contains EVERY top-level command, including `schema` itself.
+    let subs = command["subcommands"].as_array().unwrap();
+    let names: BTreeSet<&str> = subs
+        .iter()
+        .map(|s| {
+            s["name"]
+                .as_str()
+                .unwrap_or_else(|| panic!("each subcommand must have a string `name`: {s}"))
+        })
+        .collect();
+    for required in ["cluster", "listener", "route", "apply", "version", "schema"] {
+        assert!(
+            names.contains(required),
+            "catalog must list top-level command `{required}` (no self-exemption); got {names:?}"
+        );
+    }
+    assert_eq!(
+        subs.len(),
+        25,
+        "catalog must list EXACTLY 25 top-level commands, got {}: {names:?}",
+        subs.len()
+    );
+
+    // Drill into one arg and confirm the documented arg-shape keys exist. Prefer the global
+    // `--output`/`-o` arg, but fall back to any arg present in the tree.
+    let arg = find_any_arg(command).unwrap_or_else(|| {
+        panic!("expected at least one arg somewhere in the command tree: {command}")
+    });
+    for k in [
+        "name",
+        "long",
+        "short",
+        "help",
+        "required",
+        "global",
+        "takesValue",
+        "valueNames",
+        "possibleValues",
+        "defaults",
+    ] {
+        assert!(
+            arg.get(k).is_some(),
+            "arg object must have documented key `{k}`: {arg}"
+        );
+    }
+}
+
+/// Walk the command tree and return the first arg object found. Prefers the global
+/// `--output`/`-o` arg if present anywhere, otherwise any arg.
+fn find_any_arg(command: &Value) -> Option<Value> {
+    let mut fallback: Option<Value> = None;
+    fn walk(command: &Value, fallback: &mut Option<Value>) -> Option<Value> {
+        if let Some(args) = command["args"].as_array() {
+            for a in args {
+                let long = a["long"].as_str();
+                let short = a["short"].as_str();
+                if long == Some("output") || short == Some("o") {
+                    return Some(a.clone());
+                }
+                if fallback.is_none() {
+                    *fallback = Some(a.clone());
+                }
+            }
+        }
+        if let Some(subs) = command["subcommands"].as_array() {
+            for s in subs {
+                if let Some(found) = walk(s, fallback) {
+                    return Some(found);
+                }
+            }
+        }
+        None
+    }
+    walk(command, &mut fallback).or(fallback)
+}
+
+// ---------------------------------------------------------------------------------------------
+// CLI-R-51: `--fields` projects list items inside `data`, per item.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fields_projects_list_items_inside_data() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args([
+            "cluster",
+            "list",
+            "--team",
+            "payments",
+            "-o",
+            "json",
+            "--fields",
+            "name,revision",
+        ])
+        .output()
+        .expect("run cluster list --fields name,revision");
+
+    assert_ok(&out, "cluster list --fields name,revision");
+    let v = parse_envelope(&out.stdout);
+
+    // Envelope schemaVersion + kind survive projection.
+    assert!(
+        v["schemaVersion"].is_i64() || v["schemaVersion"].is_u64(),
+        "schemaVersion must survive projection: {v}"
+    );
+    assert!(v["kind"].is_string(), "kind must survive projection: {v}");
+
+    let data = v["data"]
+        .as_array()
+        .unwrap_or_else(|| panic!("list `data` must be an array: {}", v["data"]));
+    assert!(
+        !data.is_empty(),
+        "mock list must return at least one item: {v}"
+    );
+
+    let expected: BTreeSet<String> = ["name".to_string(), "revision".to_string()]
+        .into_iter()
+        .collect();
+    for (i, item) in data.iter().enumerate() {
+        assert_eq!(
+            key_set(item),
+            expected,
+            "data[{i}] must have EXACTLY {{name, revision}} (service_name projected away), got {item}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// CLI-R-51: `--fields` projects a single GET object inside `data`.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fields_projects_single_object() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args([
+            "cluster", "get", "demo", "--team", "payments", "-o", "json", "--fields", "name",
+        ])
+        .output()
+        .expect("run cluster get demo --fields name");
+
+    assert_ok(&out, "cluster get --fields name");
+    let v = parse_envelope(&out.stdout);
+
+    assert!(v["kind"].is_string(), "kind must survive projection: {v}");
+    let expected: BTreeSet<String> = ["name".to_string()].into_iter().collect();
+    assert_eq!(
+        key_set(&v["data"]),
+        expected,
+        "single-object `data` must have ONLY {{name}}, got {}",
+        v["data"]
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// CLI-R-51: a requested key that is absent is OMITTED, not injected as null.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fields_absent_key_is_omitted_not_null() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args([
+            "cluster",
+            "get",
+            "demo",
+            "--team",
+            "payments",
+            "-o",
+            "json",
+            "--fields",
+            "name,does_not_exist",
+        ])
+        .output()
+        .expect("run cluster get demo --fields name,does_not_exist");
+
+    assert_ok(&out, "cluster get --fields name,does_not_exist");
+    let v = parse_envelope(&out.stdout);
+
+    let data = v["data"]
+        .as_object()
+        .unwrap_or_else(|| panic!("single-object `data` must be an object: {}", v["data"]));
+    let expected: BTreeSet<String> = ["name".to_string()].into_iter().collect();
+    assert_eq!(
+        key_set(&v["data"]),
+        expected,
+        "absent requested key must be OMITTED, leaving ONLY {{name}}, got {}",
+        v["data"]
+    );
+    assert!(
+        !data.contains_key("does_not_exist"),
+        "`does_not_exist` must NOT be present (not even as null): {}",
+        v["data"]
+    );
+}

--- a/crates/flowplane/tests/cli_s6_confirm.rs
+++ b/crates/flowplane/tests/cli_s6_confirm.rs
@@ -1,0 +1,183 @@
+//! S6 — CLI destructive confirmation conformance (black-box).
+//!
+//! These tests drive the *built* `flowplane` binary as a subprocess and assert only against
+//! the documented confirmation contract (CLI-R-22 / CLI-R-26). They never look at CLI
+//! internals: every assertion is derived from the acceptance criteria, not the implementation.
+//!
+//! Contract under test:
+//!   * CLI-R-22: Destructive actions (e.g. `cluster delete <name>`) confirm on a TTY;
+//!     `--yes`/`-y` bypasses the confirmation. A declared `--yes` must gate a real
+//!     confirmation (no dead flag).
+//!   * CLI-R-26: When stdin is NOT a TTY, no command ever blocks on a prompt. A destructive
+//!     action on a non-TTY WITHOUT `--yes` fails fast with exit code 2 and a hint to pass
+//!     `--yes`, and must NEVER read/block on stdin. Example:
+//!     `flowplane cluster delete db < /dev/null`
+//!     → stderr contains `error (confirmation_required): ... pass --yes`, exit 2.
+//!
+//! Scope boundary — PTY path NOT covered here: the interactive `[y/N]` "y" acceptance path
+//! requires a real PTY. `std::process::Command::output()` gives the child a NULL (closed,
+//! non-TTY) stdin, so only the non-TTY paths are exercised here. The interactive accept path
+//! is covered by unit tests; a PTY dependency is not worth pulling in for this slice.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod common;
+
+use std::process::{Output, Stdio};
+
+fn exit_code(out: &Output) -> i32 {
+    out.status
+        .code()
+        .unwrap_or_else(|| panic!("process terminated without an exit code (killed by signal?)"))
+}
+
+// ---------------------------------------------------------------------------------------------
+// Case 1: `--yes` skips confirm on a non-TTY → delete proceeds (exit 0). Proves `--yes` is NOT
+// a dead flag — it bypasses the confirmation guard and the (204) network call succeeds.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn yes_skips_confirm_and_delete_proceeds() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args([
+            "cluster", "delete", "alpha", "--team", "payments", "--yes", "-o", "json",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("run cluster delete alpha --yes");
+
+    assert_eq!(
+        exit_code(&out),
+        0,
+        "--yes must bypass confirmation on non-TTY and let the delete (204) succeed (exit 0): \
+         stderr {:?}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        !out.stdout.is_empty(),
+        "--yes delete must emit a JSON success envelope on stdout, got empty: stderr {:?}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Case 2: non-TTY WITHOUT `--yes` → fail fast exit 2, never blocks. The captured subprocess
+// already has a non-TTY stdin; we set `Stdio::null()` explicitly to be unambiguous. The CLI
+// must refuse rather than prompt: exit 2, `confirmation_required` + `--yes` on stderr, empty
+// stdout. (`.output()` waits for the child, so the test returning at all proves it did not
+// block on stdin — the timeout-bounded liveness check.)
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn non_tty_without_yes_fails_fast_exit_2() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args([
+            "cluster", "delete", "alpha", "--team", "payments", "-o", "json",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("run cluster delete alpha (no --yes, non-TTY)");
+
+    assert_eq!(
+        exit_code(&out),
+        2,
+        "destructive action on non-TTY without --yes must fail fast with exit 2: stderr {:?}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("confirmation_required"),
+        "stderr must carry the `confirmation_required` error code: {stderr:?}",
+    );
+    assert!(
+        stderr.contains("--yes"),
+        "stderr must hint to pass `--yes`: {stderr:?}",
+    );
+    assert!(
+        out.stdout.is_empty(),
+        "confirmation-required error must keep stdout empty, got: {:?}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Case 3: the short alias `-y` also skips confirmation (exit 0). The spec says `--yes/-y`, so
+// if `-y` is not wired as a valid alias this fails — a legitimate contract check.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn short_y_alias_skips_confirm() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args([
+            "cluster", "delete", "alpha", "--team", "payments", "-y", "-o", "json",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("run cluster delete alpha -y");
+
+    assert_eq!(
+        exit_code(&out),
+        0,
+        "-y (short alias of --yes) must bypass confirmation and let the delete succeed (exit 0): \
+         stderr {:?}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        !out.stdout.is_empty(),
+        "-y delete must emit a JSON success envelope on stdout, got empty: stderr {:?}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Case 4: confirmation fires BEFORE the network call. Point the CLI at a DEAD server and delete
+// with NO `--yes` on a non-TTY: the guard must short-circuit with exit 2 / `confirmation_required`
+// rather than ever reaching the (failing) transport — a transport error would be a different
+// exit code. This locks in "confirm gates before network".
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn confirm_gates_before_network() {
+    let home = common::unique_tempdir();
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", common::dead_base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args([
+            "cluster", "delete", "alpha", "--team", "payments", "-o", "json",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("run cluster delete alpha (no --yes) against a dead server");
+
+    assert_eq!(
+        exit_code(&out),
+        2,
+        "confirmation guard must short-circuit BEFORE any network call (exit 2, not a transport \
+         error exit code): stderr {:?}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("confirmation_required"),
+        "stderr must carry `confirmation_required` (proving confirm ran before network): {stderr:?}",
+    );
+    assert!(
+        out.stdout.is_empty(),
+        "confirmation-required error must keep stdout empty, got: {:?}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+}

--- a/crates/flowplane/tests/cli_s7_coverage.rs
+++ b/crates/flowplane/tests/cli_s7_coverage.rs
@@ -1,0 +1,749 @@
+//! S7 — whole-tree CLI coverage capstone (black-box).
+//!
+//! This is the coverage capstone for the Flowplane CLI conformance epic. The CLI's output
+//! rules live in a shared layer (`render()`, the typed `{schemaVersion, kind, data}` envelope,
+//! and `GlobalOptions`), so they apply to every command *by construction* — but this file
+//! PROVES that coverage instead of assuming it, with NO silent sampling.
+//!
+//! The serialized clap command tree is read **black-box** from `flowplane schema -o json`
+//! (envelope `{schemaVersion, kind:"cliSchema", data:{catalogVersion, command}}`). The root
+//! `command` node is recursive: `{name, about, args, subcommands}`; each arg carries the
+//! documented keys `name`/`long`/`short`/`type`/`required`/`global`/`takesValue`/`valueNames`/
+//! `possibleValues`/`defaults`/`help`. GLOBAL flags (output/json/no-color/quiet/verbose/
+//! dry-run/yes/revision/fields/timeout/out/token/server/team/org/context) live on the ROOT
+//! command's `args`; per-subcommand `args` hold only that command's own flags.
+//!
+//! What this file proves:
+//!   * Test 1 (criterion 13): a frozen, hand-listed inventory of EVERY leaf command path,
+//!     partitioned into SNAPSHOT_COVERED / EXEMPT / SHARED_LAYER_COVERED, whose union must
+//!     equal the live leaf set EXACTLY — a new or removed command fails CI loudly.
+//!   * Test 2 (criterion 4 / CLI-R-15): frozen `-o json` envelopes for the whole cluster
+//!     family, driven against the harness mock — any shape/field drift in the shared envelope
+//!     fails CI.
+//!   * Test 3 (criterion 13): structural clap-lints read off `flowplane schema` — output is a
+//!     universal global, `-o` is format-only, `--revision` stays global, file-driven mutators
+//!     carry `-f`.
+//!   * Test 4 (criterion 13): `-o`/`--quiet` honoured on a representative command.
+//!
+//! Parallel-safety (criterion 13a): every test uses a per-test `unique_tempdir()`, a per-test
+//! ephemeral-port mock, and per-child env; no shared global state and no `--test-threads=1`,
+//! so the suite passes run twice concurrently.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod common;
+
+use std::collections::BTreeSet;
+use std::process::Output;
+
+use serde_json::{json, Value};
+
+// =============================================================================================
+// Frozen leaf inventories (Test 1). The UNION of these three must equal the live leaf set.
+// =============================================================================================
+
+/// Leaf paths whose exact `-o json` envelope is frozen live against the mock in Test 2.
+const SNAPSHOT_COVERED: &[&str] = &[
+    "cluster list",
+    "cluster get",
+    "cluster create",
+    "cluster update",
+    "cluster delete",
+];
+
+/// Leaf paths that do NOT emit the resource-JSON envelope and so have no envelope to snapshot.
+/// Each carries a one-line reason for the exemption.
+const EXEMPT: &[&str] = &[
+    "serve",                   // long-running daemon, never returns an envelope
+    "completion",              // emits a shell completion script, not the envelope
+    "db migrate",              // database migration runner
+    "auth login",              // interactive OIDC browser/device flow
+    "auth logout",             // clears local credentials
+    "auth token",              // prints the raw bearer token to stdout
+    "auth whoami",             // live-auth identity probe
+    "openapi",                 // emits an OpenAPI document, not the envelope
+    "dataplane bootstrap",     // emits Envoy bootstrap YAML
+    "dataplane cert list",     // PKI/cert material surface
+    "dataplane cert register", // PKI/cert material surface
+    "dataplane cert issue",    // PKI/cert material surface
+    "dataplane cert revoke",   // PKI/cert material surface
+    "config path",             // prints a filesystem path
+    "config set-context",      // mutates local config (no server envelope)
+    "config use-context",      // mutates local config (no server envelope)
+    "config get-contexts",     // local-config introspection (covered by S3)
+    "config show",             // local-config introspection (covered by S3)
+];
+
+/// Resource readers/mutators that flow through the SAME `render()` + RestClient envelope path
+/// already proven by the cluster snapshots (Test 2) and their own slice tests. Listing every
+/// one is the no-silent-sampling guarantee: the union check below fails if any command is added
+/// or removed without being classified here.
+const SHARED_LAYER_COVERED: &[&str] = &[
+    // org
+    "org list",
+    "org get",
+    "org create",
+    "org delete",
+    "org member list",
+    "org member add",
+    "org member remove",
+    // team
+    "team list",
+    "team create",
+    "team delete",
+    "team member list",
+    "team member add",
+    "team member remove",
+    "team grant list",
+    "team grant add",
+    "team grant remove",
+    // listener
+    "listener list",
+    "listener get",
+    "listener create",
+    "listener update",
+    "listener delete",
+    // route
+    "route list",
+    "route get",
+    "route create",
+    "route update",
+    "route delete",
+    "route generate",
+    "route apply",
+    // api
+    "api list",
+    "api get",
+    "api status",
+    "api create",
+    "api delete",
+    "api spec reject",
+    "api spec publish",
+    // mcp
+    "mcp status",
+    "mcp connections",
+    "mcp enable",
+    "mcp disable",
+    // ai providers
+    "ai providers list",
+    "ai providers get",
+    "ai providers create",
+    "ai providers update",
+    "ai providers delete",
+    // ai routes
+    "ai routes list",
+    "ai routes get",
+    "ai routes create",
+    "ai routes update",
+    "ai routes delete",
+    // ai budgets
+    "ai budgets list",
+    "ai budgets get",
+    "ai budgets create",
+    "ai budgets update",
+    "ai budgets delete",
+    // ai usage
+    "ai usage",
+    // rate-limit domain
+    "rate-limit domain list",
+    "rate-limit domain get",
+    "rate-limit domain create",
+    "rate-limit domain update",
+    "rate-limit domain delete",
+    // rate-limit policy
+    "rate-limit policy list",
+    "rate-limit policy get",
+    "rate-limit policy create",
+    "rate-limit policy update",
+    "rate-limit policy delete",
+    // rate-limit override
+    "rate-limit override get",
+    "rate-limit override set",
+    "rate-limit override update",
+    "rate-limit override delete",
+    // rate-limit force-repush
+    "rate-limit force-repush",
+    // learn discover
+    "learn discover start",
+    "learn discover list",
+    "learn discover status",
+    "learn discover stop",
+    "learn discover generate-spec",
+    // learn
+    "learn start",
+    "learn list",
+    "learn get",
+    "learn stop",
+    "learn generate-spec",
+    "learn cancel",
+    // secret
+    "secret list",
+    "secret get",
+    "secret create",
+    "secret rotate",
+    // dataplane
+    "dataplane list",
+    "dataplane get",
+    "dataplane create",
+    "dataplane telemetry",
+    // stats
+    "stats overview",
+    // ops
+    "ops xds status",
+    "ops xds nacks",
+    "ops trace",
+    // top-level
+    "expose",
+    "unexpose",
+    "apply",
+    "version",
+    "schema",
+];
+
+// =============================================================================================
+// Helpers
+// =============================================================================================
+
+fn exit_code(out: &Output) -> i32 {
+    out.status
+        .code()
+        .unwrap_or_else(|| panic!("process terminated without an exit code (killed by signal?)"))
+}
+
+/// Run `flowplane schema -o json` with NO server configured (schema makes no network call) and
+/// return the parsed envelope. Uses an isolated temp HOME like every other test.
+fn live_schema() -> Value {
+    let home = common::unique_tempdir();
+    let out = common::flowplane_cmd(&home)
+        .args(["schema", "-o", "json"])
+        .output()
+        .expect("run schema -o json");
+    assert_eq!(
+        exit_code(&out),
+        0,
+        "schema -o json must exit 0; stderr: {:?}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    serde_json::from_slice(&out.stdout).unwrap_or_else(|e| {
+        panic!(
+            "schema stdout is not a JSON envelope ({e}): {:?}",
+            String::from_utf8_lossy(&out.stdout)
+        )
+    })
+}
+
+/// The recursive root `command` node from a parsed schema envelope.
+fn root_command(schema: &Value) -> &Value {
+    let cmd = &schema["data"]["command"];
+    assert!(
+        cmd.is_object(),
+        "data.command must be the root command object: {schema}"
+    );
+    cmd
+}
+
+/// Collect every LEAF command path (space-joined) from the command tree. A leaf is a node with
+/// an empty `subcommands` array. The root itself is excluded (its name is the binary).
+fn collect_leaves(command: &Value) -> BTreeSet<String> {
+    fn walk(node: &Value, path: &[String], acc: &mut BTreeSet<String>) {
+        let subs = node["subcommands"].as_array().cloned().unwrap_or_default();
+        if subs.is_empty() {
+            if !path.is_empty() {
+                acc.insert(path.join(" "));
+            }
+            return;
+        }
+        for s in &subs {
+            let name = s["name"]
+                .as_str()
+                .unwrap_or_else(|| panic!("each subcommand must have a string `name`: {s}"));
+            let mut next = path.to_vec();
+            next.push(name.to_string());
+            walk(s, &next, acc);
+        }
+    }
+    let mut acc = BTreeSet::new();
+    walk(command, &[], &mut acc);
+    acc
+}
+
+/// Walk every command node (root + all descendants), invoking `f(path, node)` for each.
+fn for_each_command<F: FnMut(&str, &Value)>(command: &Value, mut f: F) {
+    fn walk<F: FnMut(&str, &Value)>(node: &Value, path: &[String], f: &mut F) {
+        f(&path.join(" "), node);
+        if let Some(subs) = node["subcommands"].as_array() {
+            for s in subs {
+                let name = s["name"].as_str().unwrap_or_default();
+                let mut next = path.to_vec();
+                next.push(name.to_string());
+                walk(s, &next, f);
+            }
+        }
+    }
+    walk(command, &[], &mut f);
+}
+
+/// Find a leaf command node by its space-joined path.
+fn find_command<'a>(command: &'a Value, target: &str) -> Option<&'a Value> {
+    fn walk<'a>(node: &'a Value, path: &[String], target: &str) -> Option<&'a Value> {
+        if path.join(" ") == target {
+            return Some(node);
+        }
+        if let Some(subs) = node["subcommands"].as_array() {
+            for s in subs {
+                let name = s["name"].as_str().unwrap_or_default();
+                let mut next = path.to_vec();
+                next.push(name.to_string());
+                if let Some(found) = walk(s, &next, target) {
+                    return Some(found);
+                }
+            }
+        }
+        None
+    }
+    walk(command, &[], target)
+}
+
+/// True if this command node declares its own arg with `long == long` and `short == short`.
+fn has_arg(node: &Value, long: &str, short: Option<&str>) -> bool {
+    node["args"]
+        .as_array()
+        .map(|args| {
+            args.iter().any(|a| {
+                a["long"].as_str() == Some(long)
+                    && (short.is_none() || a["short"].as_str() == short)
+            })
+        })
+        .unwrap_or(false)
+}
+
+/// Parse a child's stdout as the JSON success envelope, asserting exit 0.
+fn parse_envelope(out: &Output, ctx: &str) -> Value {
+    assert_eq!(
+        exit_code(out),
+        0,
+        "{ctx}: expected exit 0, got {:?}; stderr: {:?}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    serde_json::from_slice(&out.stdout).unwrap_or_else(|e| {
+        panic!(
+            "{ctx}: stdout is not a JSON envelope ({e}): {:?}",
+            String::from_utf8_lossy(&out.stdout)
+        )
+    })
+}
+
+/// Write the minimal valid-JSON body file the mock ignores (no `name` → mock defaults to
+/// `created`), return its path string.
+fn write_body(home: &std::path::Path) -> String {
+    let path = home.join("body.json");
+    std::fs::write(&path, r#"{"spec":{"endpoints":[]}}"#).expect("write body file");
+    path.to_str().expect("body path is utf-8").to_string()
+}
+
+// =============================================================================================
+// Test 1 — Frozen leaf inventory (criterion 13): union of the three lists == live leaf set.
+// =============================================================================================
+#[test]
+fn frozen_leaf_inventory_equals_live_tree() {
+    let schema = live_schema();
+    let live = collect_leaves(root_command(&schema));
+
+    // The three inventories must be internally disjoint (no leaf classified twice).
+    let mut union: BTreeSet<String> = BTreeSet::new();
+    for (label, list) in [
+        ("SNAPSHOT_COVERED", SNAPSHOT_COVERED),
+        ("EXEMPT", EXEMPT),
+        ("SHARED_LAYER_COVERED", SHARED_LAYER_COVERED),
+    ] {
+        for &leaf in list {
+            assert!(
+                union.insert(leaf.to_string()),
+                "leaf `{leaf}` is classified in more than one inventory (found again in \
+                 {label}); each leaf must appear in exactly ONE list"
+            );
+        }
+    }
+
+    // The core no-silent-sampling guarantee: union == live, exactly.
+    let missing_from_lists: Vec<&String> = live.difference(&union).collect();
+    let stale_in_lists: Vec<&String> = union.difference(&live).collect();
+
+    assert!(
+        missing_from_lists.is_empty() && stale_in_lists.is_empty(),
+        "CLI leaf inventory drifted from the live `flowplane schema` tree.\n\
+         \n  NEW leaves present live but NOT classified (add a snapshot or classify each into \
+         SNAPSHOT_COVERED / EXEMPT / SHARED_LAYER_COVERED): {missing_from_lists:?}\n\
+         \n  STALE leaves in the inventory but NO LONGER live (remove them): {stale_in_lists:?}\n\
+         \n  live leaf count = {}, classified leaf count = {}",
+        live.len(),
+        union.len(),
+    );
+}
+
+// =============================================================================================
+// Test 2 — Live `-o json` snapshots for the cluster family (criterion 4 / CLI-R-15).
+// A field/shape diff in the shared envelope fails CI. Discovered `kind` values:
+//   list → "clusterList"  |  get/create/update → "cluster"  |  delete → "mutationResult".
+// =============================================================================================
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cluster_family_json_envelopes_are_frozen() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+    let body = write_body(&home);
+
+    let run = |args: Vec<String>| {
+        common::flowplane_cmd(&home)
+            .env("FLOWPLANE_SERVER", mock.base_url())
+            .env("FLOWPLANE_TOKEN", "t")
+            .args(&args)
+            .output()
+            .expect("run cluster command")
+    };
+
+    // cluster list → clusterList, data is the two-item array.
+    let list = run(vec![
+        "cluster".into(),
+        "list".into(),
+        "--team".into(),
+        "payments".into(),
+        "-o".into(),
+        "json".into(),
+    ]);
+    assert_eq!(
+        parse_envelope(&list, "cluster list"),
+        json!({
+            "schemaVersion": 1,
+            "kind": "clusterList",
+            "data": [
+                { "name": "alpha", "revision": 1, "service_name": "alpha-svc" },
+                { "name": "beta", "revision": 2, "service_name": "beta-svc" }
+            ]
+        }),
+        "cluster list -o json envelope drifted"
+    );
+
+    // cluster get alpha → cluster, single object.
+    let get = run(vec![
+        "cluster".into(),
+        "get".into(),
+        "alpha".into(),
+        "--team".into(),
+        "payments".into(),
+        "-o".into(),
+        "json".into(),
+    ]);
+    assert_eq!(
+        parse_envelope(&get, "cluster get alpha"),
+        json!({
+            "schemaVersion": 1,
+            "kind": "cluster",
+            "data": { "name": "alpha", "revision": 1, "service_name": "svc" }
+        }),
+        "cluster get -o json envelope drifted"
+    );
+
+    // cluster create -f <body> → cluster; mock derives name from body (none → "created").
+    let create = run(vec![
+        "cluster".into(),
+        "create".into(),
+        "--team".into(),
+        "payments".into(),
+        "-f".into(),
+        body.clone(),
+        "-o".into(),
+        "json".into(),
+    ]);
+    assert_eq!(
+        parse_envelope(&create, "cluster create"),
+        json!({
+            "schemaVersion": 1,
+            "kind": "cluster",
+            "data": { "name": "created", "revision": 1 }
+        }),
+        "cluster create -o json envelope drifted"
+    );
+
+    // cluster update demo -f <body> --revision 1 → cluster; applied_revision echoes If-Match (1).
+    let update = run(vec![
+        "cluster".into(),
+        "update".into(),
+        "demo".into(),
+        "--team".into(),
+        "payments".into(),
+        "-f".into(),
+        body.clone(),
+        "--revision".into(),
+        "1".into(),
+        "-o".into(),
+        "json".into(),
+    ]);
+    assert_eq!(
+        parse_envelope(&update, "cluster update demo"),
+        json!({
+            "schemaVersion": 1,
+            "kind": "cluster",
+            "data": { "name": "demo", "revision": 2, "applied_revision": 1 }
+        }),
+        "cluster update -o json envelope drifted"
+    );
+
+    // cluster delete alpha --yes --revision 1 → mutationResult (mock returns 204). `--yes` is
+    // required because the subprocess stdin is non-TTY (else the confirm prompt exits 2).
+    let delete = run(vec![
+        "cluster".into(),
+        "delete".into(),
+        "alpha".into(),
+        "--team".into(),
+        "payments".into(),
+        "--yes".into(),
+        "--revision".into(),
+        "1".into(),
+        "-o".into(),
+        "json".into(),
+    ]);
+    assert_eq!(
+        parse_envelope(&delete, "cluster delete alpha"),
+        json!({
+            "schemaVersion": 1,
+            "kind": "mutationResult",
+            "data": {
+                "method": "DELETE",
+                "path": "/api/v1/teams/payments/clusters/alpha",
+                "result": "ok"
+            }
+        }),
+        "cluster delete -o json envelope drifted"
+    );
+}
+
+// =============================================================================================
+// Test 3 — clap-lints (criterion 13): structural invariants, read black-box off the schema.
+// =============================================================================================
+#[test]
+fn clap_lints_hold_across_the_whole_tree() {
+    let schema = live_schema();
+    let command = root_command(&schema);
+
+    // ---- output-flag-universal: the root has a global `--output`/`-o` of type enum. ----
+    let output = command["args"]
+        .as_array()
+        .and_then(|args| args.iter().find(|a| a["long"].as_str() == Some("output")))
+        .unwrap_or_else(|| panic!("root command must declare a global `--output` arg"));
+    assert_eq!(
+        output["short"].as_str(),
+        Some("o"),
+        "global --output must have short `-o`: {output}"
+    );
+    assert_eq!(
+        output["type"].as_str(),
+        Some("enum"),
+        "global --output must be of type `enum`: {output}"
+    );
+    assert_eq!(
+        output["global"].as_bool(),
+        Some(true),
+        "--output must be a global so it applies to every command: {output}"
+    );
+
+    // ---- o-is-format-only: the ONLY arg anywhere whose short == "o" is the root `output`. ----
+    let mut o_claimers: Vec<(String, String)> = Vec::new();
+    for_each_command(command, |path, node| {
+        if let Some(args) = node["args"].as_array() {
+            for a in args {
+                if a["short"].as_str() == Some("o") {
+                    let where_ = if path.is_empty() {
+                        "ROOT".to_string()
+                    } else {
+                        path.to_string()
+                    };
+                    o_claimers.push((where_, a["long"].as_str().unwrap_or("?").to_string()));
+                }
+            }
+        }
+    });
+    assert_eq!(
+        o_claimers,
+        vec![("ROOT".to_string(), "output".to_string())],
+        "the short flag `-o` must be claimed by exactly ONE arg (root `--output`); other \
+         claimants collide with the format flag: {o_claimers:?}"
+    );
+
+    // ---- revision-uniform: `--revision` is a global integer on root, applying to every ----
+    // update/delete by construction. The ONLY legitimate per-subcommand re-declaration is
+    // `secret rotate`, where revision is a required local positional of the rotate semantic.
+    let revision = command["args"]
+        .as_array()
+        .and_then(|args| args.iter().find(|a| a["long"].as_str() == Some("revision")))
+        .unwrap_or_else(|| panic!("root command must declare a global `--revision` arg"));
+    assert_eq!(
+        revision["global"].as_bool(),
+        Some(true),
+        "--revision must be a global so every update/delete accepts it: {revision}"
+    );
+    assert_eq!(
+        revision["type"].as_str(),
+        Some("integer"),
+        "--revision must be of type `integer`: {revision}"
+    );
+    let mut local_revisions: BTreeSet<String> = BTreeSet::new();
+    for_each_command(command, |path, node| {
+        if path.is_empty() {
+            return; // the root's global revision is expected.
+        }
+        if let Some(args) = node["args"].as_array() {
+            if args.iter().any(|a| a["long"].as_str() == Some("revision")) {
+                local_revisions.insert(path.to_string());
+            }
+        }
+    });
+    let expected_local: BTreeSet<String> = ["secret rotate".to_string()].into_iter().collect();
+    assert_eq!(
+        local_revisions, expected_local,
+        "`--revision` must stay global and NOT be re-declared per-subcommand, with the single \
+         documented exception of `secret rotate` (required local revision). Unexpected/duplicated \
+         declarations: {local_revisions:?}"
+    );
+
+    // ---- file-driven mutators carry `-f`: every file-bearing leaf is a known body-driven ----
+    // create/update/rotate/set/telemetry/register/apply, each with short `f`; readers must not.
+    // (NOTE: not every `create` leaf takes -f — org/team/api/dataplane create use flags, not a
+    // manifest body — so the lint pins the EXACT file-driven set rather than "all creates".)
+    let mut file_bearing: BTreeSet<String> = BTreeSet::new();
+    for leaf in collect_leaves(command) {
+        let node = find_command(command, &leaf).expect("leaf exists in tree");
+        if node["args"]
+            .as_array()
+            .map(|args| args.iter().any(|a| a["long"].as_str() == Some("file")))
+            .unwrap_or(false)
+        {
+            // Every file arg must use the `-f` short form.
+            assert!(
+                has_arg(node, "file", Some("f")),
+                "`{leaf}` declares a `--file` arg but not with short `-f`: {node}"
+            );
+            file_bearing.insert(leaf);
+        }
+    }
+    let expected_file_bearing: BTreeSet<String> = [
+        "apply",
+        "cluster create",
+        "cluster update",
+        "listener create",
+        "listener update",
+        "route create",
+        "route update",
+        "ai providers create",
+        "ai providers update",
+        "ai routes create",
+        "ai routes update",
+        "ai budgets create",
+        "ai budgets update",
+        "rate-limit domain create",
+        "rate-limit domain update",
+        "rate-limit policy create",
+        "rate-limit policy update",
+        "rate-limit override set",
+        "rate-limit override update",
+        "secret create",
+        "secret rotate",
+        "dataplane telemetry",
+        "dataplane cert register",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect();
+    assert_eq!(
+        file_bearing, expected_file_bearing,
+        "the set of leaves carrying a `-f`/`--file` arg drifted; every file-driven mutator must \
+         keep `-f` and no reader may gain one"
+    );
+
+    // Spot-check the canonical body-driven mutators positively...
+    for leaf in ["cluster create", "cluster update", "secret rotate"] {
+        let node = find_command(command, leaf).expect("leaf exists");
+        assert!(
+            has_arg(node, "file", Some("f")),
+            "`{leaf}` must carry a per-command `-f`/`--file` arg: {node}"
+        );
+    }
+    // ...and confirm readers do NOT require a file body.
+    for leaf in ["cluster list", "cluster get", "cluster delete"] {
+        let node = find_command(command, leaf).expect("leaf exists");
+        assert!(
+            !has_arg(node, "file", None),
+            "reader `{leaf}` must NOT declare a `--file` arg: {node}"
+        );
+    }
+}
+
+// =============================================================================================
+// Test 4 — `-o` / `--quiet` honoured on a representative command (criterion 13).
+// =============================================================================================
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn output_format_and_quiet_are_honoured() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+
+    let run = |extra: &[&str]| {
+        let mut args = vec!["cluster", "list", "--team", "payments"];
+        args.extend_from_slice(extra);
+        common::flowplane_cmd(&home)
+            .env("FLOWPLANE_SERVER", mock.base_url())
+            .env("FLOWPLANE_TOKEN", "t")
+            .args(&args)
+            .output()
+            .expect("run cluster list")
+    };
+
+    // `-o json` parses as the data envelope.
+    let json_out = run(&["-o", "json"]);
+    let json_env = parse_envelope(&json_out, "cluster list -o json");
+    assert_eq!(
+        json_env["kind"], "clusterList",
+        "json kind must be clusterList"
+    );
+
+    // `-o yaml` differs from json: the same payload rendered as YAML is NOT valid JSON.
+    let yaml_out = run(&["-o", "yaml"]);
+    assert_eq!(
+        exit_code(&yaml_out),
+        0,
+        "cluster list -o yaml must exit 0; stderr: {:?}",
+        String::from_utf8_lossy(&yaml_out.stderr)
+    );
+    assert_ne!(
+        yaml_out.stdout, json_out.stdout,
+        "`-o yaml` output must differ from `-o json`"
+    );
+    assert!(
+        serde_json::from_slice::<Value>(&yaml_out.stdout).is_err(),
+        "`-o yaml` must NOT parse as JSON: {:?}",
+        String::from_utf8_lossy(&yaml_out.stdout)
+    );
+
+    // `-o json --quiet` still emits the data envelope on stdout (quiet silences chrome, not the
+    // requested data), and stdout is exactly that one JSON document with no extra prose.
+    let quiet_out = run(&["-o", "json", "--quiet"]);
+    let quiet_env = parse_envelope(&quiet_out, "cluster list -o json --quiet");
+    assert_eq!(
+        quiet_env["kind"], "clusterList",
+        "`--quiet` must not suppress the requested data envelope"
+    );
+    assert!(
+        quiet_env["data"].is_array(),
+        "`--quiet` data envelope must still carry the list array: {quiet_env}"
+    );
+    // No trailing prose: stdout is a single parseable JSON document and nothing else.
+    let mut docs = serde_json::Deserializer::from_slice(&quiet_out.stdout).into_iter::<Value>();
+    assert!(
+        docs.next().is_some(),
+        "quiet stdout must contain the envelope"
+    );
+    assert!(
+        docs.next().is_none(),
+        "quiet stdout must be exactly ONE JSON document with no extra prose: {:?}",
+        String::from_utf8_lossy(&quiet_out.stdout)
+    );
+}

--- a/crates/flowplane/tests/common/mod.rs
+++ b/crates/flowplane/tests/common/mod.rs
@@ -1,0 +1,152 @@
+//! Shared, parallel-safe test scaffolding for the CLI conformance suite.
+//!
+//! This module is neutral test infrastructure — an ephemeral HTTP mock that mimics the
+//! Flowplane REST surface, plus a helper that runs the *built* `flowplane` binary as a
+//! subprocess with an isolated `HOME`/`FLOWPLANE_CONFIG` and explicit per-child env. It
+//! deliberately contains no assertions and no knowledge of the CLI's output internals:
+//! tests drive the binary black-box and assert against the documented contract.
+//!
+//! Parallel-safety (invariant 18): the mock binds `127.0.0.1:0` (unique port per test) and
+//! every child process gets its own temp dir + env, so the suite runs green under default
+//! nextest parallelism with no `--test-threads=1`.
+#![allow(dead_code)]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::Path;
+use axum::http::StatusCode;
+use axum::routing::get;
+use axum::{Json, Router};
+use serde_json::{json, Value};
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+
+/// A running mock server. Aborts its task on drop.
+pub struct MockServer {
+    base_url: String,
+    handle: JoinHandle<()>,
+}
+
+impl MockServer {
+    /// `http://127.0.0.1:<port>` to pass as `FLOWPLANE_SERVER` / `--server`.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+impl Drop for MockServer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+/// Start an ephemeral mock of the resource REST surface on a unique loopback port.
+///
+/// Behavior (enough for the output-model slice):
+/// - `GET    /api/v1/teams/{team}/clusters`         → 200, a two-item list
+/// - `GET    /api/v1/teams/{team}/clusters/{name}`  → 200, a single object
+/// - `POST   /api/v1/teams/{team}/clusters`         → 201, the created object
+/// - `PATCH  /api/v1/teams/{team}/clusters/{name}`  → 200, the updated object
+/// - `DELETE /api/v1/teams/{team}/clusters/{name}`  → 204, empty body
+pub async fn start_mock() -> MockServer {
+    let app = Router::new()
+        .route(
+            "/api/v1/teams/{team}/clusters",
+            get(list_clusters).post(create_cluster),
+        )
+        .route(
+            "/api/v1/teams/{team}/clusters/{name}",
+            get(get_cluster)
+                .patch(update_cluster)
+                .delete(delete_cluster),
+        );
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock server to an ephemeral port");
+    let addr = listener.local_addr().expect("mock server local addr");
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    MockServer {
+        base_url: format!("http://{addr}"),
+        handle,
+    }
+}
+
+async fn list_clusters(Path(_team): Path<String>) -> Json<Value> {
+    Json(json!([
+        { "name": "alpha", "revision": 1, "service_name": "alpha-svc" },
+        { "name": "beta", "revision": 2, "service_name": "beta-svc" }
+    ]))
+}
+
+async fn get_cluster(Path((_team, name)): Path<(String, String)>) -> Json<Value> {
+    Json(json!({ "name": name, "revision": 1, "service_name": "svc" }))
+}
+
+async fn create_cluster(
+    Path(_team): Path<String>,
+    Json(body): Json<Value>,
+) -> (StatusCode, Json<Value>) {
+    let name = body
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or("created")
+        .to_string();
+    (
+        StatusCode::CREATED,
+        Json(json!({ "name": name, "revision": 1 })),
+    )
+}
+
+async fn update_cluster(
+    Path((_team, name)): Path<(String, String)>,
+    Json(_body): Json<Value>,
+) -> Json<Value> {
+    Json(json!({ "name": name, "revision": 2 }))
+}
+
+async fn delete_cluster(Path((_team, _name)): Path<(String, String)>) -> StatusCode {
+    StatusCode::NO_CONTENT
+}
+
+static SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// A unique temp directory for one test's isolated `HOME`/`FLOWPLANE_CONFIG`.
+pub fn unique_tempdir() -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after epoch")
+        .as_nanos();
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!(
+        "flowplane-cli-it-{}-{nanos}-{seq}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// A `Command` for the built `flowplane` binary with a clean, isolated environment.
+///
+/// Inherits nothing output-affecting from the parent: `HOME` and `FLOWPLANE_CONFIG` point
+/// at a fresh temp dir, `NO_COLOR` is cleared, and `--server`/token are left to the caller.
+pub fn flowplane_cmd(home: &std::path::Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_flowplane"));
+    cmd.env_clear();
+    // Keep a minimal PATH so the process can run; everything else is explicit.
+    if let Some(path) = std::env::var_os("PATH") {
+        cmd.env("PATH", path);
+    }
+    cmd.env("HOME", home);
+    cmd.env("FLOWPLANE_CONFIG", home.join("config.toml"));
+    cmd.env_remove("NO_COLOR");
+    cmd.env_remove("FLOWPLANE_TOKEN");
+    cmd.env_remove("FLOWPLANE_SERVER");
+    cmd
+}

--- a/crates/flowplane/tests/common/mod.rs
+++ b/crates/flowplane/tests/common/mod.rs
@@ -110,9 +110,30 @@ fn injected_error(name: &str) -> Option<(StatusCode, Value)> {
     Some((status, body))
 }
 
-async fn get_cluster(Path((_team, name)): Path<(String, String)>) -> (StatusCode, Json<Value>) {
+async fn get_cluster(
+    Path((_team, name)): Path<(String, String)>,
+    headers: axum::http::HeaderMap,
+) -> (StatusCode, Json<Value>) {
     if let Some((status, body)) = injected_error(&name) {
         return (status, Json(body));
+    }
+    // The reserved name `probe` echoes the request's effective auth/scope headers, so a test
+    // can observe which token/org the CLI's precedence resolution actually sent.
+    if name == "probe" {
+        let header = |key: &str| {
+            headers
+                .get(key)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string)
+        };
+        return (
+            StatusCode::OK,
+            Json(json!({
+                "name": "probe",
+                "received_authorization": header("authorization"),
+                "received_org": header("x-flowplane-org"),
+            })),
+        );
     }
     (
         StatusCode::OK,

--- a/crates/flowplane/tests/common/mod.rs
+++ b/crates/flowplane/tests/common/mod.rs
@@ -156,16 +156,57 @@ async fn create_cluster(
     )
 }
 
+/// The `If-Match` revision the CLI sent (read-modify-write / explicit `--revision`), or null.
+fn if_match(headers: &axum::http::HeaderMap) -> Value {
+    headers
+        .get(axum::http::header::IF_MATCH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<i64>().ok())
+        .map(|n| json!(n))
+        .unwrap_or(Value::Null)
+}
+
 async fn update_cluster(
     Path((_team, name)): Path<(String, String)>,
+    headers: axum::http::HeaderMap,
     Json(_body): Json<Value>,
-) -> Json<Value> {
-    Json(json!({ "name": name, "revision": 2 }))
+) -> Response {
+    // The reserved name `conflict` simulates a revision race: whatever the client sent as
+    // `If-Match`, the server has moved on to revision 7 and rejects with 409.
+    if name == "conflict" {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "code": "conflict",
+                "message": "revision mismatch: current revision is 7"
+            })),
+        )
+            .into_response();
+    }
+    // Echo the received If-Match so a test can prove the CLI sent the resource's current
+    // revision (read-modify-write) when no explicit --revision was given.
+    Json(json!({
+        "name": name,
+        "revision": 2,
+        "applied_revision": if_match(&headers),
+    }))
+    .into_response()
 }
 
 async fn delete_cluster(Path((_team, name)): Path<(String, String)>) -> Response {
     if let Some((status, body)) = injected_error(&name) {
         return (status, Json(body)).into_response();
+    }
+    // The reserved name `conflict` simulates a revision race on delete.
+    if name == "conflict" {
+        return (
+            StatusCode::CONFLICT,
+            Json(json!({
+                "code": "conflict",
+                "message": "revision mismatch: current revision is 7"
+            })),
+        )
+            .into_response();
     }
     StatusCode::NO_CONTENT.into_response()
 }

--- a/crates/flowplane/tests/common/mod.rs
+++ b/crates/flowplane/tests/common/mod.rs
@@ -19,6 +19,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::extract::Path;
 use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
 use serde_json::{json, Value};
@@ -85,8 +86,38 @@ async fn list_clusters(Path(_team): Path<String>) -> Json<Value> {
     ]))
 }
 
-async fn get_cluster(Path((_team, name)): Path<(String, String)>) -> Json<Value> {
-    Json(json!({ "name": name, "revision": 1, "service_name": "svc" }))
+/// Error injection: a resource name like `err-404`/`err-429`/`err-503`/`err-401`/`err-403`
+/// makes the item endpoints return that HTTP status with a JSON error body, so error-path
+/// tests can drive every status class deterministically. Any other name is a normal 200.
+fn injected_error(name: &str) -> Option<(StatusCode, Value)> {
+    let code = name.strip_prefix("err-")?.parse::<u16>().ok()?;
+    let status = StatusCode::from_u16(code).ok()?;
+    let body = match status {
+        // 401 deliberately omits a `hint` so the client must synthesize the login hint.
+        StatusCode::UNAUTHORIZED => {
+            json!({ "code": "unauthorized", "message": "missing or invalid token" })
+        }
+        // 403 names the (resource, action) the way deny_to_error does server-side.
+        StatusCode::FORBIDDEN => json!({
+            "code": "forbidden",
+            "message": "access denied",
+            "hint": "forbidden: team:payments resource=clusters action=delete"
+        }),
+        StatusCode::NOT_FOUND => json!({ "code": "not_found", "message": "cluster not found" }),
+        StatusCode::TOO_MANY_REQUESTS => json!({ "code": "rate_limited", "message": "slow down" }),
+        _ => json!({ "code": status.as_str(), "message": "server error" }),
+    };
+    Some((status, body))
+}
+
+async fn get_cluster(Path((_team, name)): Path<(String, String)>) -> (StatusCode, Json<Value>) {
+    if let Some((status, body)) = injected_error(&name) {
+        return (status, Json(body));
+    }
+    (
+        StatusCode::OK,
+        Json(json!({ "name": name, "revision": 1, "service_name": "svc" })),
+    )
 }
 
 async fn create_cluster(
@@ -111,8 +142,21 @@ async fn update_cluster(
     Json(json!({ "name": name, "revision": 2 }))
 }
 
-async fn delete_cluster(Path((_team, _name)): Path<(String, String)>) -> StatusCode {
-    StatusCode::NO_CONTENT
+async fn delete_cluster(Path((_team, name)): Path<(String, String)>) -> Response {
+    if let Some((status, body)) = injected_error(&name) {
+        return (status, Json(body)).into_response();
+    }
+    StatusCode::NO_CONTENT.into_response()
+}
+
+/// A loopback URL with no listener — connecting to it fails fast with "connection refused",
+/// for exercising the transport-error path. Binds an ephemeral port then drops it so the
+/// port is (almost certainly) free again, avoiding a fixed-port collision.
+pub fn dead_base_url() -> String {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local addr");
+    drop(listener);
+    format!("http://{addr}")
 }
 
 static SEQ: AtomicU64 = AtomicU64::new(0);

--- a/docs/concepts/cli-contract.md
+++ b/docs/concepts/cli-contract.md
@@ -1,0 +1,88 @@
+# The CLI as a typed contract
+
+> Audience: cli-users, api-teams, platform-engineers · Status: stable
+
+This page explains *why* the `flowplane` CLI behaves the way it does — the versioned output
+envelope, the structured errors, the scriptable exit codes, optimistic concurrency, and the
+`schema` command. It is understanding-oriented. For the step-by-step recipe see
+[Script Flowplane from a shell or agent](../how-to/script-the-cli.md); for exact fields and flags
+see [`../reference/cli.md`](../reference/cli.md).
+
+## One surface, two consumers
+
+Flowplane's command surface has two readers: a **human** at a terminal, and an **agent/script**
+consuming the same binary. A CLI that only reads well to a human forces machines to scrape prose —
+brittle, and the first thing that breaks on a cosmetic change. So the CLI is designed as a *typed
+contract*: a human-friendly default that becomes a stable, machine-parseable shape the moment it is
+consumed by a program. The same command serves both; neither pays for the other.
+
+That single idea explains every behavior below.
+
+## Output adapts to its consumer
+
+Reader commands print a table on an interactive terminal and switch to JSON automatically when
+stdout is not a terminal. The terminal is the signal: a human gets readability, a pipe gets data.
+An explicit `-o/--output` always wins, so a script never has to depend on that heuristic.
+
+## Why a versioned envelope, not a bare object
+
+Every JSON success payload is wrapped in `{schemaVersion, kind, data}` rather than printed raw.
+Three reasons:
+
+- **Forward compatibility.** `schemaVersion` is an integer contract version. Consumers can detect a
+  shape change instead of silently mis-parsing one. The shape is frozen by a snapshot test suite, so
+  a later release cannot quietly re-shape it.
+- **Self-description.** `kind` (`cluster`, `clusterList`, `mutationResult`, …) tells a consumer what
+  `data` is without inferring it from the command it ran.
+- **Uniformity.** Reads, mutations, and `schema` all use the same outer shape, so one parser handles
+  every command.
+
+The cost — a tiny wrapper around the resource — buys a stable integration point.
+
+## Errors are data, on the right stream
+
+Failures are written as a structured object to **stderr**, leaving stdout empty. A pipeline that
+reads stdout therefore never confuses an error for a result. The error object is deliberately *not*
+wrapped in the success envelope — it is a distinct shape with `code`, `message`, `retryable`, and
+(when present) `status`, `request_id`, and `hint`.
+
+`retryable` is the key affordance: it is `true` for transient failures (`429`, any `5xx`, transport
+and timeout errors) and `false` for terminal `4xx`. A client can implement backoff by reading one
+boolean instead of hard-coding a status list.
+
+## Exit codes carry the failure class
+
+The process exits `0` on success and a **specific code by failure class** otherwise — usage `2`,
+auth `3`, not-found/conflict `4`, validation `5`, rate-limited `6`, server/transport `7` — rather
+than a generic non-zero. A script can branch on `$?` alone, before parsing any JSON, and a CI job
+can distinguish "your input was wrong" (`2`/`5`) from "the server is down" (`7`). The codes mirror
+the error classes, so the exit code and the `code`/`retryable` fields always agree.
+
+## Optimistic concurrency instead of last-write-wins
+
+`update` and `delete` are revision-checked. With an explicit `--revision`, the CLI sends it as an
+`If-Match` precondition; with none, it reads the resource's current revision first and sends that
+(read-modify-write). Either way a concurrent edit surfaces as a `409` (exit `4`) that names both the
+attempted and the server's current revision — a detected conflict, never a silent overwrite. This
+keeps two operators (or two agents) from clobbering each other.
+
+## `schema`: the CLI describes itself
+
+`flowplane schema` emits the entire command tree as JSON — every command, flag, value type, and
+default — with no network call. This exists so agents do not have to scrape `--help` text. It is
+also the **derivation seam** between the human CLI and the agent/MCP layer: the machine-readable
+catalog is the single source the MCP tool definitions are derived from, so the two surfaces cannot
+drift apart. (See decision FP-DEC-0003.)
+
+## Safety is explicit, never a hang
+
+Destructive commands confirm. On a terminal they prompt `[y/N]`; on a non-interactive terminal they
+**fail fast** with a usage error rather than block on input that will never arrive — the classic
+`--full-auto < /dev/null` deadlock is impossible. `--yes` is the explicit, greppable opt-out for
+automation. The principle: never silently destroy, and never silently hang.
+
+## Further reading
+
+- [Script Flowplane from a shell or agent](../how-to/script-the-cli.md) — the hands-on recipe.
+- [`../reference/cli.md`](../reference/cli.md) — the exhaustive command and flag reference.
+- [`spec/16-cli-standard.md`](../../spec/16-cli-standard.md) — the full CLI standard and the external authorities it derives from.

--- a/docs/how-to/cli-auth-and-contexts.md
+++ b/docs/how-to/cli-auth-and-contexts.md
@@ -4,7 +4,7 @@
 
 This guide gets the `flowplane` CLI talking to a control plane: set a token, point at the right server, optionally scope to an org/team, and verify. It assumes you have the `flowplane` binary on your `PATH` and a control-plane URL to talk to.
 
-For the full command surface see [`../reference/cli.md`](../reference/cli.md), and for the complete list of environment variables and config keys see [`../reference/configuration.md`](../reference/configuration.md).
+For the full command surface see [`../reference/cli.md`](../reference/cli.md), and for the complete list of environment variables and config keys see [`../reference/configuration.md`](../reference/configuration.md). Once authenticated, to drive the CLI non-interactively from a script or agent see [Script Flowplane from a shell or agent](script-the-cli.md).
 
 ## Fastest path: token + server, then verify
 

--- a/docs/how-to/script-the-cli.md
+++ b/docs/how-to/script-the-cli.md
@@ -1,0 +1,201 @@
+# Script Flowplane from a shell or agent
+
+> Audience: cli-users, api-teams · Status: stable
+
+This guide shows how to drive the `flowplane` CLI **non-interactively** — from a shell script,
+a CI job, or an LLM agent. You will read structured JSON output, branch on exit codes, project
+just the fields you need, discover the command surface programmatically, and make changes safely
+with confirmation and optimistic concurrency.
+
+It assumes you already have the CLI talking to a control plane. If not, do
+[Authenticate the CLI and point it at the right server/org/team](cli-auth-and-contexts.md) first.
+For the exhaustive flag/command list see [`../reference/cli.md`](../reference/cli.md); for *why* the
+CLI behaves as a typed contract see [The CLI as a typed contract](../concepts/cli-contract.md).
+
+Every command below is copy-pasteable. Examples use the team `payments`; substitute your own.
+
+## 1. Get machine-readable output
+
+Reader commands print a **table** on an interactive terminal but switch to **JSON automatically
+when stdout is not a terminal** — so a pipe just works, no flag needed:
+
+```bash
+flowplane cluster list --team payments | jq '.data'
+```
+
+To be explicit (recommended in scripts so behavior never depends on the terminal), pass
+`-o json` (or the identical `--json`):
+
+```bash
+flowplane cluster list --team payments -o json
+```
+
+Every success payload is wrapped in a stable, versioned envelope:
+
+```json
+{
+  "schemaVersion": 1,
+  "kind": "clusterList",
+  "data": [
+    { "name": "alpha", "revision": 1, "service_name": "alpha-svc" },
+    { "name": "beta",  "revision": 2, "service_name": "beta-svc" }
+  ]
+}
+```
+
+- `schemaVersion` — integer contract version of the envelope; branch on it if you parse defensively.
+- `kind` — what `data` holds (`cluster` for one object, `clusterList` for a list, `mutationResult`
+  for a delete, etc.).
+- `data` — the resource (object) or resources (array).
+
+Pull a single value out with `jq`:
+
+```bash
+flowplane cluster get alpha --team payments -o json | jq -r '.data.revision'
+# 1
+```
+
+## 2. Branch on exit codes
+
+The CLI exits with a **scriptable code by failure class** (not a generic `1`). On failure the
+error is a JSON object on **stderr** (stdout stays empty), so your pipeline never parses an error
+as data:
+
+```bash
+if out=$(flowplane cluster get missing --team payments -o json 2>err.json); then
+  echo "found: $(jq -r '.data.name' <<<"$out")"
+else
+  code=$?
+  echo "failed with exit $code: $(jq -r '.code + ": " + .message' err.json)"
+fi
+```
+
+The full map (see [`../reference/cli.md#exit-codes`](../reference/cli.md#exit-codes)):
+
+| Code | Meaning | Trigger |
+|------|---------|---------|
+| `0` | Success | — |
+| `1` | Generic / internal CLI error | Unclassified local failure |
+| `2` | Usage error | Invalid flags/arguments |
+| `3` | Auth | HTTP `401`, `403` |
+| `4` | Not found / conflict / precondition | HTTP `404`, `409`, `412` |
+| `5` | Validation | HTTP `400`, `422` |
+| `6` | Rate limited | HTTP `429` |
+| `7` | Server / transport | HTTP `5xx`, connection refused, timeout |
+
+The error envelope carries a `retryable` boolean — `true` for `429`/`5xx`/transport, `false` for
+terminal `4xx`. A retry loop can key off it:
+
+```bash
+for attempt in 1 2 3; do
+  flowplane cluster get alpha --team payments -o json >out.json 2>err.json && break
+  if [ "$(jq -r '.retryable' err.json)" != "true" ]; then
+    echo "giving up: $(jq -r '.message' err.json)"; exit 1
+  fi
+  sleep $((attempt * 2))
+done
+```
+
+## 3. Project only the fields you need
+
+`--fields` trims reader output to a comma-separated key set, applied **inside** `data` (per item
+for lists). `schemaVersion` and `kind` always survive; absent keys are omitted:
+
+```bash
+flowplane cluster list --team payments -o json --fields name,revision
+```
+
+```json
+{
+  "schemaVersion": 1,
+  "kind": "clusterList",
+  "data": [
+    { "name": "alpha", "revision": 1 },
+    { "name": "beta",  "revision": 2 }
+  ]
+}
+```
+
+## 4. Discover the command surface programmatically
+
+Instead of scraping `--help`, ask for the whole CLI as JSON — every command, flag, value type,
+and default. `schema` makes **no network call**, so an agent can introspect offline:
+
+```bash
+flowplane schema -o json | jq -r '.data.command.subcommands[].name'
+# serve
+# db
+# auth
+# ...
+```
+
+Inspect one command's flags:
+
+```bash
+flowplane schema -o json \
+  | jq '.data.command.subcommands[] | select(.name=="cluster")
+        | .subcommands[] | select(.name=="create") | .args'
+```
+
+The output is the same `{schemaVersion, kind:"cliSchema", data}` envelope; `data.command` is the
+recursive command tree.
+
+## 5. Make changes safely (non-interactive)
+
+Destructive commands (`delete`, `unexpose`) **confirm before acting**. On a terminal they prompt
+`[y/N]`; with no terminal they **fail fast** rather than hang. In a script you must pass `--yes`:
+
+```bash
+# Without --yes on a pipe/CI runner: exits 2, never blocks.
+flowplane cluster delete alpha --team payments </dev/null
+# error (confirmation_required): refusing to delete … without --yes on a non-interactive terminal
+
+# Correct in automation:
+flowplane cluster delete alpha --team payments --yes
+```
+
+Updates and deletes are **optimistically concurrent**. Pass the revision you read; if the server
+moved on, you get a `409` (exit `4`) naming both revisions instead of clobbering a concurrent edit:
+
+```bash
+rev=$(flowplane cluster get alpha --team payments -o json | jq -r '.data.revision')
+flowplane cluster update alpha --team payments -f cluster.json --revision "$rev" --yes
+```
+
+Omitting `--revision` makes the CLI read-modify-write (it reads the current revision and sends it
+for you) — convenient interactively, but in a script prefer passing the `--revision` you already
+read, so a concurrent change is reported rather than silently overwritten.
+
+## 6. Pin everything explicitly in CI
+
+For reproducible runs, set the connection and scope via environment instead of relying on a config
+file or context, and silence chrome with `--quiet`:
+
+```bash
+export FLOWPLANE_SERVER=https://fp.example.com
+export FLOWPLANE_TOKEN=…           # highest-priority token source
+export FLOWPLANE_TEAM=payments
+export FLOWPLANE_TIMEOUT=15        # seconds
+
+flowplane cluster list -o json --quiet | jq '.data[].name'
+```
+
+Precedence for every value (including the token) is `flag > env > context > file > default` — see
+[`../reference/configuration.md`](../reference/configuration.md). `--quiet` removes progress and
+human-readable summaries, leaving only the requested data envelope on stdout.
+
+## Verify
+
+A quick end-to-end check that your scripting setup works:
+
+```bash
+flowplane cluster list --team payments -o json | jq -e '.schemaVersion == 1' >/dev/null \
+  && echo "OK: structured output flowing"
+```
+
+If that prints `OK`, JSON output, your token, and your server resolution are all working.
+
+## Further reading
+
+- [`../reference/cli.md`](../reference/cli.md) — every command, flag, the envelope, and the exit-code table.
+- [The CLI as a typed contract](../concepts/cli-contract.md) — why the envelope, exit codes, and `schema` are shaped this way.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -22,7 +22,7 @@ These flags are accepted on every command (`global = true`). Place them before o
 | `--verbose` | | | `false` | Verbose output. |
 | `--dry-run` | | | `false` | Do not perform mutating actions. |
 | `--yes` | `-y` | | `false` | Assume "yes" for confirmation prompts. |
-| `--revision <N>` | | | | Resource revision (i64). |
+| `--revision <N>` | | | | Optimistic-concurrency precondition for `update`/`delete`, sent as `If-Match`. Omit it and the CLI does read-modify-write: it reads the resource's current revision and sends that, so a concurrent edit is detected. A stale revision fails with a `409` whose error envelope names both the `attempted_revision` and the server's current one. |
 | `--timeout <SECS>` | | `FLOWPLANE_TIMEOUT` | `30` | HTTP timeout in seconds (u64). |
 | `--out <PATH>` | | | | Write command output to a file. |
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -14,9 +14,9 @@ These flags are accepted on every command (`global = true`). Place them before o
 | `--server <URL>` | | `FLOWPLANE_SERVER` | `http://127.0.0.1:8080` | Control-plane base URL. |
 | `--team <NAME>` | | `FLOWPLANE_TEAM` | | Team scope. |
 | `--org <NAME>` | | `FLOWPLANE_ORG` | | Organization scope. |
-| `--output <FMT>` | `-o` | | `table` | Output format: `table`, `json`, `yaml`, `wide`. |
-| `--json` | | | `false` | Shorthand for `--output json` (overrides `--output`). |
-| `--no-color` | | | `false` | Disable colored output. |
+| `--output <FMT>` | `-o` | | `table` on a TTY, `json` when stdout is piped | Output format: `table`, `json`, `yaml`, `wide`. An explicit `-o` always wins; otherwise the default is `table` on an interactive terminal and `json` when stdout is not a TTY (so `… \| jq` works without `-o json`). |
+| `--json` | | | `false` | Exactly equivalent to `--output json`. |
+| `--no-color` | | | `false` | Disable colored output. Color is also disabled by the `NO_COLOR` environment variable, when stdout is not a TTY, or when output is redirected with `--out`. |
 | `--quiet` | | | `false` | Suppress non-essential output. |
 | `--verbose` | | | `false` | Verbose output. |
 | `--dry-run` | | | `false` | Do not perform mutating actions. |
@@ -41,6 +41,32 @@ These are read directly (not as flags) by config resolution:
 | `FLOWPLANE_OIDC_CALLBACK_URL` | OIDC callback URL fallback. |
 
 Token resolution order: `FLOWPLANE_TOKEN` → selected context token → config-file token → `~/.flowplane/credentials` file. The config directory and credential files are written with `0700`/`0600` permissions on Unix.
+
+## JSON output envelope
+
+Under `-o json` (and `-o yaml`) every command's success payload is wrapped in a typed
+envelope so machine consumers can rely on a stable shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "kind": "cluster",
+  "data": { "name": "alpha", "revision": 3 }
+}
+```
+
+- `schemaVersion` — integer version of the **output contract** (not the product version).
+  It starts at `1` and is bumped only on a breaking change to this envelope shape.
+- `kind` — the resource kind. Singular for a single resource (`cluster`), suffixed with
+  `List` for a collection (`clusterList`). `version` → `version`; a body-less mutation
+  (e.g. `delete`) → `mutationResult`; `apply` → `applyResult`.
+- `data` — the resource object, the array/`items` collection, or the command-specific
+  payload.
+
+This envelope wraps reader output, mutation results (including `version`, `delete`, and
+`apply`), so a command that previously printed prose (e.g. `version`, `cluster delete`)
+now emits the envelope under `-o json`. Human formats (`table`, `wide`) are unwrapped and
+remain free-form.
 
 ## Top-level commands
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -68,6 +68,46 @@ This envelope wraps reader output, mutation results (including `version`, `delet
 now emits the envelope under `-o json`. Human formats (`table`, `wide`) are unwrapped and
 remain free-form.
 
+## Errors & exit codes
+
+Every failure — an HTTP error from the server, a transport/network failure, or an `apply`
+partial-failure — is written as a structured error envelope to **stderr** (stdout stays
+empty), and the process exits with a scriptable code. Under `-o json` the error envelope is
+JSON; otherwise it is a compact `error (code): message` line. The error envelope is
+separate from the success envelope above (it is **not** wrapped in `{schemaVersion,kind,data}`):
+
+```json
+{
+  "code": "not_found",
+  "message": "cluster \"alpha\" not found",
+  "status": 404,
+  "retryable": false,
+  "request_id": "01J…",
+  "hint": "…"
+}
+```
+
+- `retryable` — `true` for transient failures (HTTP `429`, any `5xx`, and transport/timeout
+  failures), `false` for terminal `4xx`.
+- `hint` — on a `401` with no server-supplied hint the client synthesizes
+  `run \`flowplane auth login\` to authenticate`; a `403` carries the server's hint naming
+  the `(resource, action)`.
+- `status` — the HTTP status (absent for transport failures, whose `code` is
+  `connection_failed`/`timeout`/`transport_error`).
+
+### Exit codes
+
+| Code | Meaning | Trigger |
+|------|---------|---------|
+| `0` | Success | — |
+| `1` | Generic / internal CLI error | Unclassified local failure |
+| `2` | Usage error | Invalid flags/arguments (clap-native) |
+| `3` | Authentication / authorization | HTTP `401`, `403` |
+| `4` | Not found / conflict / precondition | HTTP `404`, `409`, `412` |
+| `5` | Validation | HTTP `400`, `422` |
+| `6` | Rate limited | HTTP `429` |
+| `7` | Server / transport | HTTP `5xx`, connection refused, timeout |
+
 ## Top-level commands
 
 `serve`, `db`, `openapi`, `auth`, `config`, `org`, `team`, `cluster`, `listener`, `route`, `api`, `mcp`, `ai`, `learn`, `secret`, `dataplane`, `expose`, `unexpose`, `stats`, `ops`, `apply`, `completion`, `version`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,7 +21,7 @@ These flags are accepted on every command (`global = true`). Place them before o
 | `--quiet` | | | `false` | Suppress non-essential output. |
 | `--verbose` | | | `false` | Verbose output. |
 | `--dry-run` | | | `false` | Do not perform mutating actions. |
-| `--yes` | `-y` | | `false` | Assume "yes" for confirmation prompts. |
+| `--yes` | `-y` | | `false` | Skip the confirmation prompt on destructive commands (`delete`, `unexpose`). Required to run a destructive command on a non-interactive terminal — see [Destructive confirmations](#destructive-confirmations). |
 | `--revision <N>` | | | | Optimistic-concurrency precondition for `update`/`delete`, sent as `If-Match`. Omit it and the CLI does read-modify-write: it reads the resource's current revision and sends that, so a concurrent edit is detected. A stale revision fails with a `409` whose error envelope names both the `attempted_revision` and the server's current one. |
 | `--fields <a,b,c>` | | | | Project reader output to only these comma-separated keys, applied inside the envelope `data` (per item for lists). `schemaVersion`/`kind` always survive; an absent key is omitted (no `null`). |
 | `--timeout <SECS>` | | `FLOWPLANE_TIMEOUT` | `30` | HTTP timeout in seconds (u64). |
@@ -47,6 +47,22 @@ Configuration precedence is uniform for every value — `flag > env > context > 
 Token resolution follows the same rule: `--token` → `FLOWPLANE_TOKEN` → selected context token →
 config-file token → `~/.flowplane/credentials` file. The config directory and credential files are
 written with `0700`/`0600` permissions on Unix, and the token is redacted in `config show`.
+
+## Destructive confirmations
+
+Destructive commands (`delete` and `unexpose`) confirm before acting:
+
+- **On an interactive terminal**, the CLI prompts `delete <resource>? [y/N]:`. The default is
+  no — only `y`/`yes` proceeds; a bare Enter or anything else aborts (exit `1`). The prompt is
+  written to stderr.
+- **`--yes` / `-y`** skips the prompt and proceeds immediately. Use it in scripts and automation.
+- **On a non-interactive terminal** (piped or redirected stdin) **without `--yes`**, the command
+  does not prompt and does not hang: it fails fast with exit code `2` and an
+  `error (confirmation_required): … pass --yes` message on stderr. The CLI never reads from a
+  non-TTY stdin, so it can never deadlock waiting for an answer that will not come.
+
+`apply` is additive-only and does not delete; `apply --prune` is currently rejected as
+unsupported, so it is not a confirmation surface.
 
 ## JSON output envelope
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4,6 +4,8 @@
 
 Exhaustive reference for the `flowplane` binary: global options, every top-level command, and its subcommands, arguments, and flags.
 
+To drive the CLI from a script or agent, see the how-to [Script Flowplane from a shell or agent](../how-to/script-the-cli.md); for the reasoning behind the output envelope, exit codes, and `schema`, see [The CLI as a typed contract](../concepts/cli-contract.md).
+
 ## Global options
 
 These flags are accepted on every command (`global = true`). Place them before or after the subcommand.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -23,6 +23,7 @@ These flags are accepted on every command (`global = true`). Place them before o
 | `--dry-run` | | | `false` | Do not perform mutating actions. |
 | `--yes` | `-y` | | `false` | Assume "yes" for confirmation prompts. |
 | `--revision <N>` | | | | Optimistic-concurrency precondition for `update`/`delete`, sent as `If-Match`. Omit it and the CLI does read-modify-write: it reads the resource's current revision and sends that, so a concurrent edit is detected. A stale revision fails with a `409` whose error envelope names both the `attempted_revision` and the server's current one. |
+| `--fields <a,b,c>` | | | | Project reader output to only these comma-separated keys, applied inside the envelope `data` (per item for lists). `schemaVersion`/`kind` always survive; an absent key is omitted (no `null`). |
 | `--timeout <SECS>` | | `FLOWPLANE_TIMEOUT` | `30` | HTTP timeout in seconds (u64). |
 | `--out <PATH>` | | | | Write command output to a file. |
 
@@ -115,7 +116,7 @@ separate from the success envelope above (it is **not** wrapped in `{schemaVersi
 
 ## Top-level commands
 
-`serve`, `db`, `openapi`, `auth`, `config`, `org`, `team`, `cluster`, `listener`, `route`, `api`, `mcp`, `ai`, `learn`, `secret`, `dataplane`, `expose`, `unexpose`, `stats`, `ops`, `apply`, `completion`, `version`.
+`serve`, `db`, `openapi`, `auth`, `config`, `org`, `team`, `cluster`, `listener`, `route`, `api`, `mcp`, `ai`, `rate-limit`, `learn`, `secret`, `dataplane`, `expose`, `unexpose`, `stats`, `ops`, `apply`, `completion`, `version`, `schema`.
 
 ---
 
@@ -384,6 +385,16 @@ Generate a shell completion script.
 
 ### `version`
 Print the binary version (from `CARGO_PKG_VERSION`). No subcommands or args.
+
+### `schema`
+Print the machine-readable CLI catalog — the whole command tree (commands, subcommands,
+flags, types, enums, required/defaults, help) as JSON. Makes no network call. This is the
+**canonical CLI contract source and the MCP-derivation seam** (ADR FP-DEC-0003): generated
+consumers (shell completion, the future MCP tool catalog, docs) derive from `flowplane schema`
+rather than scraping `--help`. Under `-o json` the payload is the standard envelope with
+`kind: "cliSchema"`; `data` carries its own integer `catalogVersion` (distinct from the
+envelope `schemaVersion`) and the `command` tree. A generator drift test pins the catalog to
+`Cli::command()`. No subcommands or args.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -14,6 +14,7 @@ These flags are accepted on every command (`global = true`). Place them before o
 | `--server <URL>` | | `FLOWPLANE_SERVER` | `http://127.0.0.1:8080` | Control-plane base URL. |
 | `--team <NAME>` | | `FLOWPLANE_TEAM` | | Team scope. |
 | `--org <NAME>` | | `FLOWPLANE_ORG` | | Organization scope. |
+| `--token <TOKEN>` | | `FLOWPLANE_TOKEN` | | Bearer token. Highest-priority token source; falls back to the selected context, the config-file token, then `~/.flowplane/credentials`. Redacted in `config show`. |
 | `--output <FMT>` | `-o` | | `table` on a TTY, `json` when stdout is piped | Output format: `table`, `json`, `yaml`, `wide`. An explicit `-o` always wins; otherwise the default is `table` on an interactive terminal and `json` when stdout is not a TTY (so `… \| jq` works without `-o json`). |
 | `--json` | | | `false` | Exactly equivalent to `--output json`. |
 | `--no-color` | | | `false` | Disable colored output. Color is also disabled by the `NO_COLOR` environment variable, when stdout is not a TTY, or when output is redirected with `--out`. |
@@ -22,7 +23,7 @@ These flags are accepted on every command (`global = true`). Place them before o
 | `--dry-run` | | | `false` | Do not perform mutating actions. |
 | `--yes` | `-y` | | `false` | Assume "yes" for confirmation prompts. |
 | `--revision <N>` | | | | Resource revision (i64). |
-| `--timeout <SECS>` | | | `30` | HTTP timeout in seconds (u64). |
+| `--timeout <SECS>` | | `FLOWPLANE_TIMEOUT` | `30` | HTTP timeout in seconds (u64). |
 | `--out <PATH>` | | | | Write command output to a file. |
 
 ### Other environment variables
@@ -32,15 +33,19 @@ These are read directly (not as flags) by config resolution:
 | Env var | Meaning |
 |---------|---------|
 | `FLOWPLANE_CONFIG` | Path to the config TOML file. Default: `$HOME/.flowplane/config.toml`. |
-| `FLOWPLANE_TOKEN` | Bearer token (highest-priority token source). |
-| `FLOWPLANE_ORG` | Organization fallback. |
-| `FLOWPLANE_TEAM` | Team fallback. |
+| `FLOWPLANE_TOKEN` | Bearer token (env tier; below `--token`, above context/file). |
+| `FLOWPLANE_ORG` | Organization (env tier of the precedence rule). |
+| `FLOWPLANE_TEAM` | Team (env tier of the precedence rule). |
+| `FLOWPLANE_TIMEOUT` | HTTP timeout in seconds (env tier; below `--timeout`, above the `30` default). |
 | `FLOWPLANE_OIDC_ISSUER` | OIDC issuer URL fallback. |
 | `FLOWPLANE_OIDC_CLIENT_ID` | OIDC client ID fallback. |
 | `FLOWPLANE_OIDC_SCOPE` | OIDC scope fallback. |
 | `FLOWPLANE_OIDC_CALLBACK_URL` | OIDC callback URL fallback. |
 
-Token resolution order: `FLOWPLANE_TOKEN` → selected context token → config-file token → `~/.flowplane/credentials` file. The config directory and credential files are written with `0700`/`0600` permissions on Unix.
+Configuration precedence is uniform for every value — `flag > env > context > file > default`.
+Token resolution follows the same rule: `--token` → `FLOWPLANE_TOKEN` → selected context token →
+config-file token → `~/.flowplane/credentials` file. The config directory and credential files are
+written with `0700`/`0600` permissions on Unix, and the token is redacted in `config show`.
 
 ## JSON output envelope
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -9,7 +9,7 @@ Every `FLOWPLANE_*` variable read by the control plane (`server`), the rate-limi
 | Surface | Resolution order |
 |---------|------------------|
 | Server (`flowplane serve`) | env var > TOML file (`FLOWPLANE_CONFIG`) > built-in default |
-| CLI | flag > env var > CLI config file |
+| CLI | flag > env var > selected context > CLI config file > built-in default (uniform for every value, including the bearer token) |
 
 Booleans accept `true`/`1`/`yes` and `false`/`0`/`no`. Invalid server values fail startup with an `invalid_config` error.
 
@@ -68,9 +68,10 @@ Booleans accept `true`/`1`/`yes` and `false`/`0`/`no`. Invalid server values fai
 | `FLOWPLANE_AGENT_TLS_SERVER_NAME` | agent | `localhost` | no | Server name for TLS verification. |
 | `FLOWPLANE_AGENT_HEALTH_BIND_ADDR` | agent | `127.0.0.1:19902` | no | Local health endpoint bind address. |
 | `FLOWPLANE_SERVER` | cli | `http://127.0.0.1:8080` | no | API base URL the CLI targets. |
-| `FLOWPLANE_TOKEN` | cli | — | no | Bearer token for API requests. |
+| `FLOWPLANE_TOKEN` | cli | — | no | Bearer token for API requests (env tier; below `--token`, above context/file/credentials). |
 | `FLOWPLANE_ORG` | cli | — | no | Active organization (name or UUID). |
 | `FLOWPLANE_TEAM` | cli | — | no | Active team. |
+| `FLOWPLANE_TIMEOUT` | cli | `30` | no | HTTP request timeout in seconds (env tier; below `--timeout`, above the default). |
 | `FLOWPLANE_OIDC_CLIENT_ID` | cli | — | no | OIDC client id for CLI login. |
 | `FLOWPLANE_OIDC_SCOPE` | cli | `openid email profile` | no | OIDC scopes requested at CLI login. |
 | `FLOWPLANE_OIDC_CALLBACK_URL` | cli | `http://127.0.0.1:8976/callback` | no | OAuth callback URL for CLI login. |

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -219,6 +219,9 @@ To tear down what you created:
 ./target/debug/flowplane unexpose local
 ```
 
+`unexpose` is destructive, so on an interactive terminal it asks for `[y/N]` confirmation before
+acting. Answer `y`, or pass `--yes` to skip the prompt (required when running non-interactively).
+
 ---
 
 ## You now have a working gateway

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -154,6 +154,11 @@ On success the command prints a table describing the created resources, includin
 ./target/debug/flowplane route list
 ```
 
+These print a table at your terminal. Piped into another tool they switch to JSON automatically, so
+`./target/debug/flowplane cluster list | jq '.data'` works without any extra flag. To script
+Flowplane this way — structured output, exit codes, safe deletes — see
+[Script Flowplane from a shell or agent](../how-to/script-the-cli.md).
+
 ---
 
 ## 5. Create a dataplane record

--- a/spec/16-cli-conformance.md
+++ b/spec/16-cli-conformance.md
@@ -1,0 +1,103 @@
+# 16 — CLI Conformance Backlog (Tier 1)
+
+> Measures the current `flowplane` binary against `spec/16-cli-standard.md`. **Tier 1 only** this pass
+> (machine/scriptable contract); Tier 2 ergonomics deferred to a second run per the standard's tier split.
+> Build under test: **`flowplane 1.1.0`** (`./target/debug/flowplane version` → `1.1.0`; the `version`
+> command emits no git SHA — see key `output+version+main.rs:208`, itself a finding).
+
+## Test environment
+
+- Binary: `./target/debug/flowplane` (pre-built; not rebuilt).
+- Server: running on `127.0.0.1:8080` (gvproxy listener confirmed), **dev mode** (`FLOWPLANE_DEV_MODE=true`,
+  in-process issuer, per-boot 1h dev token at `/shared/dev-token`, `serve.rs`).
+- **Auth: resolved mid-run.** The first token was stale (dev token TTL is 1h, minted once per boot and not
+  refreshed); after the operator restarted the CP, the fresh `/shared/dev-token` authenticated
+  (`auth whoami` exit 0). The **full create→route→filter→read dogfood, idempotency, and live 403/404/409
+  were then exercised for real.** No infrastructure was stood up by this run — the operator owns the CP
+  lifecycle; the run only read the token file and drove the CLI.
+- An earlier symptom (`identity provider unreachable (https://dev.flowplane.local/jwks)`, 503) is a
+  **misleading dev-mode message** — JWKS is served in-process, never fetched externally; the real cause was
+  always token expiry. Logged as an error-message-clarity observation, not a Tier 1 contract finding.
+
+## Command tree (enumerated before judging)
+
+Top-level commands (24) from `Cli`/`Command` in `crates/flowplane/src/main.rs:31-141`:
+`serve · db(migrate) · openapi · auth · config · org · team · cluster · listener · route · api · mcp ·
+ai · rate-limit · learn · secret · dataplane · expose · unexpose · stats · ops · apply · completion ·
+version`.
+
+Global flags (apply to every subcommand, `GlobalOptions`, `config.rs:13-43`):
+`--context · --server[env FLOWPLANE_SERVER] · --team · --org · -o/--output{table,json,yaml,wide} ·
+--json · --no-color · --quiet · --verbose · --dry-run · -y/--yes · --revision · --timeout[=30] · --out`.
+
+Resource verb sets (`cluster`/`listener` = `ResourceCommand`: list,get,create,update,delete;
+`route` = list,get,create,update,delete,generate,apply). Body input is `-f/--file` on create/update.
+
+---
+
+## Findings (Tier 1, sorted by rule)
+
+| key | rule (CLI-R-NN) | mode | command(s) | evidence (path:line + run) | deviation | verdict | migration cost |
+|---|---|---|---|---|---|---|---|
+| input+apply+cli/client.rs:84 | CLI-R-09 | real-run | `apply -f -` | `client.rs:84` reads body; run: `cat m.json \| flowplane apply -f - --dry-run` parsed manifest, reached reconcile (then 503 auth) | stdin `-` is honoured for `apply` | conforms | — |
+| output+version+main.rs:208 | CLI-R-10 | real-run | `version` | `main.rs:208` `println!("{VERSION}")`; run: `version -o json` and `version --json` both print bare `1.1.0` | `version` ignores `-o`/`--output`; no command-level structured output | needs-change | low (route `version` through `render()`) |
+| output+mutations+cli/client.rs:145 | CLI-R-10 | real-run | `listener/route delete` | `client.rs:145-150` 204/empty → `print_mutation_summary` prose; run: `listener delete cli-test-listener -o json --revision 2` → stdout `deleted api/v1/teams/default/listeners/cli-test-listener` (prose + raw path, not JSON) | delete emits prose even under `-o json`; leaks the URL path instead of a structured result | needs-change | medium |
+| output+apply+cli/mod.rs(run_apply) | CLI-R-10 | real-run | `apply` | run: `apply -f l.json -o json` → stdout `apply summary:` / `  unchanged listener "…"` (prose) — ignores `-o json` entirely | `apply` has no structured output; its reconcile result (created/updated/unchanged per resource) is unscriptable | needs-change | medium |
+| output+global+cli/config.rs:99 | CLI-R-11 | real-run | all (`--json` vs `-o json`) | `config.rs:99-105` `format()`: `--json`→Json else `--output`; run: `version --json` ignores it (≠ `-o json` which is also ignored) → divergence proves dual-path risk | two format selectors; `version` honours neither | needs-change | low (drop `--json`, or assert equivalence) |
+| output+global+cli/config.rs:99 | CLI-R-12 | real-run | all readers | `config.rs:99-105` default `OutputFormat::Table`; no `is_terminal` anywhere (`grep` in `cli/` → none) | default is `table` even when stdout is piped/non-TTY; `list \| jq` needs explicit `-o json` | needs-change | low (add TTY check in `format()`) |
+| output+mutation+cli/output.rs:500 | CLI-R-13 | reasoned | all mutations | `output.rs:500-502` `print_mutation_summary` early-returns on `quiet`; `client.rs:146` guards summary on `!quiet` | `--quiet` does suppress the human summary; not verified that data/stderr split holds on a live write | conforms | — |
+| output+global+cli/config.rs:42 | CLI-R-14 | real-run | all (`--out`) | `config.rs:42` `--out <PathBuf>`; `output.rs:120` writes file; `-o` is enum-only (`config.rs:23`) | `-o` = format, `--out` = destination; no overload present | conforms | — |
+| output+all+cli/output.rs:114 | CLI-R-15 | reasoned | all `-o json` | `output.rs:114-126` generic `serde_to_string_pretty`; no `schemaVersion`, no snapshot suite | JSON shape is unversioned and unsnapshotted; no breaking-change gate | needs-change | medium (add snapshots + version field) |
+| output+global+cli/config.rs:28 | CLI-R-16 | real-run | all | `config.rs:28` `no_color` field; `grep no_color/NO_COLOR` → only the definition, never read | `--no-color` is a dead flag; no `NO_COLOR` env handling (output is plain, so no ANSI leaks, but the contract is unmet) | needs-change | low |
+| errors+all+cli/output.rs:28 | CLI-R-30 | real-run | all HTTP errors | `output.rs:28-50`; run: `cluster list` → `error (unavailable): … / → hint / request id`; `-o json` → `{code,message,status,request_id,hint}` to **stderr**, empty stdout, exit 6 | HTTP-error envelope conforms (TTY + JSON-to-stderr) | conforms | — |
+| errors+network+main.rs:154 | CLI-R-30 | real-run | any (transport failure) | `main.rs:154` `eprintln!("Error: {err:?}")`; run (server down earlier): `Error: send request / Caused by: … Connection refused (os error 61)` raw chain, not JSON under `-o json`, exit 1 | transport/network errors bypass the envelope → raw anyhow dump, unstructured | needs-change | medium (wrap reqwest send/timeout in envelope) |
+| errors+apply+cli/mod.rs(run_apply) | CLI-R-30 | real-run | `apply` | run: `apply -f m.json --dry-run -o json` → JSON envelope on stderr **then** `Error: apply failed for 1 resource(s); see summary above` raw trailer, exit 1 | apply double-renders (structured + raw anyhow) and collapses underlying status | needs-change | medium |
+| errors+exit+cli/output.rs:103 | CLI-R-31 | real-run | all HTTP errors | `output.rs:103-112` mapping; run: 503→exit 6 (`cluster list`), 401→exit **2** (`cluster list` w/ dev token) | semantic range exists (good) | conforms | — |
+| errors+exit+cli/output.rs:105 | CLI-R-31 | real-run | usage vs auth | run: `cluster get` (missing arg, clap) → exit **2**; 401 → exit **2** (`output.rs:105`) — **same code** | clap usage errors collide with auth (401/403) on exit 2 | needs-change | low (remap auth to 3, usage stays 2) |
+| errors+exit+main.rs:154 | CLI-R-31 | real-run | transport / apply | `main.rs:154` non-`CliHttpError` → exit 1; run: connection-refused → 1; `apply` 503 → 1 (not 6) | transport + apply failures collapse to generic exit 1, losing class | needs-change | medium |
+| errors+exit+cli/output.rs:106 | CLI-R-31 | real-run | get/create/update/delete | run (live): 404 `listener get nope-xyz` → exit 3; 409 dup `route create` → exit 3; 422 `validation_failed` (bad filter body) → exit 4 (`output.rs:106-107`) | not-found and conflict share exit 3; validation is 4 — distinct classes resolve correctly for these (the unresolved issue is the usage/auth-on-2 collision, separate row) | conforms | — |
+| errors+envelope+cli/output.rs:52 | CLI-R-32 | real-run | all errors | `output.rs:52-101` envelope builder; run: 503 JSON envelope = `{code,hint,message,request_id,status}` — **no `retryable`**; `grep retry/transient` in `cli/` → none | no machine retryable/terminal signal; agents must infer from status | needs-change | medium |
+| errors+auth+cli/output.rs:28 | CLI-R-33 | real-run | 401/403 | `output.rs:28-50` passes server `hint` through verbatim; run: 401 `token expired` → `→ re-authenticate: flowplane auth login` (server-supplied, shown), but 401 `token validation failed` → **no** hint | hint quality depends entirely on the server; client never synthesizes a `flowplane auth login` hint when the server omits one, so some 401s teach and some don't | needs-change | low |
+| config+token+cli/config.rs:200 | CLI-R-40 | real-run | all (precedence) | `config.rs:200-209` token = `FLOWPLANE_TOKEN` env → ctx → file → credentials (**no flag, env highest**); `:211-228` server/org/team = flag → env → ctx → file | precedence inverts for `token` vs every other value | needs-change | medium |
+| config+timeout+cli/config.rs:39 | CLI-R-41 | real-run | all (`--timeout`) | `config.rs:39-40` `--timeout` default 30, no env, not in `effective()`; doc `docs/reference/cli.md` lists no `FLOWPLANE_TIMEOUT` | `timeout` has flag+ (no env, no file resolution path) — missing tiers | needs-change | low |
+| config+stateless+cli/config.rs:190 | CLI-R-42 | real-run | all | `config.rs:190-243` resolves entirely from flags/env/file; run: full `FLOWPLANE_*` env drove the request (reached server) with no `config use-context` | invocation is fully specifiable by env/flags; context is optional override | conforms | — |
+| config+secrets+cli/config.rs:171 | CLI-R-43 | real-run | config/credentials write | `config.rs:171-183` file `0600`, dir `0700`; unit `private_file_write_*` `config.rs:274-309` | credential/config files are private; `config show` redaction not re-verified this pass | conforms | — |
+| mutation+create+cli/mod.rs(run_resource) | CLI-R-45 | real-run | `route/listener create` | run: second `route create -f rc.json` → `error (conflict): route config "cli-test-routes" already exists` exit 3 (with hint `→ choose a different name or update`) | re-create is not idempotent; agents must catch 409 (no `--idempotency-key`) | needs-change | medium |
+| mutation+apply+cli/mod.rs(run_apply) | CLI-R-45 | real-run | `apply` | run: `apply -f listener.json` twice → both `unchanged listener "cli-test-listener"` exit 0 (GET-then-decide reconcile) | `apply` IS idempotent/declarative — conforming; caveat `--prune` is a no-op (`apply --help`: "additive-only") | conforms | — |
+| mutation+dryrun+cli/client.rs:121 | CLI-R-46 | real-run | `cluster/listener/secret create --dry-run` | `client.rs:121-125` short-circuits non-GET, echoes `{method,path,body}`; run: `cluster create -f m.json --dry-run` → table `PATH/BODY/METHOD` with body `{...}` (no server validation) | per-resource `--dry-run` is a client-side echo, not a server-validated plan; body unreadable in table | needs-change | high |
+| mutation+dryrun+cli/mod.rs(run_apply) | CLI-R-46 | real-run | `apply --dry-run` | run: `apply -f m.json --dry-run` reached the server (503 auth) rather than echoing → different semantics from per-resource dry-run | two conflicting `--dry-run` behaviours (apply=server, create=client echo) | needs-change | medium |
+| mutation+revision+cli/config.rs:38 | CLI-R-47 | real-run | all update/delete | `config.rs:38` global `--revision` → `client.rs:192-194` `If-Match`; run: `listener update … --revision 1` → rev 2, exit 0; `route delete cli-test-routes` (no `--revision`) → exit 4 `error (validation_failed): this operation requires the resource revision` / `→ … send its revision as: If-Match: <revision>` | `--revision` is uniform and works; but it is **mandatory** on delete (server rejects without it) — the CLI does **no** read-modify-write fallback the standard assumes, though the error teaches the fix well | needs-change | medium |
+| interactivity+destructive+cli/config.rs:35 | CLI-R-22 | real-run | `delete`, `unexpose`, `apply --prune` | `config.rs:35` `-y/--yes` defined; `grep confirm/prompt/read_line` in `cli/` → none (only `"prompts_enabled":false` literal `mod.rs:2726`) | `--yes` is a dead flag; destructive commands never prompt and have no confirmation guard | needs-change | medium |
+| interactivity+noninteractive+cli/mod.rs | CLI-R-26 | real-run | all | no `is_terminal` / prompt anywhere; deletes execute immediately | never blocks on a prompt (satisfied by absence) — but for the wrong reason (no guard exists); non-TTY safety is incidental, not designed | conforms (incidentally) | low (formalize with CLI-R-22) |
+| agent+introspect+cli/mod.rs | CLI-R-50 | real-run | (missing) `schema`/`--help=json` | `grep introspect/schema/--help=json` → none; `openapi` (`main.rs:169`) prints the **REST** OpenAPI, not the CLI tree | no machine-readable command catalog; MCP schemas cannot be derived from the CLI | needs-change | high |
+| agent+fields+cli/output.rs:114 | CLI-R-51 | reasoned | all readers | `output.rs:114-126` renders whole value; no `--fields`/jsonpath/`--template` arg in `GlobalOptions` (`config.rs:13-43`) | no field selection; agents pay for full payloads | needs-change | medium |
+
+---
+
+## Coverage note
+
+**Ran for real (`real-run`):**
+- **The representative dogfood, end to end:** `route create cli-test-routes` (exit 0) → `listener create cli-test-listener` cross-referencing the route (exit 0) → attach a CORS filter via `listener update … --revision 1` (exit 0, rev 1→2) → `listener get -o json` read-back showing the filter → `apply` idempotency (re-apply → `unchanged`, exit 0) → `listener delete --revision 2` / `route delete --revision 1` cleanup. All test resources removed.
+- **Live error/exit behaviour:** 503→exit 6, 401 (expired token)→exit 2, 404 (`listener get nope-xyz`)→exit 3, 409 (dup `route create`)→exit 3, 422 (bad filter body)→exit 4; error envelope on TTY and under `-o json` (to stderr, empty stdout); the **exit-2 collision** (clap usage `cluster get` == 401) captured directly.
+- **Offline / auth-independent surface:** top-level + leaf `--help`, `version` (+ `--json`, `-o json` both ignored), `completion bash`, unknown-subcommand suggestion (`clustr`/`cluster lst`), missing-required-arg exit 2, `apply -f /nonexistent.json`, `apply -f -` via stdin, `cluster create --dry-run` (client echo) vs `apply --dry-run` (server dispatch), `auth whoami`.
+
+**Read only (`reasoned`, source-grounded with `path:line`):**
+- `CLI-R-13` `--quiet` data/stderr split on a real mutation; `CLI-R-43` `config show` token redaction; `CLI-R-15` field-by-field JSON stability (no snapshot history exists to diff against); `CLI-R-51` field selection (no such flag exists to exercise).
+
+**Could not verify / structural absences (marked `needs-change` without a positive run):**
+- **`CLI-R-50` introspection** — no `schema`/`--help=json` exists, so there is no output to derive MCP schemas from. Structural.
+- **The standard's dogfood assumes a `filter` verb that does not exist.** The workflow *was* completed, but only by embedding `http_filters` JSON inside the listener spec (`mod.rs:2857`); `main.rs:31-141` has no `Filter` command. Worse for first-contact: the filter sub-schema is **undiscoverable** from any CLI surface — leaf `--help` is empty and there is no `filter types`/schema command, so the CORS body shape had to be reverse-engineered through **five successive `validation_failed` round-trips**, with the errors leaking internal Rust type names (`expected internally tagged enum OriginMatcher`, `missing field 'match'`). A first-contact agent without source access would be stuck. Logged against CLI-R-30 (errors leak internals) and CLI-R-50 (no schema source); the underlying verb gap is a Tier 2 grammar item.
+- **Create vs update body-shape mismatch** (real-run): `create` wants `{name,spec}`, `update` rejects `name` and wants bare `{spec}` (`unknown field 'name', expected 'spec'`). Surfaced during the dogfood; it is a CLI-R-08 (Tier 2) input-model issue, recorded here for the Tier 2 pass.
+
+**Build pinned:** `./target/debug/flowplane version` → `1.1.0`. The `version` command emits **no git SHA**
+(`main.rs:208` prints only `CARGO_PKG_VERSION`), so the exact commit cannot be pinned from the CLI — itself
+a Tier 1 finding (row `output+version+main.rs:208`). Tested build = whatever the running dev-mode CP and the
+pre-built `target/debug` binary were at session time (branch `feature/fpv2-4ht-global-rate-limit`).
+
+**No silent gaps:** every Tier 1 rule in the standard has at least one row in the table (conforms or needs-change). Tier 2 rules (CLI-R-01..08, 27, 44, 52) are intentionally out of scope this pass and carry no rows.
+
+**Remaining `reasoned` rows** are now only the genuinely structural ones (CLI-R-15 stability, CLI-R-50
+introspection, CLI-R-51 field selection — features that do not exist to exercise) plus CLI-R-13/43
+quality checks. They cannot become `real-run` until the corresponding feature is built; the keys are
+stable, so they update in place when it is.
+</content>

--- a/spec/16-cli-standard.md
+++ b/spec/16-cli-standard.md
@@ -1,0 +1,438 @@
+# 16 — Flowplane CLI Standard
+
+> Audience: CLI contributors, reviewers, and the agents that consume `flowplane`.
+> Status: **authored** (rules: all tiers · conformance scan: Tier 1 only — see `spec/16-cli-conformance.md`).
+> The `flowplane` binary is one deterministic command surface with two consumers — the human
+> CLI and the agent/MCP layer derived from it. This document defines what a *brilliant* version
+> of that surface is, derived from external authorities first, then reconciled with the code.
+
+## How this standard was built (anti-anchoring note)
+
+The rules below were derived from external authorities (CLIG.dev, POSIX/GNU, kubectl/gh,
+BSD `sysexits.h`, Clap v4 idioms) **before** auditing the existing commands, so the status quo
+did not define "good". `spec/12-cli-design.md` and `spec/07-cli-and-workflows.md` were then read
+as *auditable input*, not ground truth. The conformance scan (Deliverable 2) measures the current
+binary (`flowplane 1.1.0`) against these rules.
+
+---
+
+## 0. Status block — relationship to `spec/12` and `spec/07`
+
+`spec/12-cli-design.md` is the project's prior CLI design note. `spec/07-cli-and-workflows.md`
+inventories the **v1** CLI (`/tmp/flowplane-v1`) and is a known-issues checklist. Their fate here:
+
+### Adopted from `spec/12` (agrees with authorities)
+- **§1.1 noun-verb grammar, ≤12 nouns, no bare top-level verbs** → adopted as **CLI-R-01/02**
+  (kubectl/gh). (Current binary has 24 top-level commands and bare verbs `expose`/`unexpose` — a
+  conformance gap, not a standard change.)
+- **§1.2 `-o table|json|yaml|wide`, `--out` for file output, `-o` always means format** → adopted as
+  **CLI-R-10/14** (kubectl/gh).
+- **§1.3 `--dry-run` on mutations; `--yes/-y` for scripts** → adopted as **CLI-R-22/26**.
+- **§1.6 error style `error (code): message` + `→ hint` + request id; semantic exit codes** → adopted
+  as **CLI-R-30/31** (CLIG). The code already implements this style (`output.rs`).
+- **§1.7 config precedence `flag > env > file > default`, uniform per value** → adopted as
+  **CLI-R-40** (D-005). The *principle* is adopted; the code violates it for `token` (see conformance).
+- **§1.8 completions** → adopted as **CLI-R-52**.
+- **§1.9 help with examples + related commands** → adopted as **CLI-R-05/06**.
+
+### Extended beyond `spec/12`
+- `spec/12` has no rule for **machine-readable CLI introspection** (`schema`/`--help=json`). Added as
+  **CLI-R-50** — the single most important agent affordance and the seam MCP tool schemas derive from.
+- `spec/12` has no **retryable-vs-terminal** signal. Added as **CLI-R-32**.
+- `spec/12` does not require **TTY/`NO_COLOR` detection** or a non-TTY default. Added as **CLI-R-12/16**.
+- `spec/12` does not commit the `-o json` shape to a **stability/versioning** discipline. Added as
+  **CLI-R-15**.
+
+### Superseded / flagged as anti-pattern
+- **`spec/12` §1.2 keeps a `--json` flag as "sugar for `-o json`".** Flagged as a **mild
+  anti-pattern** and superseded by **CLI-R-11**: a second flag that aliases an enum value is redundant
+  surface, invites the `version --json` divergence seen in the code (where `--json` is silently
+  ignored), and gives agents two code-paths to test. Keep `-o/--output` as the *only* format selector;
+  if `--json` is retained, it MUST be exactly `--output json` with zero command-specific exceptions.
+- **`spec/12` §6 "exit codes 0/1/2/3/4/5/6/7 per spec/10 §8"** conflicts with BSD `sysexits.h`
+  (64–78). **CLI-R-31 reconciles this in favour of the compact 0–7 semantic range** (see the rule for
+  why a script author is better served by it) — but fixes the **2-collision** the current code has
+  (clap usage errors and `401/403` both exit `2`).
+
+`spec/07` is treated purely as a hint list; every item was re-verified against the current binary,
+which has already fixed several v1 problems it describes (structured error envelope, semantic exit
+codes, `apply`, shell completion all now exist).
+
+---
+
+## 1. Principles (≤7, each traceable to an authority)
+
+1. **One surface, two consumers.** The machine contract (`-o json`, exit codes, errors, introspection)
+   is the source of truth; the human view is a rendering of it, and the MCP layer is *derived* from it,
+   never maintained in parallel. *(CLIG.dev — human/machine duality.)*
+2. **The machine contract is the MVP.** Anything that silently breaks a script or an agent is a Tier 1
+   defect and outranks every ergonomic concern. *(CLIG.dev — "design for machines too".)*
+3. **Errors teach and branch.** Every failure states the fact, a stable `code`, a machine-actionable
+   `hint`, and whether it is worth retrying — in English on a TTY, in JSON to an agent. *(CLIG.dev.)*
+4. **Guessable grammar.** Resource-oriented noun-verb (`<noun> <verb>`) with a fixed verb vocabulary and
+   kebab-case flags, so a user/agent can predict a command they have never run. *(kubectl/gh, POSIX/GNU.)*
+5. **Least surprise, no hidden state.** One config-precedence rule for every value; every invocation is
+   fully specifiable by flags/env; implicit context is an override, never a requirement. *(D-005, CLIG.)*
+6. **Never block, always offer an out.** Non-TTY is detected and never prompts; every destructive action
+   has `--yes`; long operations report progress; `--quiet` truly silences chrome. *(CLIG.dev.)*
+7. **The output shape is a versioned API.** `-o json` is contract: additive changes are safe; renames,
+   removals, retypes are breaking and gated. *(gh/kubectl output contract.)*
+
+---
+
+## 2. Tiers
+
+- **Tier 1 — scriptable contract.** `-o json` shape & stability, exit-code semantics, error format &
+  structure, stdin/pipe/quiet behaviour, config/auth precedence, and the agent affordances
+  (introspection, structured branchable errors, retryable signal, non-interactive paths). **Violations
+  silently break scripts and agents.** This tier is shippable on its own and is the only tier scanned in
+  this conformance pass.
+- **Tier 2 — ergonomics.** Verb grammar, flag naming, help quality, resource addressing. A human trips
+  once and adapts. Standardised after Tier 1.
+
+Every rule below is tagged `[T1]` or `[T2]`.
+
+---
+
+## 3. Rules
+
+Each rule: **statement · tier · authority · conforming example · violating example · named check.**
+Checks named `chk:<slug>` are stubs a contributor implements; "transcript" = snapshot test under
+`crates/flowplane/tests/`, "clap-lint" = a compile-time assertion in `Cli::command().debug_assert()`
+or a unit test walking the built `clap::Command`.
+
+### Axis A — Verb grammar & command shape
+
+**CLI-R-01 · Noun-verb grammar [T2]** *(kubectl/gh)*
+Every mutating/reading command is `flowplane <noun> <verb> [args]`. The verb vocabulary is fixed:
+`list | get | create | update | delete` plus a small set of noun-specific transitions
+(`publish`, `attach`, `rotate`, …). No bare top-level verbs except `version`, `completion`, `apply`,
+`serve`.
+- ✅ `flowplane cluster delete payments-db`
+- ❌ `flowplane expose http://…` / `flowplane unexpose demo` (bare top-level verbs)
+- **Check** `chk:noun-verb-grammar` — clap-lint: walk top-level subcommands; assert each is either in the
+  allow-list (`version`, `completion`, `apply`, `serve`, `db`) or has only sub-subcommands drawn from the
+  fixed verb set.
+
+**CLI-R-02 · Bounded top-level surface [T2]** *(kubectl/gh sweet spot)*
+≤ 12 top-level nouns. Diagnostics live under one noun (`ops`), not as scattered top-level verbs.
+- ✅ `flowplane ops doctor`, `flowplane ops xds status`
+- ❌ 24 top-level commands (current `main.rs`)
+- **Check** `chk:top-level-count` — clap-lint: assert `Cli::command().get_subcommands().count() <= 12`
+  (drives consolidation; tune the cap when the noun set is finalised).
+
+**CLI-R-03 · Unknown command suggests nearest valid [T2]** *(gh, CLIG discoverability)*
+A mistyped command exits `2` and prints "did you mean" with the closest valid command.
+- ✅ `flowplane clustr list` → `tip: some similar subcommands exist: 'cluster'`
+- ❌ bare "unrecognized subcommand" with no suggestion
+- **Check** `chk:suggest-nearest` — transcript: `clustr list` stderr contains `cluster`, exit `2`.
+  *(Clap provides this for free when built with the `suggestions` feature.)*
+
+### Axis B — Flag naming & input model
+
+**CLI-R-04 · POSIX/GNU flag shape [T2]** *(POSIX, GNU, Clap v4)*
+Long flags are `--kebab-case`; single-dash shorts are one character; `--` terminates option parsing;
+`-` means stdin/stdout where a path is expected. No `--snake_case`, no multi-char single-dash flags.
+- ✅ `--from-openapi`, `-o json`, `apply -f -`
+- ❌ `--from_openapi`, `-output`
+- **Check** `chk:flag-kebab` — clap-lint: walk every arg of every command, assert long name matches
+  `^[a-z][a-z0-9-]*$` and every short is exactly one char.
+
+**CLI-R-05 · Every command has a one-line summary [T2]** *(CLIG help quality)*
+Each command and sub-command renders a non-empty `about` in its parent's listing and its own `--help`.
+- ✅ `apply  Apply a declarative JSON resource manifest`
+- ❌ `create` (blank summary — current `cluster`/`listener`/`route` leaf verbs)
+- **Check** `chk:nonempty-about` — clap-lint: walk every `clap::Command`, assert `get_about().is_some()`
+  and non-empty. Fails the build on any leaf with no `///` doc comment.
+
+**CLI-R-06 · Help carries a runnable example [T1 for top-level workflows, else T2]** *(CLIG)*
+Top-level and every "spine" workflow command's `--help` includes at least one copy-pasteable example
+that parses. Examples are verified to parse, not just present.
+- ✅ root `after_help` examples, asserted by `cli_help_contains_workflow_examples` (`main.rs:372`)
+- ❌ `cluster create --help` with no example of the `-f` file shape
+- **Check** `chk:help-examples-parse` — transcript: extract `flowplane …` lines from each `--help`,
+  feed each to `Cli::try_parse_from`, assert all parse. *(Extends the existing test in `main.rs:226`.)*
+
+**CLI-R-07 · Every arg has help text [T2]** *(CLIG)*
+Every flag/positional renders a non-empty description in `--help`.
+- ✅ `--prune  Apply is additive-only until server batch support` *(text needs a rewrite, but present)*
+- ❌ `--file <FILE>` / `--team <TEAM>` rendered with blank meaning (current leaf help)
+- **Check** `chk:nonempty-arg-help` — clap-lint: assert every `Arg.get_help().is_some()`.
+
+**CLI-R-08 · Uniform create input [T2]** *(least surprise; kubectl `-f`)*
+All `create`/`update` take the resource body via `-f/--file <path|->`. Inline flag-soup bodies and
+per-noun special-casing (`secret create --config '<json>'`) are disallowed.
+- ✅ `flowplane secret create -f secret.json`
+- ❌ a `create` that takes `--config '<JSON string>'` instead of `-f`
+- **Check** `chk:create-takes-file` — clap-lint: every command named `create`/`update` has an arg
+  with long name `file` and short `f`.
+
+**CLI-R-09 · `-` is stdin/stdout [T1]** *(POSIX, CLIG composability)*
+`-f -` reads the manifest/body from stdin; `--out -` writes to stdout. Reading stdin never blocks when
+stdin is a closed/redirected non-TTY.
+- ✅ `cat gateway.json | flowplane apply -f -`
+- ❌ `apply -f -` trying to `open("-")` as a literal path
+- **Check** `chk:stdin-dash` — transcript: `printf '{...valid...}' | flowplane apply -f - --dry-run`
+  succeeds and round-trips the manifest.
+
+### Axis C — Output model
+
+**CLI-R-10 · `-o table|json|yaml|wide` on every command [T1]** *(kubectl/gh)*
+Every command — including mutations (`create/update/delete`), `expose`, `version`, and ops verbs —
+honours `-o`. There is no plain-prose-only command.
+- ✅ `flowplane cluster delete x -o json` emits a JSON result object
+- ❌ `flowplane version -o json` printing the bare string `1.1.0` (current behaviour, `main.rs:208`)
+- **Check** `chk:output-flag-universal` — transcript matrix: for a representative command per group, run
+  with each `-o` value and assert the format (valid JSON / YAML / table header). Includes `version`.
+
+**CLI-R-11 · One format selector [T1]** *(CLIG; supersedes spec/12 §1.2 `--json` sugar)*
+`-o/--output` is the only output-format control. If `--json` exists it is *exactly* `--output json`
+with no command-specific exception.
+- ✅ `--json` and `-o json` produce byte-identical output for every command
+- ❌ `version --json` ignoring the flag and printing `1.1.0`
+- **Check** `chk:json-flag-equiv` — transcript: for every command in a sampled set, assert
+  `cmd --json` output == `cmd -o json` output.
+
+**CLI-R-12 · Format defaults to the consumer [T1]** *(CLIG human/machine duality)*
+On a TTY the default is `table`; when stdout is **not** a TTY (piped/redirected) the default is `json`,
+so `flowplane cluster list | jq` works with no flag. An explicit `-o` always wins.
+- ✅ `flowplane cluster list | jq '.[].name'` (auto-json when piped)
+- ❌ default `table` regardless of TTY (current `GlobalOptions::format()`, `config.rs:99`)
+- **Check** `chk:tty-default-format` — transcript: run with stdout piped (non-TTY) and assert the output
+  parses as JSON without `-o`.
+
+**CLI-R-13 · `--quiet` suppresses all chrome [T1]** *(CLIG)*
+`--quiet` silences progress, confirmations, and human summaries, leaving only the requested data (or
+nothing for a pure mutation) on stdout, and errors on stderr.
+- ✅ `flowplane cluster create -f c.json --quiet` prints nothing on success, exit 0
+- ❌ `--quiet` still printing `created "x"`
+- **Check** `chk:quiet-silences` — transcript: `--quiet` success path has empty stdout; error path still
+  writes the error envelope to stderr.
+
+**CLI-R-14 · `-o` is format, `--out` is destination [T1]** *(kubectl; spec/12 §1.2)*
+`-o/--output` selects format only. File destination is `--out <path>`. `-o` is never overloaded to mean
+a file path (the v1 `learn export -o <FILE>` collision is prohibited).
+- ✅ `flowplane dataplane bootstrap dp -o yaml --out envoy.yaml`
+- ❌ `learn export -o ./out.json` meaning "write to file"
+- **Check** `chk:o-is-format-only` — clap-lint: assert no command redefines `-o`/`--output` as a path;
+  the global `OutputFormat` enum arg is the only `-o`.
+
+**CLI-R-15 · `-o json` is a versioned contract [T1]** *(gh/kubectl)*
+The JSON shape is an API: additive fields are safe; renaming/removing/retyping a field is breaking and
+requires a deliberate gate. Top-level machine output carries a `schemaVersion` (or the response is a
+typed envelope) so agents can branch on shape.
+- ✅ adding `created_at` to a list row
+- ❌ renaming `name`→`resourceName` in a point release with no version bump
+- **Check** `chk:json-snapshot` — snapshot tests of `-o json` for every command's happy path; a diff in
+  an existing field fails CI and forces an explicit `schemaVersion` bump in the snapshot.
+
+**CLI-R-16 · `NO_COLOR` and non-TTY disable color; `--no-color` works [T1]** *(CLIG, no-color.org)*
+Color/styling is emitted only to a TTY and only when `NO_COLOR` is unset and `--no-color` is absent.
+A declared `--no-color` flag must actually be consulted (no dead flags).
+- ✅ `NO_COLOR=1 flowplane cluster list` and `… --no-color` both emit no ANSI
+- ❌ `--no-color` defined but never read (current: `config.rs:28`, unused)
+- **Check** `chk:no-color` — transcript: assert no ANSI escape bytes in output under `NO_COLOR=1`,
+  under `--no-color`, and under non-TTY stdout; plus a clap-lint that the `no_color` field is referenced.
+
+### Axis D — Errors & exit codes
+
+**CLI-R-30 · Errors are structured and teach [T1]** *(CLIG; spec/12 §4)*
+Every error carries: a stable `code` (enum, not free text), a human `message`, an optional
+machine-actionable `hint` (ideally the corrected command), the offending field where applicable, and
+`request_id`. On a TTY: `error (code): message` / `  → hint` / `  request id: …`. Under `-o json`: the
+JSON envelope to **stderr**, nothing on stdout. Raw HTTP/JSON bodies are never dumped on a TTY.
+- ✅ `error (resource_in_use): cluster "payments-db" is referenced by 2 route configs` / `→ …`
+  (the path the code takes for HTTP errors, `output.rs:28`)
+- ❌ `Error: send request / Caused by: … Connection refused (os error 61)` — raw anyhow chain, no code,
+  no hint, not JSON even under `-o json` (current network-error path, `main.rs:154`)
+- **Check** `chk:error-envelope` — transcript: force a 404 and a network failure; assert TTY format has
+  `error (` + `→`, and `-o json` emits a JSON object with `{code,message,status,request_id}` on stderr,
+  empty stdout. **Network/transport errors must go through the same envelope, not `eprintln!("{err:?}")`.**
+
+**CLI-R-31 · Semantic exit codes, no collisions [T1]** *(BSD `sysexits.h`, reconciled)*
+Exit codes are a compact semantic range, distinct per failure class, **with usage errors separated from
+auth errors**:
+`0` success · `1` generic/unexpected · `2` **usage/parse** (clap) · `3` auth (401/403) ·
+`4` not-found/conflict/precondition (404/409/412) · `5` validation (400/422) · `6` rate-limited (429) ·
+`7` server/transport (5xx, connection, timeout).
+*Reconciliation note:* BSD `sysexits.h` (64–78) is rejected in favour of this 0–7 range because a
+control-plane script branches on **outcome class** (retry? re-auth? fix input?), which a dense
+semantically-grouped range expresses more legibly than `EX_NOPERM=77`; the cost is non-standard
+numbers, accepted. The current code (`output.rs:103`) already uses a 0–6 range but **collides clap usage
+errors and auth on `2`** and routes transport errors to `1` — both fixed here.
+- ✅ `flowplane cluster get missing` (404) exits `4`; `… get` (missing arg) exits `2`
+- ❌ `401` and a clap usage error both exiting `2` (current collision)
+- **Check** `chk:exit-codes` — transcript/unit: table-test status→exit mapping (extend
+  `http_statuses_map_to_scriptable_exit_codes`, `output.rs:552`) **plus** assert a clap usage error and a
+  401 produce *different* codes, and a connection failure exits the transport class, not `1`.
+
+**CLI-R-32 · Retryable vs terminal is machine-detectable [T1]** *(agent affordance; CLIG resilience)*
+An agent can decide to retry without parsing English: transient failures (429, 5xx, connection/timeout)
+are a distinct exit class (≥6 per CLI-R-31) **and** the JSON error envelope carries
+`"retryable": true|false`. Validation/auth/not-found are terminal (`retryable:false`).
+- ✅ `429` → exit 6, envelope `{"code":"rate_limited","retryable":true}`
+- ❌ connection-refused and a 400 both exiting `1` with no retryable signal (current)
+- **Check** `chk:retryable-signal` — transcript: assert `retryable` present and correct for a 429, a 503,
+  a connection failure, and a 400; assert the exit class matches.
+
+**CLI-R-33 · Auth/permission errors name the fix [T1]** *(CLIG errors-that-teach)*
+`401` always hints `flowplane auth login`; `403` names the missing `(resource, action)` (and team/org);
+`404` never reveals cross-tenant existence.
+- ✅ `error (unauthorized): not authenticated` / `→ run \`flowplane auth login\``
+- ❌ `401` rendered with only the server message and no login hint (current: hint only if server sends it)
+- **Check** `chk:auth-hint` — transcript: stub a 401/403 response; assert the client *injects* the login
+  hint / the `(resource,action)` even when the server omits `hint`.
+
+### Axis E — Config / auth precedence
+
+**CLI-R-40 · One precedence rule for every value [T1]** *(D-005, least surprise)*
+For **every** configurable value (server, org, team, token, timeout, output, context) precedence is
+identical: `flag > env (FLOWPLANE_*) > active context > config file > built-in default`. No value
+inverts the order.
+- ✅ `--server` beats `FLOWPLANE_SERVER` beats context beats file
+- ❌ `token` resolved `env > context > file` with **no flag and env highest**, while `server/org/team`
+  are flag-highest (current split, `config.rs:200` vs `:211`)
+- **Check** `chk:precedence-uniform` — unit: a table-driven test sets flag/env/context/file for each
+  value and asserts the same winner order for all; fails if any value diverges.
+
+**CLI-R-41 · Every value has flag + env + file [T1]** *(consistency)*
+Each value is settable by all three of: a global flag, a `FLOWPLANE_*` env var, and the config file.
+No value is missing a tier (e.g. `timeout` currently has flag+file but no env).
+- ✅ `--timeout` / `FLOWPLANE_TIMEOUT` / `timeout =` in config
+- ❌ `timeout` with no `FLOWPLANE_TIMEOUT` (current)
+- **Check** `chk:value-tiers` — unit: for each value, assert a flag, an env binding, and a config field
+  all exist.
+
+**CLI-R-42 · No required hidden state [T1]** *(agent affordance — no implicit context)*
+Any invocation is fully specifiable by flags/env alone; a previously-set context is an *override*, never
+a *requirement*. Parallel invocations and fresh shells behave identically given the same flags/env.
+- ✅ `FLOWPLANE_SERVER=… FLOWPLANE_TEAM=… FLOWPLANE_TOKEN=… flowplane cluster list` with no config file
+- ❌ a command that fails unless `config use-context` was run first
+- **Check** `chk:stateless-invocation` — transcript: run a representative command with `HOME` pointed at
+  an empty dir and everything supplied via env; assert success.
+
+**CLI-R-43 · Secrets never leak to disk or logs world-readably [T1]** *(security; CLIG)*
+Credential/config files are `0600`, their dirs `0700`; tokens are redacted in `config show` and never
+printed by `--verbose`.
+- ✅ `~/.flowplane/credentials` written `0600` (current `config.rs:171`)
+- ❌ `--verbose` echoing the bearer token
+- **Check** `chk:secret-perms` — unit (exists: `private_file_write_*`, `config.rs:274`) extended to assert
+  `config show` redaction and that no log path prints the token.
+
+### Axis F — Resource addressing & mutation semantics
+
+**CLI-R-44 · One addressing scheme [T2]** *(kubectl name-vs-id)*
+Resources are addressed by team-unique **name**; a UUID is accepted anywhere a name is (server resolves
+both). No command requires a different handle (the v1 `mcp enable <routeID>` mix is prohibited).
+- ✅ `flowplane mcp enable --api orders`
+- ❌ one command keyed by numeric/UUID while siblings use names
+- **Check** `chk:name-addressing` — transcript: addressing a resource by name and by id yields the same
+  result for a sampled command.
+
+**CLI-R-45 · Mutations are idempotent or declarative [T1]** *(agent affordance; kubectl apply)*
+Prefer declarative `apply` semantics; `create` of an identical existing resource is a no-op success (or
+supports `--idempotency-key`), so an agent that retries does not double-create or hard-fail.
+- ✅ `flowplane apply -f gateway.json` twice → second run reports "unchanged"
+- ❌ second `create` of the same name → opaque `409` with no idempotency path
+- **Check** `chk:idempotent-apply` — transcript (server-backed): apply the same manifest twice; assert
+  the second is a success with a no-change result.
+
+**CLI-R-46 · `--dry-run` returns the real would-be effect [T1]** *(agent approval seam; CLIG)*
+`--dry-run` performs server-side validation and returns the structured diff/plan that the real mutation
+would produce — not a trivial echo of the request — so it is a usable approval gate.
+- ✅ `apply --dry-run` returns the server's computed create/update/no-op plan per resource
+- ❌ `--dry-run` echoing `{method, path, body}` client-side without contacting the server
+  (current, `client.rs:121`)
+- **Check** `chk:dryrun-fidelity` — transcript (server-backed): assert `--dry-run` output structurally
+  equals the subsequent real mutation's effect.
+
+**CLI-R-47 · Optimistic concurrency everywhere or nowhere [T1]** *(consistency; spec/07 #2)*
+`update`/`delete` accept `--revision N` (→ `If-Match`) uniformly across resources; without it the CLI
+does read-modify-write and fails a race with a clear `409` showing both revisions.
+- ✅ `flowplane cluster update web -f c.json --revision 7`
+- ❌ revision honoured only for `rate-limit` (v1 behaviour)
+- **Check** `chk:revision-uniform` — clap-lint: every `update`/`delete` exposes `--revision`; transcript:
+  a stale `--revision` yields a `409` envelope naming both revisions.
+
+### Axis G — Interactivity & feedback
+
+**CLI-R-22 · Destructive actions confirm on TTY, `--yes` skips [T1]** *(CLIG; spec/12 §1.3)*
+`delete`, `--prune`, `unexpose`, and publish-of-discovered prompt `[y/N]` on a TTY and proceed only on
+confirmation; `--yes/-y` bypasses. A declared `--yes` must gate a real confirmation (no dead flag).
+- ✅ `flowplane cluster delete db` → `delete cluster "db"? [y/N]`; `… --yes` skips
+- ❌ `--yes` defined but no confirmation exists anywhere (current: `-y` is a no-op)
+- **Check** `chk:confirm-destructive` — transcript: destructive command on a pty prompts; with `--yes`
+  does not; clap-lint asserts the `yes` field is referenced by destructive handlers.
+
+**CLI-R-26 · Never prompt on non-TTY [T1]** *(agent affordance — the `--full-auto < /dev/null` deadlock)*
+When stdin is not a TTY, no command ever blocks on a prompt. A destructive action on non-TTY without
+`--yes` fails fast with exit `2` and a hint to pass `--yes`, rather than hanging.
+- ✅ `flowplane cluster delete db < /dev/null` → `error (confirmation_required): … pass --yes` exit 2
+- ❌ a `read_line` that blocks forever when stdin is closed
+- **Check** `chk:no-prompt-noninteractive` — transcript: destructive command with stdin=`/dev/null` and
+  no `--yes` exits non-zero promptly (timeout-bounded) and never reads stdin.
+
+**CLI-R-27 · Progress for long operations [T2]** *(CLIG feedback)*
+Operations that take >2s (xDS convergence, learn sessions, bootstrap) emit progress to **stderr** so
+stdout stays a clean data stream; `--quiet` suppresses it.
+- ✅ spinner/status lines on stderr during `dataplane bootstrap`
+- ❌ a long command that prints nothing until it finishes
+- **Check** `chk:progress-stderr` — transcript: assert progress bytes land on stderr, not stdout.
+
+### Axis H — Agent affordances
+
+**CLI-R-50 · Machine-readable command catalog [T1]** *(agent affordance — "the CLI's OpenAPI")*
+`flowplane schema` (or `--help=json`) emits the full command tree as JSON: commands, subcommands, every
+flag/positional with type, enum values, required/optional, defaults, and help text. MCP tool schemas are
+**derived** from this output, not hand-maintained. (Distinct from `flowplane openapi`, which is the
+*server's* REST contract, not the CLI's.)
+- ✅ `flowplane schema | jq '.commands[] | select(.name=="cluster")'`
+- ❌ no introspection command; agents must scrape `--help` text (current state)
+- **Check** `chk:cli-schema` — transcript: `flowplane schema` is valid JSON, contains every command in
+  `Cli::command()`, and a generator test asserts the MCP tool list is reproducible from it.
+
+**CLI-R-51 · Context economy — concise by default, field selection on demand [T1]** *(agent token cost)*
+Default output is the minimal useful set; verbosity is opt-in (`--verbose`/`wide`). Agents can request
+exactly the bytes they need via `--fields a,b,c` (or a jsonpath/`--template`) and `--quiet` to drop all
+chrome.
+- ✅ `flowplane cluster list -o json --fields name,revision`
+- ❌ list always returning every field, forcing the agent to pay for and `jq` them away
+- **Check** `chk:field-selection` — transcript: `--fields name` returns objects with only `name`.
+
+**CLI-R-52 · Shell completion for humans, schema for machines [T2]** *(spec/12 §1.8)*
+`flowplane completion bash|zsh|fish` is generated from the clap tree (already present), and stays in
+sync with CLI-R-50 (same source of truth).
+- ✅ `flowplane completion zsh`
+- ❌ hand-written completion drifting from the command tree
+- **Check** `chk:completion-generates` — transcript: each shell completion generates non-empty output and
+  references a sampled subcommand.
+
+---
+
+## 4. New-command checklist (tick before merging any new command)
+
+```
+[ ] Grammar: it is `<noun> <verb>` with a verb from the fixed set, or justified in review (CLI-R-01).
+[ ] about: the command and EVERY arg has a non-empty `///` doc summary (CLI-R-05, CLI-R-07).
+[ ] Example: `--help` shows ≥1 runnable example that parses in a test (CLI-R-06).
+[ ] Input: body comes via `-f/--file` (path or `-` for stdin); no inline JSON-string soup (CLI-R-08/09).
+[ ] Output: honours `-o table|json|yaml|wide`; mutations emit a JSON result under `-o json` (CLI-R-10).
+[ ] Default format flips to json on non-TTY stdout (CLI-R-12); `--quiet` silences chrome (CLI-R-13).
+[ ] File destination is `--out`, never `-o` (CLI-R-14); color gated on TTY + NO_COLOR (CLI-R-16).
+[ ] `-o json` shape added to the snapshot set with `schemaVersion` (CLI-R-15).
+[ ] Errors go through the shared envelope (code/message/hint/field/request_id/retryable), to stderr,
+    with the right exit class — including transport errors (CLI-R-30/31/32/33).
+[ ] Every configurable value uses the one precedence rule and has flag+env+file (CLI-R-40/41).
+[ ] Mutations: idempotent/declarative where possible (CLI-R-45); `--dry-run` returns the real plan
+    (CLI-R-46); `--revision` for update/delete (CLI-R-47).
+[ ] Destructive: prompts on TTY, `--yes` skips, never prompts on non-TTY (CLI-R-22/26).
+[ ] Introspection: the new command and flags appear in `flowplane schema` output (CLI-R-50).
+[ ] A `chk:*` test (transcript or clap-lint) accompanies the command — no prose-only rules.
+```
+
+---
+
+*Conformance for Tier 1 → `spec/16-cli-conformance.md`. Open design decisions → printed with the run
+that authored this file (Deliverable 3).*
+</content>
+</invoke>


### PR DESCRIPTION
## CLI Tier-1 conformance (epic `fpv2-2ge`) — breaking, 2.0.0

Brings the `flowplane` CLI to a documented, machine-consumable standard (15 Tier-1 rules of `spec/16-cli-standard.md`). Delivered slice-by-slice via `/aidf:implement`; each slice Codex-reviewed (gpt-5.5) and gated.

### What changed (user-facing)

- **Typed JSON envelope** — every `-o json` success is `{schemaVersion, kind, data}` (frozen by a snapshot suite). *(S1)*
- **Context-aware default format** — `table` on a TTY, `json` when piped; `-o` always wins; `--json` == `-o json`. *(S1)*
- **Structured error contract** — single error object on stderr (empty stdout) with `code`/`message`/`retryable`/`request_id`. *(S2)*
- **Scriptable exit codes 0–7** by failure class (usage 2, auth 3, conflict 4, validation 5, rate-limit 6, server/transport 7). *(S2)*
- **Uniform config precedence** `flag > env > context > file > default` for every value incl. token; new `--token` flag + `FLOWPLANE_TIMEOUT`; token redacted in `config show`. *(S3)*
- **Optimistic concurrency** — `--revision` / read-modify-write on update/delete; stale revision → 409 naming both. *(S4)*
- **`flowplane schema`** — machine-readable CLI catalog (no network), the MCP-derivation seam (FP-DEC-0003); **`--fields`** projection. *(S5)*
- **Destructive confirmation** — `delete`/`unexpose` prompt `[y/N]`; `--yes` skips; non-TTY without `--yes` fails fast (exit 2), never hangs. *(S6)*
- **`--no-color`/`NO_COLOR` honored** (were inert).

### Tests / quality

- **Coverage capstone** (S7): a frozen 121-leaf inventory asserted set-equal to the live `flowplane schema` tree (a new/removed command fails the test — no silent gaps), cluster `-o json` envelope snapshots, and clap-lints (output-flag-universal, o-is-format-only, revision-uniform, file-driven-mutator).
- Integration tests authored **spec-first, black-box** (separate author, never read `src/`); parallel-safe (no `--test-threads=1`; green run twice concurrently).
- **Final gate:** `533 tests / 0 skipped`, clippy 0, doctests 0 failed.

### Docs

- Per-slice `docs/reference/cli.md` + `configuration.md` updates; new `docs/how-to/script-the-cli.md` and `docs/concepts/cli-contract.md` (Diátaxis pass); `CHANGELOG.md` `[2.0.0]` breaking section. `docs-boundary` CI green.

### Release

- Workspace version bumped `1.1.0 → 2.0.0`; `spec/16-cli-standard.md` + `spec/16-cli-conformance.md` added.

### Scope notes

- REST API, MCP, and config file format unchanged (config gains an optional `timeout` field; existing files remain valid).
- **Out of scope (deliberate):** Tier-2 ergonomics (CLI-R-05/06/07: per-command `about`, per-leaf examples, per-arg `--help` text) — follow-on epic. CLI-R-45/46 (server `--dry-run`, idempotency) split to `server-resource-idempotency-and-dry-run`.

Closes epic `fpv2-2ge` (slices S1–S7).
