### PR TITLE
v2.1.0 release QA fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@ scripts and config files are unaffected.
   help or a non-parsing example now fails CI — help coverage is provable and regression-proof, like
   the Tier-1 machine contract.
 
+### Fixed
+
+- **Docs E2E QA release gaps.** Documentation now matches the v2.1.0 branch behavior for dev-mode
+  token TTL/test database guidance, global rate-limit policy update bodies, and dev-mode tenant
+  org/team setup boundaries. (#194, #195)
+- **`auth login` method-conflict exit code.** Explicit conflicting login methods now fail as a
+  usage error with exit code `2`, while no-method/no-OIDC remains exit `1` and ambient
+  `FLOWPLANE_TOKEN` fallback behavior is preserved. (#196)
+
 ## [2.0.0] - 2026-06-27
 
 Major release. CLI Tier-1 conformance: the `flowplane` CLI is brought to a documented,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ upgrade of an earlier Flowplane line — there is no in-place migration path fro
 version. `1.0.0` is its first stable release and the point at which the public REST API,
 CLI surface, and configuration contract become subject to semantic versioning.
 
+## [2.1.0] - 2026-06-27
+
+Minor release. **CLI Tier-2 help quality: `flowplane --help` is now self-sufficient.** Every
+command and subcommand renders a one-line summary, every flag and positional renders help text,
+and every spine workflow command's `--help` carries a copy-pasteable, parse-tested example.
+Purely **additive** — no command, flag, output-shape, or exit-code change (semver MINOR); existing
+scripts and config files are unaffected.
+
+### Added
+
+- **One-line `about` on every command and subcommand** (CLI-R-05). `flowplane <group> --help`
+  (e.g. `flowplane cluster --help`) now lists each subcommand with a summary instead of a blank
+  line.
+- **Help text on every flag and positional** (CLI-R-07). No argument — including the global
+  options and bare positionals like `<NAME>` — renders a blank meaning in `--help`.
+- **Runnable examples on spine workflow commands** (CLI-R-06). The 44 workflow leaves (resource
+  `create`/`update`, `route generate`, `api create`, `expose`/`unexpose`/`apply`, the
+  capture/discovery starters, `dataplane bootstrap`/`cert register`/`issue`/`revoke`,
+  `secret create`/`rotate`, …) each
+  show at least one copy-pasteable `flowplane …` example in their `--help`.
+- **Conformance lints** `chk:nonempty-about`, `chk:nonempty-arg-help`, and `chk:help-examples-parse`.
+  The first two walk the live `flowplane schema -o json` tree (black-box, reusing the Tier-1 S7
+  coverage harness); the third walks the in-process clap tree, freezes the spine/exempt
+  classification with a union-equals-live guard, and asserts every extracted example parses. Missing
+  help or a non-parsing example now fails CI — help coverage is provable and regression-proof, like
+  the Tier-1 machine contract.
+
 ## [2.0.0] - 2026-06-27
 
 Major release. CLI Tier-1 conformance: the `flowplane` CLI is brought to a documented,

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ FLOWPLANE_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/flowplane_dev
   ./target/debug/flowplane serve
 ```
 
-Dev mode logs a one-hour `dev_token` once at boot. In a second terminal:
+Dev mode logs a 24-hour `dev_token` once at boot (configurable with
+`FLOWPLANE_DEV_TOKEN_TTL`). In a second terminal:
 
 ```bash
 export FLOWPLANE_SERVER=http://127.0.0.1:8096
@@ -177,7 +178,7 @@ Run the full workspace suite with PostgreSQL-backed tests enabled. CI uses
 `cargo install cargo-nextest --locked` or `cargo binstall cargo-nextest`:
 
 ```bash
-export FLOWPLANE_TEST_DATABASE_URL=postgres://postgres:postgres@localhost:5432/flowplane_dev
+export FLOWPLANE_TEST_DATABASE_URL=postgres://postgres:postgres@localhost:5432/flowplane_test
 
 cargo nextest run --workspace --all-features   # what CI runs (via the `ci` profile)
 cargo test --workspace --all-features --doc    # doctests — nextest does not run these

--- a/crates/flowplane/src/cli/client.rs
+++ b/crates/flowplane/src/cli/client.rs
@@ -1,7 +1,7 @@
 use crate::cli::config::{effective, EffectiveConfig, GlobalOptions, OutputFormat};
 use crate::cli::output::{
-    derive_kind, print_mutation_summary, render, render_error, render_revision_conflict,
-    render_transport_error,
+    print_mutation_summary, render, render_error, render_revision_conflict, render_transport_error,
+    resolve_kind,
 };
 use anyhow::{Context, Result};
 use serde_json::json;
@@ -289,7 +289,7 @@ impl RestClient {
                     OutputFormat::Json | OutputFormat::Yaml
                 ))
         {
-            render(&self.global, &derive_kind(path, &value), &value)?;
+            render(&self.global, &resolve_kind(path, &value), &value)?;
         } else if render_response {
             print_mutation_summary(&self.global, &method_label, path, Some(&value))?;
         }

--- a/crates/flowplane/src/cli/commands.rs
+++ b/crates/flowplane/src/cli/commands.rs
@@ -3,8 +3,11 @@ use std::path::PathBuf;
 
 #[derive(Debug, Subcommand)]
 pub enum AuthCommand {
+    /// Print the identity and scopes of the active credential.
     Whoami,
+    /// Print the raw bearer token for the active context.
     Token,
+    /// Acquire and store a bearer token (static token, PKCE, or device flow).
     Login {
         #[arg(long)]
         token: Option<String>,
@@ -23,13 +26,17 @@ pub enum AuthCommand {
         #[arg(long, default_value = "openid email profile")]
         scope: String,
     },
+    /// Clear the stored credential for the active context.
     Logout,
 }
 
 #[derive(Debug, Subcommand)]
 pub enum ConfigCommand {
+    /// Print the path to the CLI config file.
     Path,
+    /// Print the merged CLI configuration.
     Show,
+    /// Create or update a named context (server, org, team, token).
     SetContext {
         name: String,
         #[arg(long)]
@@ -43,26 +50,27 @@ pub enum ConfigCommand {
         #[arg(long)]
         token_stdin: bool,
     },
-    UseContext {
-        name: String,
-    },
+    /// Switch the active context.
+    UseContext { name: String },
+    /// List the configured contexts.
     GetContexts,
 }
 
 #[derive(Debug, Subcommand)]
 pub enum OrgCommand {
+    /// List organizations.
     List,
-    Get {
-        org: String,
-    },
+    /// Show one organization.
+    Get { org: String },
+    /// Create an organization.
     Create {
         name: String,
         #[arg(long)]
         display_name: Option<String>,
     },
-    Delete {
-        org: String,
-    },
+    /// Delete an organization.
+    Delete { org: String },
+    /// Manage organization members.
     Member {
         #[command(subcommand)]
         command: OrgMemberCommand,
@@ -71,9 +79,9 @@ pub enum OrgCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum OrgMemberCommand {
-    List {
-        org: String,
-    },
+    /// List members of an organization.
+    List { org: String },
+    /// Add a member to an organization.
     Add {
         org: String,
         #[arg(long)]
@@ -85,28 +93,31 @@ pub enum OrgMemberCommand {
         #[arg(long)]
         role: String,
     },
-    Remove {
-        org: String,
-        user_id: String,
-    },
+    /// Remove a member from an organization.
+    Remove { org: String, user_id: String },
 }
 
 #[derive(Debug, Subcommand)]
 pub enum TeamCommand {
+    /// List teams.
     List,
+    /// Create a team.
     Create {
         name: String,
         #[arg(long)]
         display_name: Option<String>,
     },
+    /// Delete a team.
     Delete {
         #[arg(long)]
         team: Option<String>,
     },
+    /// Manage team members.
     Member {
         #[command(subcommand)]
         command: TeamMemberCommand,
     },
+    /// Manage a team's resource grants.
     Grant {
         #[command(subcommand)]
         command: GrantCommand,
@@ -115,15 +126,18 @@ pub enum TeamCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum TeamMemberCommand {
+    /// List members of a team.
     List {
         #[arg(long)]
         team: Option<String>,
     },
+    /// Add a member to a team.
     Add {
         #[arg(long)]
         team: Option<String>,
         email: String,
     },
+    /// Remove a member from a team.
     Remove {
         #[arg(long)]
         team: Option<String>,
@@ -133,10 +147,12 @@ pub enum TeamMemberCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum GrantCommand {
+    /// List a team's grants.
     List {
         #[arg(long)]
         team: Option<String>,
     },
+    /// Grant a member an action on a resource.
     Add {
         #[arg(long)]
         team: Option<String>,
@@ -146,6 +162,7 @@ pub enum GrantCommand {
         #[arg(long)]
         action: String,
     },
+    /// Revoke a grant.
     Remove {
         #[arg(long)]
         team: Option<String>,
@@ -155,21 +172,25 @@ pub enum GrantCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum ResourceCommand {
+    /// List the resources in this collection.
     List {
         #[arg(long)]
         team: Option<String>,
     },
+    /// Show one resource.
     Get {
         #[arg(long)]
         team: Option<String>,
         name: String,
     },
+    /// Create a resource from a JSON file.
     Create {
         #[arg(long)]
         team: Option<String>,
         #[arg(short, long)]
         file: PathBuf,
     },
+    /// Update a resource from a JSON file (requires `--revision`).
     Update {
         #[arg(long)]
         team: Option<String>,
@@ -177,6 +198,7 @@ pub enum ResourceCommand {
         #[arg(short, long)]
         file: PathBuf,
     },
+    /// Delete a resource.
     Delete {
         #[arg(long)]
         team: Option<String>,
@@ -186,21 +208,25 @@ pub enum ResourceCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum RouteCommand {
+    /// List route configurations.
     List {
         #[arg(long)]
         team: Option<String>,
     },
+    /// Show one route configuration.
     Get {
         #[arg(long)]
         team: Option<String>,
         name: String,
     },
+    /// Create a route configuration from a JSON file.
     Create {
         #[arg(long)]
         team: Option<String>,
         #[arg(short, long)]
         file: PathBuf,
     },
+    /// Update a route configuration from a JSON file (requires `--revision`).
     Update {
         #[arg(long)]
         team: Option<String>,
@@ -208,11 +234,13 @@ pub enum RouteCommand {
         #[arg(short, long)]
         file: PathBuf,
     },
+    /// Delete a route configuration.
     Delete {
         #[arg(long)]
         team: Option<String>,
         name: String,
     },
+    /// Generate a route plan from a published API spec.
     Generate {
         #[arg(long)]
         team: Option<String>,
@@ -221,6 +249,7 @@ pub enum RouteCommand {
         #[arg(long)]
         listener_port: u16,
     },
+    /// Apply a previously generated route plan.
     Apply {
         #[arg(long)]
         team: Option<String>,
@@ -230,18 +259,22 @@ pub enum RouteCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum AiCommand {
+    /// Manage AI providers.
     Providers {
         #[command(subcommand)]
         command: ResourceCommand,
     },
+    /// Manage AI routes.
     Routes {
         #[command(subcommand)]
         command: ResourceCommand,
     },
+    /// Manage AI budgets.
     Budgets {
         #[command(subcommand)]
         command: ResourceCommand,
     },
+    /// Show AI token-usage records.
     Usage {
         #[arg(long)]
         team: Option<String>,
@@ -279,12 +312,14 @@ pub enum RateLimitCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum RateLimitPolicyCommand {
+    /// List the policies in a domain.
     List {
         #[arg(long)]
         team: Option<String>,
         #[arg(long)]
         domain: String,
     },
+    /// Show one policy.
     Get {
         #[arg(long)]
         team: Option<String>,
@@ -292,6 +327,7 @@ pub enum RateLimitPolicyCommand {
         domain: String,
         name: String,
     },
+    /// Create a policy from a JSON file.
     Create {
         #[arg(long)]
         team: Option<String>,
@@ -300,6 +336,7 @@ pub enum RateLimitPolicyCommand {
         #[arg(short, long)]
         file: PathBuf,
     },
+    /// Update a policy from a JSON file (requires `--revision`).
     Update {
         #[arg(long)]
         team: Option<String>,
@@ -309,6 +346,7 @@ pub enum RateLimitPolicyCommand {
         #[arg(short, long)]
         file: PathBuf,
     },
+    /// Delete a policy.
     Delete {
         #[arg(long)]
         team: Option<String>,
@@ -320,6 +358,7 @@ pub enum RateLimitPolicyCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum RateLimitOverrideCommand {
+    /// Show a team's override of a policy.
     Get {
         #[arg(long)]
         team: Option<String>,
@@ -339,6 +378,7 @@ pub enum RateLimitOverrideCommand {
         #[arg(short, long)]
         file: PathBuf,
     },
+    /// Update a policy override from a JSON file (requires `--revision`).
     Update {
         #[arg(long)]
         team: Option<String>,
@@ -349,6 +389,7 @@ pub enum RateLimitOverrideCommand {
         #[arg(short, long)]
         file: PathBuf,
     },
+    /// Delete a policy override.
     Delete {
         #[arg(long)]
         team: Option<String>,
@@ -361,24 +402,29 @@ pub enum RateLimitOverrideCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum ApiCommand {
+    /// List API definitions.
     List {
         #[arg(long)]
         team: Option<String>,
     },
+    /// Show one API definition.
     Get {
         #[arg(long)]
         team: Option<String>,
         name: String,
     },
+    /// Show an API definition's lifecycle status.
     Status {
         #[arg(long)]
         team: Option<String>,
         name: String,
     },
+    /// Manage an API's imported spec versions.
     Spec {
         #[command(subcommand)]
         command: ApiSpecCommand,
     },
+    /// Create an API definition (optionally importing an OpenAPI document).
     Create {
         #[arg(long)]
         team: Option<String>,
@@ -398,6 +444,7 @@ pub enum ApiCommand {
         #[arg(long)]
         route: Option<String>,
     },
+    /// Delete an API definition.
     Delete {
         #[arg(long)]
         team: Option<String>,
@@ -407,6 +454,7 @@ pub enum ApiCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum ApiSpecCommand {
+    /// Reject a pending spec version.
     Reject {
         #[arg(long)]
         team: Option<String>,
@@ -415,6 +463,7 @@ pub enum ApiSpecCommand {
         #[arg(long, default_value = "")]
         reason: String,
     },
+    /// Publish a reviewed spec version.
     Publish {
         #[arg(long)]
         team: Option<String>,
@@ -427,20 +476,24 @@ pub enum ApiSpecCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum McpCommand {
+    /// Show MCP server status.
     Status {
         #[arg(long)]
         team: Option<String>,
     },
+    /// List active MCP connections.
     Connections {
         #[arg(long)]
         team: Option<String>,
     },
+    /// Expose an API as an MCP tool.
     Enable {
         #[arg(long = "api", alias = "tool")]
         api: String,
         #[arg(long)]
         team: Option<String>,
     },
+    /// Stop exposing an API as an MCP tool.
     Disable {
         #[arg(long = "api", alias = "tool")]
         api: String,
@@ -451,10 +504,12 @@ pub enum McpCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum LearnCommand {
+    /// Schema-free traffic discovery sessions.
     Discover {
         #[command(subcommand)]
         command: LearnDiscoverCommand,
     },
+    /// Start a capture session against an existing API.
     Start {
         #[arg(long)]
         team: Option<String>,
@@ -480,6 +535,7 @@ pub enum LearnCommand {
         #[arg(long, default_value_t = 500)]
         max_distinct_paths: i32,
     },
+    /// List capture sessions.
     List {
         #[arg(long)]
         team: Option<String>,
@@ -490,21 +546,25 @@ pub enum LearnCommand {
         #[arg(long, default_value_t = 0)]
         offset: i64,
     },
+    /// Show one capture session.
     Get {
         #[arg(long)]
         team: Option<String>,
         session: String,
     },
+    /// Stop a capture session.
     Stop {
         #[arg(long)]
         team: Option<String>,
         session: String,
     },
+    /// Generate an OpenAPI spec from a capture session.
     GenerateSpec {
         #[arg(long)]
         team: Option<String>,
         session: String,
     },
+    /// Cancel a capture session.
     Cancel {
         #[arg(long)]
         team: Option<String>,
@@ -514,6 +574,7 @@ pub enum LearnCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum LearnDiscoverCommand {
+    /// Start a discovery session against a raw upstream.
     Start {
         #[arg(long)]
         team: Option<String>,
@@ -533,6 +594,7 @@ pub enum LearnDiscoverCommand {
         #[arg(long, default_value_t = 500)]
         max_distinct_paths: i32,
     },
+    /// List discovery sessions.
     List {
         #[arg(long)]
         team: Option<String>,
@@ -543,16 +605,19 @@ pub enum LearnDiscoverCommand {
         #[arg(long, default_value_t = 0)]
         offset: i64,
     },
+    /// Show a discovery session's status.
     Status {
         #[arg(long)]
         team: Option<String>,
         session: String,
     },
+    /// Stop a discovery session.
     Stop {
         #[arg(long)]
         team: Option<String>,
         session: String,
     },
+    /// Generate an OpenAPI spec from a discovery session.
     GenerateSpec {
         #[arg(long)]
         team: Option<String>,
@@ -562,21 +627,25 @@ pub enum LearnDiscoverCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum SecretCommand {
+    /// List secrets (metadata only).
     List {
         #[arg(long)]
         team: Option<String>,
     },
+    /// Show one secret's metadata.
     Get {
         #[arg(long)]
         team: Option<String>,
         name: String,
     },
+    /// Create a secret from a JSON file.
     Create {
         #[arg(long)]
         team: Option<String>,
         #[arg(short, long)]
         file: PathBuf,
     },
+    /// Rotate a secret's value from a JSON file.
     Rotate {
         #[arg(long)]
         team: Option<String>,
@@ -590,15 +659,18 @@ pub enum SecretCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum DataplaneCommand {
+    /// List dataplanes.
     List {
         #[arg(long)]
         team: Option<String>,
     },
+    /// Show one dataplane.
     Get {
         #[arg(long)]
         team: Option<String>,
         name: String,
     },
+    /// Register a dataplane.
     Create {
         #[arg(long)]
         team: Option<String>,
@@ -606,6 +678,7 @@ pub enum DataplaneCommand {
         #[arg(long, default_value = "")]
         description: String,
     },
+    /// Submit dataplane telemetry from a JSON file.
     Telemetry {
         #[arg(long)]
         team: Option<String>,
@@ -613,6 +686,7 @@ pub enum DataplaneCommand {
         #[arg(short, long)]
         file: PathBuf,
     },
+    /// Generate an Envoy bootstrap config for a dataplane.
     #[command(alias = "envoy-config")]
     Bootstrap {
         #[arg(long)]
@@ -633,6 +707,7 @@ pub enum DataplaneCommand {
         #[arg(long)]
         ca_path: Option<String>,
     },
+    /// Manage dataplane proxy certificates.
     Cert {
         #[command(subcommand)]
         command: CertCommand,
@@ -681,16 +756,19 @@ pub struct UnexposeCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum CertCommand {
+    /// List a dataplane's proxy certificates.
     List {
         #[arg(long)]
         team: Option<String>,
     },
+    /// Register a proxy certificate from a JSON file.
     Register {
         #[arg(long)]
         team: Option<String>,
         #[arg(short, long)]
         file: PathBuf,
     },
+    /// Issue a proxy certificate for a dataplane.
     Issue {
         #[arg(long)]
         team: Option<String>,
@@ -698,6 +776,7 @@ pub enum CertCommand {
         #[arg(long, default_value_t = 24)]
         ttl_hours: i64,
     },
+    /// Revoke a proxy certificate.
     Revoke {
         #[arg(long)]
         team: Option<String>,
@@ -709,6 +788,7 @@ pub enum CertCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum StatsCommand {
+    /// Show a team's resource counts.
     Overview {
         #[arg(long)]
         team: Option<String>,
@@ -717,10 +797,12 @@ pub enum StatsCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum OpsCommand {
+    /// xDS delivery diagnostics.
     Xds {
         #[command(subcommand)]
         command: XdsCommand,
     },
+    /// Search request traces.
     Trace {
         #[arg(long)]
         team: Option<String>,
@@ -737,10 +819,12 @@ pub enum OpsCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum XdsCommand {
+    /// Show xDS stream status.
     Status {
         #[arg(long)]
         team: Option<String>,
     },
+    /// Show recent xDS NACKs.
     Nacks {
         #[arg(long)]
         team: Option<String>,

--- a/crates/flowplane/src/cli/commands.rs
+++ b/crates/flowplane/src/cli/commands.rs
@@ -8,6 +8,9 @@ pub enum AuthCommand {
     /// Print the raw bearer token for the active context.
     Token,
     /// Acquire and store a bearer token (static token, PKCE, or device flow).
+    #[command(
+        after_help = "Example:\n  flowplane auth login --device-code --issuer https://issuer.example --client-id flowplane-cli"
+    )]
     Login {
         /// Static bearer token to store for the active context.
         #[arg(long)]
@@ -45,6 +48,9 @@ pub enum ConfigCommand {
     /// Print the merged CLI configuration.
     Show,
     /// Create or update a named context (server, org, team, token).
+    #[command(
+        after_help = "Example:\n  flowplane config set-context prod --server https://fp.example --org acme --team payments"
+    )]
     SetContext {
         /// Name of the context to create or update.
         name: String,
@@ -83,6 +89,7 @@ pub enum OrgCommand {
         org: String,
     },
     /// Create an organization.
+    #[command(after_help = "Example:\n  flowplane org create acme --display-name Acme")]
     Create {
         /// Name (slug) of the organization to create.
         name: String,
@@ -110,6 +117,9 @@ pub enum OrgMemberCommand {
         org: String,
     },
     /// Add a member to an organization.
+    #[command(
+        after_help = "Example:\n  flowplane org member add acme --email user@example.com --role org-admin"
+    )]
     Add {
         /// Organization to add the member to.
         org: String,
@@ -140,6 +150,7 @@ pub enum TeamCommand {
     /// List teams.
     List,
     /// Create a team.
+    #[command(after_help = "Example:\n  flowplane team create payments --display-name Payments")]
     Create {
         /// Name (slug) of the team to create.
         name: String,
@@ -174,6 +185,9 @@ pub enum TeamMemberCommand {
         team: Option<String>,
     },
     /// Add a member to a team.
+    #[command(
+        after_help = "Example:\n  flowplane team member add user@example.com --team payments"
+    )]
     Add {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -200,6 +214,9 @@ pub enum GrantCommand {
         team: Option<String>,
     },
     /// Grant a member an action on a resource.
+    #[command(
+        after_help = "Example:\n  flowplane team grant add user@example.com --team payments --resource clusters --action write"
+    )]
     Add {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -240,6 +257,9 @@ pub enum ResourceCommand {
         name: String,
     },
     /// Create a resource from a JSON file.
+    #[command(
+        after_help = "Example (resource create takes the JSON body via -f):\n  flowplane cluster create --team payments -f resource.json\n\nThe same -f body shape applies to listener / ai providers|routes|budgets / rate-limit domain."
+    )]
     Create {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -249,6 +269,9 @@ pub enum ResourceCommand {
         file: PathBuf,
     },
     /// Update a resource from a JSON file (requires `--revision`).
+    #[command(
+        after_help = "Example (resource update takes the JSON body via -f and the current --revision):\n  flowplane cluster update web --team payments -f resource.json --revision 3\n\nThe same shape applies to listener / ai providers|routes|budgets / rate-limit domain."
+    )]
     Update {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -286,6 +309,7 @@ pub enum RouteCommand {
         name: String,
     },
     /// Create a route configuration from a JSON file.
+    #[command(after_help = "Example:\n  flowplane route create --team payments -f route.json")]
     Create {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -295,6 +319,9 @@ pub enum RouteCommand {
         file: PathBuf,
     },
     /// Update a route configuration from a JSON file (requires `--revision`).
+    #[command(
+        after_help = "Example:\n  flowplane route update edge --team payments -f route.json --revision 3"
+    )]
     Update {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -314,6 +341,9 @@ pub enum RouteCommand {
         name: String,
     },
     /// Generate a route plan from a published API spec.
+    #[command(
+        after_help = "Example:\n  flowplane route generate --team payments --from-spec 018ff2ef-bfc6-7000-8000-000000000001 --listener-port 19090"
+    )]
     Generate {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -416,6 +446,9 @@ pub enum RateLimitPolicyCommand {
         name: String,
     },
     /// Create a policy from a JSON file.
+    #[command(
+        after_help = "Example:\n  flowplane rate-limit policy create --team payments --domain edge -f policy.json"
+    )]
     Create {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -428,6 +461,9 @@ pub enum RateLimitPolicyCommand {
         file: PathBuf,
     },
     /// Update a policy from a JSON file (requires `--revision`).
+    #[command(
+        after_help = "Example:\n  flowplane rate-limit policy update per-ip --team payments --domain edge -f policy.json --revision 3"
+    )]
     Update {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -469,6 +505,9 @@ pub enum RateLimitOverrideCommand {
         policy: String,
     },
     /// Create the override from a JSON file (`{ "spec": { "requests_per_unit": N } }`).
+    #[command(
+        after_help = "Example:\n  flowplane rate-limit override set --team payments --domain edge --policy per-ip -f override.json"
+    )]
     Set {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -484,6 +523,9 @@ pub enum RateLimitOverrideCommand {
         file: PathBuf,
     },
     /// Update a policy override from a JSON file (requires `--revision`).
+    #[command(
+        after_help = "Example:\n  flowplane rate-limit override update --team payments --domain edge --policy per-ip -f override.json --revision 3"
+    )]
     Update {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -542,6 +584,9 @@ pub enum ApiCommand {
         command: ApiSpecCommand,
     },
     /// Create an API definition (optionally importing an OpenAPI document).
+    #[command(
+        after_help = "Example:\n  flowplane api create catalog --team payments --from-openapi openapi.json"
+    )]
     Create {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -583,6 +628,7 @@ pub enum ApiCommand {
 #[derive(Debug, Subcommand)]
 pub enum ApiSpecCommand {
     /// Reject a pending spec version.
+    #[command(after_help = "Example:\n  flowplane api spec reject catalog 3 --reason superseded")]
     Reject {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -596,6 +642,7 @@ pub enum ApiSpecCommand {
         reason: String,
     },
     /// Publish a reviewed spec version.
+    #[command(after_help = "Example:\n  flowplane api spec publish catalog 3")]
     Publish {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -625,6 +672,7 @@ pub enum McpCommand {
         team: Option<String>,
     },
     /// Expose an API as an MCP tool.
+    #[command(after_help = "Example:\n  flowplane mcp enable --api catalog --team payments")]
     Enable {
         /// Name of the API to expose as an MCP tool.
         #[arg(long = "api", alias = "tool")]
@@ -634,6 +682,7 @@ pub enum McpCommand {
         team: Option<String>,
     },
     /// Stop exposing an API as an MCP tool.
+    #[command(after_help = "Example:\n  flowplane mcp disable --api catalog --team payments")]
     Disable {
         /// Name of the API to stop exposing as an MCP tool.
         #[arg(long = "api", alias = "tool")]
@@ -652,6 +701,9 @@ pub enum LearnCommand {
         command: LearnDiscoverCommand,
     },
     /// Start a capture session against an existing API.
+    #[command(
+        after_help = "Example:\n  flowplane learn start catalog-capture --team payments --api catalog"
+    )]
     Start {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -741,6 +793,9 @@ pub enum LearnCommand {
 #[derive(Debug, Subcommand)]
 pub enum LearnDiscoverCommand {
     /// Start a discovery session against a raw upstream.
+    #[command(
+        after_help = "Example:\n  flowplane learn discover start public-probe --team payments --upstream 10.0.0.5:80 --listener-port 19080"
+    )]
     Start {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -827,6 +882,7 @@ pub enum SecretCommand {
         name: String,
     },
     /// Create a secret from a JSON file.
+    #[command(after_help = "Example:\n  flowplane secret create --team payments -f secret.json")]
     Create {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -836,6 +892,9 @@ pub enum SecretCommand {
         file: PathBuf,
     },
     /// Rotate a secret's value from a JSON file.
+    #[command(
+        after_help = "Example:\n  flowplane secret rotate db-password --team payments --revision 2 -f secret.json"
+    )]
     Rotate {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -868,6 +927,7 @@ pub enum DataplaneCommand {
         name: String,
     },
     /// Register a dataplane.
+    #[command(after_help = "Example:\n  flowplane dataplane create edge-1 --team payments")]
     Create {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -879,6 +939,9 @@ pub enum DataplaneCommand {
         description: String,
     },
     /// Submit dataplane telemetry from a JSON file.
+    #[command(
+        after_help = "Example:\n  flowplane dataplane telemetry edge-1 --team payments -f telemetry.json"
+    )]
     Telemetry {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -891,6 +954,9 @@ pub enum DataplaneCommand {
     },
     /// Generate an Envoy bootstrap config for a dataplane.
     #[command(alias = "envoy-config")]
+    #[command(
+        after_help = "Example:\n  flowplane dataplane bootstrap edge-1 --team payments --mode dev"
+    )]
     Bootstrap {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -982,6 +1048,9 @@ pub enum CertCommand {
         team: Option<String>,
     },
     /// Register a proxy certificate from a JSON file.
+    #[command(
+        after_help = "Example:\n  flowplane dataplane cert register --team payments -f cert.json"
+    )]
     Register {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -991,6 +1060,7 @@ pub enum CertCommand {
         file: PathBuf,
     },
     /// Issue a proxy certificate for a dataplane.
+    #[command(after_help = "Example:\n  flowplane dataplane cert issue edge-1 --team payments")]
     Issue {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]
@@ -1002,6 +1072,9 @@ pub enum CertCommand {
         ttl_hours: i64,
     },
     /// Revoke a proxy certificate.
+    #[command(
+        after_help = "Example:\n  flowplane dataplane cert revoke 0A1B2C3D --team payments --reason compromised"
+    )]
     Revoke {
         /// Team scope; defaults to the active context's team.
         #[arg(long)]

--- a/crates/flowplane/src/cli/commands.rs
+++ b/crates/flowplane/src/cli/commands.rs
@@ -9,20 +9,28 @@ pub enum AuthCommand {
     Token,
     /// Acquire and store a bearer token (static token, PKCE, or device flow).
     Login {
+        /// Static bearer token to store for the active context.
         #[arg(long)]
         token: Option<String>,
+        /// Read the static bearer token from stdin.
         #[arg(long)]
         token_stdin: bool,
+        /// Use the OAuth device-authorization flow.
         #[arg(long, alias = "device-code")]
         device: bool,
+        /// Use the OAuth authorization-code flow with PKCE.
         #[arg(long)]
         pkce: bool,
+        /// OIDC issuer URL to authenticate against.
         #[arg(long)]
         issuer: Option<String>,
+        /// OAuth client ID to use for the login flow.
         #[arg(long)]
         client_id: Option<String>,
+        /// Local redirect URL for the PKCE callback.
         #[arg(long)]
         callback_url: Option<String>,
+        /// OAuth scopes to request.
         #[arg(long, default_value = "openid email profile")]
         scope: String,
     },
@@ -38,20 +46,29 @@ pub enum ConfigCommand {
     Show,
     /// Create or update a named context (server, org, team, token).
     SetContext {
+        /// Name of the context to create or update.
         name: String,
+        /// Control-plane server base URL for the context.
         #[arg(long)]
         server: String,
+        /// Organization scope to store in the context.
         #[arg(long)]
         org: Option<String>,
+        /// Team scope to store in the context.
         #[arg(long)]
         team: Option<String>,
+        /// Bearer token to store in the context.
         #[arg(long)]
         token: Option<String>,
+        /// Read the context's bearer token from stdin.
         #[arg(long)]
         token_stdin: bool,
     },
     /// Switch the active context.
-    UseContext { name: String },
+    UseContext {
+        /// Name of the context to switch to.
+        name: String,
+    },
     /// List the configured contexts.
     GetContexts,
 }
@@ -61,15 +78,23 @@ pub enum OrgCommand {
     /// List organizations.
     List,
     /// Show one organization.
-    Get { org: String },
+    Get {
+        /// Name of the organization to show.
+        org: String,
+    },
     /// Create an organization.
     Create {
+        /// Name (slug) of the organization to create.
         name: String,
+        /// Optional human-readable display name for the organization.
         #[arg(long)]
         display_name: Option<String>,
     },
     /// Delete an organization.
-    Delete { org: String },
+    Delete {
+        /// Name of the organization to delete.
+        org: String,
+    },
     /// Manage organization members.
     Member {
         #[command(subcommand)]
@@ -80,21 +105,34 @@ pub enum OrgCommand {
 #[derive(Debug, Subcommand)]
 pub enum OrgMemberCommand {
     /// List members of an organization.
-    List { org: String },
+    List {
+        /// Organization whose members to list.
+        org: String,
+    },
     /// Add a member to an organization.
     Add {
+        /// Organization to add the member to.
         org: String,
+        /// Email address identifying the user to add.
         #[arg(long)]
         email: Option<String>,
+        /// Subject (JWT `sub`) identifying the user to add.
         #[arg(long)]
         subject: Option<String>,
+        /// User ID identifying the user to add.
         #[arg(long)]
         user_id: Option<String>,
+        /// Role to assign to the member.
         #[arg(long)]
         role: String,
     },
     /// Remove a member from an organization.
-    Remove { org: String, user_id: String },
+    Remove {
+        /// Organization to remove the member from.
+        org: String,
+        /// User ID of the member to remove.
+        user_id: String,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -103,12 +141,15 @@ pub enum TeamCommand {
     List,
     /// Create a team.
     Create {
+        /// Name (slug) of the team to create.
         name: String,
+        /// Optional human-readable display name for the team.
         #[arg(long)]
         display_name: Option<String>,
     },
     /// Delete a team.
     Delete {
+        /// Team to delete; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
     },
@@ -128,19 +169,24 @@ pub enum TeamCommand {
 pub enum TeamMemberCommand {
     /// List members of a team.
     List {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
     },
     /// Add a member to a team.
     Add {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Email address of the user to add.
         email: String,
     },
     /// Remove a member from a team.
     Remove {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// User ID of the member to remove.
         user_id: String,
     },
 }
@@ -149,23 +195,30 @@ pub enum TeamMemberCommand {
 pub enum GrantCommand {
     /// List a team's grants.
     List {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
     },
     /// Grant a member an action on a resource.
     Add {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Email address of the member to grant access to.
         email: String,
+        /// Resource type the grant applies to.
         #[arg(long)]
         resource: String,
+        /// Action the grant permits on the resource.
         #[arg(long)]
         action: String,
     },
     /// Revoke a grant.
     Remove {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Identifier of the grant to revoke.
         grant_id: String,
     },
 }
@@ -174,34 +227,44 @@ pub enum GrantCommand {
 pub enum ResourceCommand {
     /// List the resources in this collection.
     List {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
     },
     /// Show one resource.
     Get {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the resource to show.
         name: String,
     },
     /// Create a resource from a JSON file.
     Create {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Path to the JSON request body (use `-` for stdin).
         #[arg(short, long)]
         file: PathBuf,
     },
     /// Update a resource from a JSON file (requires `--revision`).
     Update {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the resource to update.
         name: String,
+        /// Path to the JSON request body (use `-` for stdin).
         #[arg(short, long)]
         file: PathBuf,
     },
     /// Delete a resource.
     Delete {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the resource to delete.
         name: String,
     },
 }
@@ -210,49 +273,64 @@ pub enum ResourceCommand {
 pub enum RouteCommand {
     /// List route configurations.
     List {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
     },
     /// Show one route configuration.
     Get {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the route configuration to show.
         name: String,
     },
     /// Create a route configuration from a JSON file.
     Create {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Path to the JSON request body (use `-` for stdin).
         #[arg(short, long)]
         file: PathBuf,
     },
     /// Update a route configuration from a JSON file (requires `--revision`).
     Update {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the route configuration to update.
         name: String,
+        /// Path to the JSON request body (use `-` for stdin).
         #[arg(short, long)]
         file: PathBuf,
     },
     /// Delete a route configuration.
     Delete {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the route configuration to delete.
         name: String,
     },
     /// Generate a route plan from a published API spec.
     Generate {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Reviewed or published learned spec version ID to generate the route plan from.
         #[arg(long)]
         from_spec: String,
+        /// Listener port the generated routes bind to.
         #[arg(long)]
         listener_port: u16,
     },
     /// Apply a previously generated route plan.
     Apply {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Identifier of the previously generated route plan to apply.
         plan_id: String,
     },
 }
@@ -276,14 +354,19 @@ pub enum AiCommand {
     },
     /// Show AI token-usage records.
     Usage {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Filter usage records to this AI provider ID.
         #[arg(long)]
         provider_id: Option<String>,
+        /// Filter usage records to this route configuration ID.
         #[arg(long)]
         route_config_id: Option<String>,
+        /// Maximum number of records to return.
         #[arg(long, default_value_t = 50)]
         limit: i64,
+        /// Number of records to skip for pagination.
         #[arg(long, default_value_t = 0)]
         offset: i64,
     },
@@ -314,44 +397,59 @@ pub enum RateLimitCommand {
 pub enum RateLimitPolicyCommand {
     /// List the policies in a domain.
     List {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Rate-limit domain the policies belong to.
         #[arg(long)]
         domain: String,
     },
     /// Show one policy.
     Get {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Rate-limit domain the policy belongs to.
         #[arg(long)]
         domain: String,
+        /// Name of the policy to show.
         name: String,
     },
     /// Create a policy from a JSON file.
     Create {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Rate-limit domain to create the policy in.
         #[arg(long)]
         domain: String,
+        /// Path to the JSON request body (use `-` for stdin).
         #[arg(short, long)]
         file: PathBuf,
     },
     /// Update a policy from a JSON file (requires `--revision`).
     Update {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Rate-limit domain the policy belongs to.
         #[arg(long)]
         domain: String,
+        /// Name of the policy to update.
         name: String,
+        /// Path to the JSON request body (use `-` for stdin).
         #[arg(short, long)]
         file: PathBuf,
     },
     /// Delete a policy.
     Delete {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Rate-limit domain the policy belongs to.
         #[arg(long)]
         domain: String,
+        /// Name of the policy to delete.
         name: String,
     },
 }
@@ -360,41 +458,55 @@ pub enum RateLimitPolicyCommand {
 pub enum RateLimitOverrideCommand {
     /// Show a team's override of a policy.
     Get {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Rate-limit domain the policy belongs to.
         #[arg(long)]
         domain: String,
+        /// Policy whose team override to show.
         #[arg(long)]
         policy: String,
     },
     /// Create the override from a JSON file (`{ "spec": { "requests_per_unit": N } }`).
     Set {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Rate-limit domain the policy belongs to.
         #[arg(long)]
         domain: String,
+        /// Policy to override.
         #[arg(long)]
         policy: String,
+        /// Path to the JSON request body (use `-` for stdin).
         #[arg(short, long)]
         file: PathBuf,
     },
     /// Update a policy override from a JSON file (requires `--revision`).
     Update {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Rate-limit domain the policy belongs to.
         #[arg(long)]
         domain: String,
+        /// Policy whose override to update.
         #[arg(long)]
         policy: String,
+        /// Path to the JSON request body (use `-` for stdin).
         #[arg(short, long)]
         file: PathBuf,
     },
     /// Delete a policy override.
     Delete {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Rate-limit domain the policy belongs to.
         #[arg(long)]
         domain: String,
+        /// Policy whose override to delete.
         #[arg(long)]
         policy: String,
     },
@@ -404,19 +516,24 @@ pub enum RateLimitOverrideCommand {
 pub enum ApiCommand {
     /// List API definitions.
     List {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
     },
     /// Show one API definition.
     Get {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the API definition to show.
         name: String,
     },
     /// Show an API definition's lifecycle status.
     Status {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the API definition whose status to show.
         name: String,
     },
     /// Manage an API's imported spec versions.
@@ -426,28 +543,39 @@ pub enum ApiCommand {
     },
     /// Create an API definition (optionally importing an OpenAPI document).
     Create {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the API definition to create.
         name: String,
+        /// Optional human-readable display name for the API.
         #[arg(long)]
         display_name: Option<String>,
+        /// Optional description for the API definition.
         #[arg(long, default_value = "")]
         description: String,
+        /// Path to an OpenAPI document to import.
         #[arg(long)]
         from_openapi: Option<PathBuf>,
+        /// Route configuration ID to attach the API to.
         #[arg(long)]
         route_config_id: Option<String>,
+        /// Listener ID to attach the API to.
         #[arg(long)]
         listener_id: Option<String>,
+        /// Virtual host name to attach the API to.
         #[arg(long)]
         virtual_host: Option<String>,
+        /// Route name to attach the API to.
         #[arg(long)]
         route: Option<String>,
     },
     /// Delete an API definition.
     Delete {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the API definition to delete.
         name: String,
     },
 }
@@ -456,19 +584,27 @@ pub enum ApiCommand {
 pub enum ApiSpecCommand {
     /// Reject a pending spec version.
     Reject {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the API whose spec version to reject.
         api: String,
+        /// Spec version number to reject.
         version: i64,
+        /// Optional human-readable reason recorded in the audit log.
         #[arg(long, default_value = "")]
         reason: String,
     },
     /// Publish a reviewed spec version.
     Publish {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the API whose spec version to publish.
         api: String,
+        /// Spec version number to publish.
         version: i64,
+        /// Optional human-readable reason recorded in the audit log.
         #[arg(long, default_value = "")]
         reason: String,
     },
@@ -478,25 +614,31 @@ pub enum ApiSpecCommand {
 pub enum McpCommand {
     /// Show MCP server status.
     Status {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
     },
     /// List active MCP connections.
     Connections {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
     },
     /// Expose an API as an MCP tool.
     Enable {
+        /// Name of the API to expose as an MCP tool.
         #[arg(long = "api", alias = "tool")]
         api: String,
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
     },
     /// Stop exposing an API as an MCP tool.
     Disable {
+        /// Name of the API to stop exposing as an MCP tool.
         #[arg(long = "api", alias = "tool")]
         api: String,
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
     },
@@ -511,63 +653,87 @@ pub enum LearnCommand {
     },
     /// Start a capture session against an existing API.
     Start {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name for the capture session.
         name: String,
+        /// Name of the existing API to capture traffic for.
         #[arg(long)]
         api: Option<String>,
+        /// API definition ID to capture traffic for.
         #[arg(long)]
         api_definition_id: Option<String>,
+        /// Route configuration ID to scope capture to.
         #[arg(long)]
         route_config_id: Option<String>,
+        /// Listener ID to scope capture to.
         #[arg(long)]
         listener_id: Option<String>,
+        /// Virtual host name to scope capture to.
         #[arg(long)]
         virtual_host: Option<String>,
+        /// Route name to scope capture to.
         #[arg(long)]
         route: Option<String>,
+        /// Target number of request samples to collect.
         #[arg(long, default_value_t = 1000)]
         target_sample_count: i32,
+        /// Maximum capture duration in seconds.
         #[arg(long)]
         max_duration_seconds: Option<i32>,
+        /// Maximum total bytes to capture.
         #[arg(long, default_value_t = 10 * 1024 * 1024)]
         max_bytes: i64,
+        /// Maximum number of distinct paths to track.
         #[arg(long, default_value_t = 500)]
         max_distinct_paths: i32,
     },
     /// List capture sessions.
     List {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Filter sessions by status.
         #[arg(long)]
         status: Option<String>,
+        /// Maximum number of sessions to return.
         #[arg(long, default_value_t = 50)]
         limit: i64,
+        /// Number of sessions to skip for pagination.
         #[arg(long, default_value_t = 0)]
         offset: i64,
     },
     /// Show one capture session.
     Get {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Identifier of the capture session to show.
         session: String,
     },
     /// Stop a capture session.
     Stop {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Identifier of the capture session to stop.
         session: String,
     },
     /// Generate an OpenAPI spec from a capture session.
     GenerateSpec {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Identifier of the capture session to generate a spec from.
         session: String,
     },
     /// Cancel a capture session.
     Cancel {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Identifier of the capture session to cancel.
         session: String,
     },
 }
@@ -576,51 +742,70 @@ pub enum LearnCommand {
 pub enum LearnDiscoverCommand {
     /// Start a discovery session against a raw upstream.
     Start {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name for the discovery session.
         name: String,
+        /// Upstream address to capture traffic from.
         #[arg(long)]
         upstream: String,
+        /// Listener port to bind for capture.
         #[arg(long)]
         listener_port: i32,
+        /// Connect to the upstream over TLS.
         #[arg(long)]
         upstream_tls: bool,
+        /// Target number of request samples to collect.
         #[arg(long, default_value_t = 1000)]
         target_sample_count: i32,
+        /// Maximum capture duration in seconds.
         #[arg(long)]
         max_duration_seconds: Option<i32>,
+        /// Maximum total bytes to capture.
         #[arg(long, default_value_t = 10 * 1024 * 1024)]
         max_bytes: i64,
+        /// Maximum number of distinct paths to track.
         #[arg(long, default_value_t = 500)]
         max_distinct_paths: i32,
     },
     /// List discovery sessions.
     List {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Filter sessions by status.
         #[arg(long)]
         status: Option<String>,
+        /// Maximum number of sessions to return.
         #[arg(long, default_value_t = 50)]
         limit: i64,
+        /// Number of sessions to skip for pagination.
         #[arg(long, default_value_t = 0)]
         offset: i64,
     },
     /// Show a discovery session's status.
     Status {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Identifier of the discovery session to show.
         session: String,
     },
     /// Stop a discovery session.
     Stop {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Identifier of the discovery session to stop.
         session: String,
     },
     /// Generate an OpenAPI spec from a discovery session.
     GenerateSpec {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Identifier of the discovery session to generate a spec from.
         session: String,
     },
 }
@@ -629,29 +814,38 @@ pub enum LearnDiscoverCommand {
 pub enum SecretCommand {
     /// List secrets (metadata only).
     List {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
     },
     /// Show one secret's metadata.
     Get {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the secret to show.
         name: String,
     },
     /// Create a secret from a JSON file.
     Create {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Path to the JSON request body (use `-` for stdin).
         #[arg(short, long)]
         file: PathBuf,
     },
     /// Rotate a secret's value from a JSON file.
     Rotate {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the secret to rotate.
         name: String,
+        /// Current revision being rotated (optimistic concurrency).
         #[arg(long)]
         revision: i64,
+        /// Path to the JSON request body (use `-` for stdin).
         #[arg(short, long)]
         file: PathBuf,
     },
@@ -661,49 +855,67 @@ pub enum SecretCommand {
 pub enum DataplaneCommand {
     /// List dataplanes.
     List {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
     },
     /// Show one dataplane.
     Get {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the dataplane to show.
         name: String,
     },
     /// Register a dataplane.
     Create {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the dataplane to register.
         name: String,
+        /// Optional description for the dataplane.
         #[arg(long, default_value = "")]
         description: String,
     },
     /// Submit dataplane telemetry from a JSON file.
     Telemetry {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the dataplane to submit telemetry for.
         name: String,
+        /// Path to the JSON request body (use `-` for stdin).
         #[arg(short, long)]
         file: PathBuf,
     },
     /// Generate an Envoy bootstrap config for a dataplane.
     #[command(alias = "envoy-config")]
     Bootstrap {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the dataplane to generate a bootstrap config for.
         name: String,
+        /// Bootstrap mode: dev (plaintext xDS) or mtls.
         #[arg(long, value_enum, default_value_t = DataplaneBootstrapMode::Dev)]
         mode: DataplaneBootstrapMode,
+        /// xDS server host the Envoy bootstrap points at.
         #[arg(long, default_value = "127.0.0.1")]
         xds_host: String,
+        /// xDS server port the Envoy bootstrap points at.
         #[arg(long, default_value_t = 18000)]
         xds_port: u16,
+        /// Envoy admin interface port.
         #[arg(long, default_value_t = 9901)]
         admin_port: u16,
+        /// Path to the client certificate for mTLS xDS.
         #[arg(long)]
         cert_path: Option<String>,
+        /// Path to the client private key for mTLS xDS.
         #[arg(long)]
         key_path: Option<String>,
+        /// Path to the CA certificate for mTLS xDS.
         #[arg(long)]
         ca_path: Option<String>,
     },
@@ -733,13 +945,18 @@ impl DataplaneBootstrapMode {
 
 #[derive(Debug, Args)]
 pub struct ExposeCommand {
+    /// Upstream address to expose through the gateway.
     pub upstream: String,
+    /// Name for the exposed route and listener.
     #[arg(long)]
     pub name: String,
+    /// Team scope; defaults to the active context's team.
     #[arg(long)]
     pub team: Option<String>,
+    /// Path prefix to route to the upstream.
     #[arg(long, default_value = "/")]
     pub path: String,
+    /// Listener port to bind.
     #[arg(long)]
     pub port: Option<u16>,
     /// Public gateway base URL clients can use to reach the listener.
@@ -749,7 +966,9 @@ pub struct ExposeCommand {
 
 #[derive(Debug, Args)]
 pub struct UnexposeCommand {
+    /// Name of the exposed route to remove.
     pub name: String,
+    /// Team scope; defaults to the active context's team.
     #[arg(long)]
     pub team: Option<String>,
 }
@@ -758,29 +977,38 @@ pub struct UnexposeCommand {
 pub enum CertCommand {
     /// List a dataplane's proxy certificates.
     List {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
     },
     /// Register a proxy certificate from a JSON file.
     Register {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Path to the JSON request body (use `-` for stdin).
         #[arg(short, long)]
         file: PathBuf,
     },
     /// Issue a proxy certificate for a dataplane.
     Issue {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Name of the dataplane to issue a certificate for.
         dataplane: String,
+        /// Certificate lifetime in hours.
         #[arg(long, default_value_t = 24)]
         ttl_hours: i64,
     },
     /// Revoke a proxy certificate.
     Revoke {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Serial number of the certificate to revoke.
         serial: String,
+        /// Reason recorded for the revocation.
         #[arg(long)]
         reason: String,
     },
@@ -790,6 +1018,7 @@ pub enum CertCommand {
 pub enum StatsCommand {
     /// Show a team's resource counts.
     Overview {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
     },
@@ -804,14 +1033,19 @@ pub enum OpsCommand {
     },
     /// Search request traces.
     Trace {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
+        /// Filter traces by request ID.
         #[arg(long)]
         request_id: Option<String>,
+        /// Filter traces by trace ID.
         #[arg(long)]
         trace_id: Option<String>,
+        /// Filter traces by request path.
         #[arg(long)]
         path: Option<String>,
+        /// Maximum number of traces to return.
         #[arg(long, default_value_t = 50)]
         limit: i64,
     },
@@ -821,11 +1055,13 @@ pub enum OpsCommand {
 pub enum XdsCommand {
     /// Show xDS stream status.
     Status {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
     },
     /// Show recent xDS NACKs.
     Nacks {
+        /// Team scope; defaults to the active context's team.
         #[arg(long)]
         team: Option<String>,
     },
@@ -833,8 +1069,10 @@ pub enum XdsCommand {
 
 #[derive(Debug, Args)]
 pub struct ApplyCommand {
+    /// Path to the JSON document of resources to apply (use `-` for stdin).
     #[arg(short, long)]
     pub file: PathBuf,
+    /// Show the diff without applying it.
     #[arg(long)]
     pub diff: bool,
     /// Refuse silently ignoring prune requests; apply is additive-only until server batch support.

--- a/crates/flowplane/src/cli/config.rs
+++ b/crates/flowplane/src/cli/config.rs
@@ -13,34 +13,45 @@ const DEFAULT_TIMEOUT_SECS: u64 = 30;
 
 #[derive(Debug, Clone, Args)]
 pub struct GlobalOptions {
+    /// Named context from the config file to use for this invocation.
     #[arg(long, global = true)]
     pub context: Option<String>,
+    /// Control-plane server base URL (overrides the context and config file).
     #[arg(long, global = true, env = "FLOWPLANE_SERVER")]
     pub server: Option<String>,
+    /// Team scope; defaults to the active context's team.
     #[arg(long, global = true, env = "FLOWPLANE_TEAM")]
     pub team: Option<String>,
+    /// Organization scope; defaults to the active context's org.
     #[arg(long, global = true, env = "FLOWPLANE_ORG")]
     pub org: Option<String>,
     /// Bearer token; highest-priority token source (CLI-R-40). Falls back to
     /// `FLOWPLANE_TOKEN`, the selected context, the config file, then the credentials file.
     #[arg(long, global = true, env = "FLOWPLANE_TOKEN", hide_env_values = true)]
     pub token: Option<String>,
+    /// Output format: table, json, yaml, or wide.
     #[arg(short = 'o', long, global = true, value_enum)]
     pub output: Option<OutputFormat>,
     /// Exactly equivalent to `--output json`; cannot be combined with `--output`
     /// (CLI-R-11: `-o/--output` is the single format selector).
     #[arg(long, global = true, conflicts_with = "output")]
     pub json: bool,
+    /// Disable ANSI color in output.
     #[arg(long, global = true)]
     pub no_color: bool,
+    /// Suppress non-essential progress output.
     #[arg(long, global = true)]
     pub quiet: bool,
+    /// Enable verbose diagnostic logging.
     #[arg(long, global = true)]
     pub verbose: bool,
+    /// Preview the request without sending it to the server.
     #[arg(long, global = true)]
     pub dry_run: bool,
+    /// Skip the confirmation prompt for destructive operations.
     #[arg(short = 'y', long, global = true)]
     pub yes: bool,
+    /// Expected current revision for optimistic-concurrency updates.
     #[arg(long, global = true)]
     pub revision: Option<i64>,
     /// Comma-separated field names to project reader output to (CLI-R-51). Applied inside
@@ -51,6 +62,7 @@ pub struct GlobalOptions {
     /// flag > `FLOWPLANE_TIMEOUT` > context > config file > default (30).
     #[arg(long, global = true, env = "FLOWPLANE_TIMEOUT")]
     pub timeout: Option<u64>,
+    /// Write output to this file instead of stdout.
     #[arg(long, global = true)]
     pub out: Option<PathBuf>,
 }

--- a/crates/flowplane/src/cli/mod.rs
+++ b/crates/flowplane/src/cli/mod.rs
@@ -56,7 +56,11 @@ fn parse_json_or_yaml(raw: &str) -> Result<Value> {
     }
 }
 
-pub async fn run_auth(global: GlobalOptions, command: AuthCommand) -> Result<()> {
+pub async fn run_auth(
+    global: GlobalOptions,
+    command: AuthCommand,
+    token_explicit: bool,
+) -> Result<()> {
     match command {
         AuthCommand::Whoami => RestClient::new(global)?
             .request(reqwest::Method::GET, "/api/v1/auth/whoami", None)
@@ -77,35 +81,39 @@ pub async fn run_auth(global: GlobalOptions, command: AuthCommand) -> Result<()>
             callback_url,
             scope,
         } => {
-            let token = match (token, token_stdin, device, pkce) {
-                (Some(token), false, false, false) => token,
-                (None, true, false, false) => read_token_from_stdin()?,
-                (None, false, true, true) => {
+            // `token` may be populated from the ambient `FLOWPLANE_TOKEN` via the global
+            // `--token` flag; only an explicit `--token <v>` on the command line
+            // (`token_explicit`) counts as a login *method* that conflicts with the others
+            // (Fix 3 / F-2). An env-sourced token is used only as a fallback when no explicit
+            // method is chosen.
+            let methods = [token_explicit, token_stdin, device, pkce]
+                .into_iter()
+                .filter(|c| *c)
+                .count();
+            if methods > 1 {
+                anyhow::bail!(
+                    "use only one login input: --token, --token-stdin, --device-code, or --pkce"
+                );
+            }
+            let token = if token_stdin {
+                read_token_from_stdin()?
+            } else if device {
+                device_login(&global, issuer, client_id, scope).await?
+            } else if pkce {
+                pkce_login(&global, issuer, client_id, callback_url, scope).await?
+            } else if token_explicit {
+                token.unwrap_or_default()
+            } else {
+                // No explicit method: fall back to an ambient `FLOWPLANE_TOKEN` if present,
+                // otherwise auto-PKCE when OIDC is configured, otherwise error.
+                let config = effective(&global)?;
+                if let Some(token) = token {
+                    token
+                } else if config.oidc_issuer.is_some() && config.oidc_client_id.is_some() {
+                    pkce_login(&global, issuer, client_id, callback_url, scope).await?
+                } else {
                     anyhow::bail!(
-                        "use only one login input: --token, --token-stdin, --device-code, or --pkce"
-                    )
-                }
-                (None, false, explicit_device, explicit_pkce) => {
-                    let config = effective(&global)?;
-                    if explicit_device {
-                        device_login(&global, issuer, client_id, scope).await?
-                    } else if explicit_pkce
-                        || (config.oidc_issuer.is_some() && config.oidc_client_id.is_some())
-                    {
-                        pkce_login(&global, issuer, client_id, callback_url, scope).await?
-                    } else {
-                        anyhow::bail!(
-                            "pass --token, --token-stdin, --device-code, or configure OIDC for PKCE"
-                        )
-                    }
-                }
-                (Some(_), true, _, _)
-                | (Some(_), _, true, _)
-                | (Some(_), _, _, true)
-                | (None, true, true, _)
-                | (None, true, _, true) => {
-                    anyhow::bail!(
-                        "use only one login input: --token, --token-stdin, --device-code, or --pkce"
+                        "pass --token, --token-stdin, --device-code, or configure OIDC for PKCE"
                     )
                 }
             };

--- a/crates/flowplane/src/cli/mod.rs
+++ b/crates/flowplane/src/cli/mod.rs
@@ -91,9 +91,10 @@ pub async fn run_auth(
                 .filter(|c| *c)
                 .count();
             if methods > 1 {
-                anyhow::bail!(
-                    "use only one login input: --token, --token-stdin, --device-code, or --pkce"
+                eprintln!(
+                    "error (usage_error): use only one login input: --token, --token-stdin, --device-code, or --pkce"
                 );
+                return Err(anyhow::Error::new(output::CliError::new(2)));
             }
             let token = if token_stdin {
                 read_token_from_stdin()?

--- a/crates/flowplane/src/cli/output.rs
+++ b/crates/flowplane/src/cli/output.rs
@@ -283,15 +283,121 @@ fn project_one(value: &Value, fields: &[String]) -> Value {
     }
 }
 
+/// Authoritative envelope `kind` for a response (CLI-R-15 / invariant 13). This is the single
+/// source of truth the renderer uses — NOT free URL inference. Non-collection / action
+/// endpoints (whose path tail is not a `{collection}/{id}` pair) get an explicit kind via
+/// [`kind_override`]; every true REST collection resolves through [`derive_kind`] (corrected
+/// singularization). The kind-parity test (`cli_s7_coverage.rs`) pins every envelope-emitting
+/// command against this resolver so a wrong/truncated/id-shaped kind fails CI.
+pub(crate) fn resolve_kind(path: &str, value: &Value) -> String {
+    let clean = path.split(['?', '#']).next().unwrap_or(path);
+    if let Some(kind) = kind_override(clean) {
+        let is_list = value.is_array() || value.get("items").map(Value::is_array).unwrap_or(false);
+        return if is_list {
+            format!("{kind}List")
+        } else {
+            kind.to_string()
+        };
+    }
+    derive_kind(clean, value)
+}
+
+/// Authoritative kind for endpoints whose path tail is an *action* (a mutation sub-route) or a
+/// *singleton view* rather than a `{collection}/{id}` pair — where singularizing the trailing
+/// path segment yields a wrong/truncated kind (`mcp/status` → `statu`) or the resource name
+/// (`expose/{name}` → `local`). Ordered; first match wins. Returns the singular base kind (the
+/// caller appends `List` for list payloads). Everything not matched here is a true REST
+/// collection resolved by [`derive_kind`]; the parity test forbids a wrong kind for any endpoint.
+fn kind_override(path: &str) -> Option<&'static str> {
+    // Mutation actions: a body-returning DELETE/POST/PATCH sub-route (or expose/unexpose) is a
+    // mutation, not a resource read — it carries the stable `mutationResult` kind (matches the
+    // body-less mutation path in client.rs).
+    const ACTION_TAILS: &[&str] = &[
+        "/expose",
+        "/rotate",
+        "/stop",
+        "/disable",
+        "/enable",
+        "/revoke",
+        "/reject",
+        "/publish",
+        "/apply",
+        "/force-repush",
+        "/rotate-token",
+    ];
+    if path.contains("/expose/") || ACTION_TAILS.iter().any(|t| path.ends_with(t)) {
+        return Some("mutationResult");
+    }
+    // Singleton / aggregate GET views (would mis-singularize to `statu`, `stat`, `op`, or the
+    // governing collection).
+    if path.ends_with("/mcp/status") {
+        return Some("mcpStatus");
+    }
+    if path.ends_with("/xds/status") {
+        return Some("xdsStatus");
+    }
+    if path.ends_with("/stats/overview") {
+        return Some("statsOverview");
+    }
+    if path.ends_with("/ops/trace") {
+        return Some("trace");
+    }
+    if path.ends_with("/envoy-config") {
+        return Some("envoyConfig");
+    }
+    if path.ends_with("/telemetry") {
+        return Some("dataplaneTelemetry");
+    }
+    if path.ends_with("/override") {
+        return Some("rateLimitOverride");
+    }
+    // `…/api-definitions/{name}/status` only (mcp/xds status tails handled above); scoped so a
+    // future singleton `…/status` endpoint cannot silently inherit this kind.
+    if path.contains("/api-definitions/") && path.ends_with("/status") {
+        return Some("apiDefinitionStatus");
+    }
+    None
+}
+
 /// Derive a stable envelope `kind` from the REST path and response shape (CLI-R-15).
 /// Singular for an object (`cluster`), `…List` for a collection (`clusterList`).
 ///
-/// Any `?query` is stripped first. For a list the collection is the trailing path segment.
-/// For an object the noun is the nearest-to-the-end *plural* segment (the governing
-/// collection) — so item reads (`…/clusters/{name}`), creates (`POST …/clusters`), and
-/// action sub-routes (`POST …/clusters/{name}/rotate`) all resolve to `cluster` rather than
-/// to an id or a verb. If no plural segment exists the trailing segment is used as-is.
+/// The governing collection is chosen from an **explicit known-collection set** (not by guessing
+/// which path segment "looks plural") — so an item read resolves to its resource (`…/clusters/x`
+/// → `cluster`) even when the id itself looks plural (`…/clusters/aliases` is still `cluster`,
+/// not `aliase`). `?query` is stripped first; lists get the `List` suffix. An unmapped path falls
+/// back to the trailing segment — the parity test forbids that for known endpoints.
 pub(crate) fn derive_kind(path: &str, value: &Value) -> String {
+    // Explicit REST collection segments the CLI addresses. The kind is the singular of the
+    // nearest-to-end entry found here, so dynamic ids (which are never in this set) are skipped.
+    const COLLECTIONS: &[&str] = &[
+        "clusters",
+        "listeners",
+        "route-configs",
+        "route-generation-plans",
+        "secrets",
+        "api-definitions",
+        "specs",
+        "spec-versions",
+        "spec-version",
+        "providers",
+        "routes",
+        "budgets",
+        "rate-limit-domains",
+        "policies",
+        "connections",
+        "tools",
+        "dataplanes",
+        "proxy-certificates",
+        "learning-sessions",
+        "learning-discovery-sessions",
+        "orgs",
+        "teams",
+        "members",
+        "grants",
+        "agents",
+        "nacks",
+    ];
     let path = path.split(['?', '#']).next().unwrap_or(path);
     let mut segments: Vec<&str> = path
         .split('/')
@@ -304,28 +410,32 @@ pub(crate) fn derive_kind(path: &str, value: &Value) -> String {
         segments.drain(0..2);
     }
     let is_list = value.is_array() || value.get("items").map(Value::is_array).unwrap_or(false);
+    // Nearest-to-end KNOWN collection; else the trailing segment (forbidden for known endpoints
+    // by the parity test).
+    let noun = segments
+        .iter()
+        .rev()
+        .find(|s| COLLECTIONS.contains(s))
+        .or_else(|| segments.last())
+        .copied()
+        .unwrap_or("result");
+    let base = singularize(noun);
     if is_list {
-        let noun = segments.last().copied().unwrap_or("result");
-        return format!("{}List", singularize(noun));
+        format!("{base}List")
+    } else {
+        base
     }
-    // Object: prefer the nearest-to-end plural (collection) segment; else the trailing segment.
-    let mut noun = segments.last().copied().unwrap_or("result");
-    for seg in segments.iter().rev() {
-        if singularize(seg).as_str() != *seg {
-            noun = *seg;
-            break;
-        }
-    }
-    singularize(noun)
 }
 
 /// Convert a plural resource segment to a camelCase singular kind (`route-configs` →
-/// `routeConfig`, `policies` → `policy`).
+/// `routeConfig`, `policies` → `policy`). Non-plural words ending in `s` (`status`, `ss`,
+/// `us`) are left intact so `status` does not become `statu` (Obs-2 / fpv2-86m.1).
 fn singularize(segment: &str) -> String {
     let camel = to_lower_camel(segment);
     if let Some(stem) = camel.strip_suffix("ies") {
         format!("{stem}y")
-    } else if camel.ends_with("ss") {
+    } else if camel.ends_with("ss") || camel.ends_with("us") {
+        // `status`, `bonus`, `…ss` collections are not plurals — never truncate them.
         camel
     } else if let Some(stem) = camel.strip_suffix('s') {
         stem.to_string()
@@ -994,6 +1104,153 @@ mod tests {
             derive_kind("/api/v1/teams/p/secrets/s1/rotate", &obj),
             "secret"
         );
+    }
+
+    #[test]
+    fn singularize_does_not_truncate_non_plurals() {
+        // `status` is not a plural — must not become `statu` (Obs-2).
+        assert_eq!(singularize("status"), "status");
+        // genuine plurals still singularize.
+        assert_eq!(singularize("clusters"), "cluster");
+        assert_eq!(singularize("policies"), "policy");
+        assert_eq!(singularize("route-configs"), "routeConfig");
+        // `…ss` words are left intact.
+        assert_eq!(singularize("address"), "address");
+    }
+
+    #[test]
+    fn resolve_kind_fixes_status_expose_and_singleton_views() {
+        let obj = serde_json::json!({ "ok": true });
+        let arr = serde_json::json!([{ "x": 1 }]);
+        // status views never truncate to `statu`.
+        assert_eq!(
+            resolve_kind("/api/v1/teams/p/mcp/status", &obj),
+            "mcpStatus"
+        );
+        assert_eq!(
+            resolve_kind("/api/v1/teams/p/xds/status", &obj),
+            "xdsStatus"
+        );
+        assert_eq!(
+            resolve_kind("/api/v1/teams/p/api-definitions/d1/status", &obj),
+            "apiDefinitionStatus"
+        );
+        // unexpose returns a body — a mutation action, never the resource name.
+        assert_eq!(
+            resolve_kind("/api/v1/teams/p/expose/local", &obj),
+            "mutationResult"
+        );
+        assert_eq!(
+            resolve_kind("/api/v1/teams/p/expose", &obj),
+            "mutationResult"
+        );
+        // other body-returning mutation actions are mutationResult too.
+        assert_eq!(
+            resolve_kind("/api/v1/teams/p/secrets/s1/rotate", &obj),
+            "mutationResult"
+        );
+        assert_eq!(
+            resolve_kind("/api/v1/teams/p/api-definitions/d1/specs/3/publish", &obj),
+            "mutationResult"
+        );
+        // singleton views get a stable kind, not a mis-singularized path tail.
+        assert_eq!(
+            resolve_kind("/api/v1/teams/p/stats/overview", &obj),
+            "statsOverview"
+        );
+        assert_eq!(resolve_kind("/api/v1/teams/p/ops/trace", &obj), "trace");
+        // ai/usage is already a clean singular — no override, no truncation.
+        assert_eq!(
+            resolve_kind("/api/v1/teams/p/ai/usage?from=x", &obj),
+            "usage"
+        );
+        // true collections still resolve correctly through the resolver.
+        assert_eq!(
+            resolve_kind("/api/v1/teams/p/clusters", &arr),
+            "clusterList"
+        );
+        assert_eq!(resolve_kind("/api/v1/teams/p/clusters/c1", &obj), "cluster");
+    }
+
+    #[test]
+    fn resolve_kind_parity_across_every_cli_endpoint() {
+        // Exhaustive contract pin (invariant 13). EVERY REST endpoint the CLI calls is checked:
+        // an INVARIANT pass asserts no endpoint yields a malformed/truncated/id-shaped kind, and
+        // an EXACT pass pins the authoritative value for the confident set (collections,
+        // singleton views, mutation actions, and the previously-broken endpoints). A new endpoint
+        // added without a kind decision will surface here as a malformed/loose kind.
+        let obj = serde_json::json!({ "name": "x" });
+
+        // INVARIANT pass — exhaustive and drift-proof: iterate the *canonical* CLI endpoint
+        // registry (`cli_endpoint_templates`), so a new endpoint is automatically checked here.
+        // Every endpoint must yield a well-formed lowerCamel kind (no hyphen/slash/`statu`/id).
+        for path in crate::cli::cli_endpoint_templates() {
+            let got = resolve_kind(path, &obj);
+            let base = got.strip_suffix("List").unwrap_or(&got);
+            assert!(
+                !base.is_empty()
+                    && base.chars().next().unwrap().is_ascii_lowercase()
+                    && base.chars().all(|c| c.is_ascii_alphanumeric()),
+                "kind {got:?} for {path} is malformed (not lowerCamel, or hyphen/slash/id-shaped)"
+            );
+            assert_ne!(got, "statu", "{path} truncated to statu");
+        }
+
+        // Exact authoritative values for the confident set.
+        let exact: &[(&str, &str)] = &[
+            ("/api/v1/teams/p/clusters/c1", "cluster"),
+            ("/api/v1/teams/p/listeners/l1", "listener"),
+            ("/api/v1/teams/p/route-configs/r1", "routeConfig"),
+            ("/api/v1/teams/p/secrets/s1", "secret"),
+            ("/api/v1/teams/p/api-definitions/a1", "apiDefinition"),
+            ("/api/v1/teams/p/dataplanes/d1", "dataplane"),
+            ("/api/v1/teams/p/rate-limit-domains/d", "rateLimitDomain"),
+            ("/api/v1/orgs/acme", "org"),
+            ("/api/v1/teams/t1", "team"),
+            ("/api/v1/teams/t1/grants/g", "grant"),
+            ("/api/v1/auth/whoami", "whoami"),
+            // singleton views
+            ("/api/v1/teams/p/mcp/status", "mcpStatus"),
+            ("/api/v1/teams/p/xds/status", "xdsStatus"),
+            (
+                "/api/v1/teams/p/api-definitions/a1/status",
+                "apiDefinitionStatus",
+            ),
+            ("/api/v1/teams/p/stats/overview", "statsOverview"),
+            ("/api/v1/teams/p/ops/trace", "trace"),
+            ("/api/v1/teams/p/ai/usage", "usage"),
+            ("/api/v1/teams/p/dataplanes/d1/envoy-config", "envoyConfig"),
+            (
+                "/api/v1/teams/p/dataplanes/d1/telemetry",
+                "dataplaneTelemetry",
+            ),
+            (
+                "/api/v1/teams/p/rate-limit-domains/d/policies/x/override",
+                "rateLimitOverride",
+            ),
+            // mutation actions
+            ("/api/v1/teams/p/expose", "mutationResult"),
+            ("/api/v1/teams/p/expose/local", "mutationResult"),
+            ("/api/v1/teams/p/secrets/s1/rotate", "mutationResult"),
+            (
+                "/api/v1/teams/p/api-definitions/a1/specs/3/publish",
+                "mutationResult",
+            ),
+            (
+                "/api/v1/teams/p/proxy-certificates/sn/revoke",
+                "mutationResult",
+            ),
+            ("/api/v1/admin/rls/force-repush", "mutationResult"),
+            ("/api/v1/teams/p/learning-sessions/s/stop", "mutationResult"),
+            // spec-version sub-resources resolve to the spec version, not the parent session.
+            (
+                "/api/v1/teams/p/learning-sessions/sess/spec-version",
+                "specVersion",
+            ),
+        ];
+        for (path, expected) in exact {
+            assert_eq!(&resolve_kind(path, &obj), expected, "kind for {path}");
+        }
     }
 
     #[test]

--- a/crates/flowplane/src/main.rs
+++ b/crates/flowplane/src/main.rs
@@ -135,7 +135,10 @@ enum Command {
         command: cli::ApplyCommand,
     },
     /// Shell completion script.
-    Completion { shell: Shell },
+    Completion {
+        /// Shell to generate the completion script for (bash, zsh, fish, …).
+        shell: Shell,
+    },
     /// Print version.
     Version,
     /// Print the machine-readable CLI schema (the canonical CLI contract; the MCP-derivation seam).

--- a/crates/flowplane/src/main.rs
+++ b/crates/flowplane/src/main.rs
@@ -110,11 +110,15 @@ enum Command {
         command: cli::DataplaneCommand,
     },
     /// Expose an upstream through Envoy with cluster + route + listener resources.
+    #[command(
+        after_help = "Example:\n  flowplane expose 10.0.0.5:8080 --name payments-api --team payments"
+    )]
     Expose {
         #[command(flatten)]
         command: cli::ExposeCommand,
     },
     /// Remove resources created by `expose`.
+    #[command(after_help = "Example:\n  flowplane unexpose payments-api --team payments")]
     Unexpose {
         #[command(flatten)]
         command: cli::UnexposeCommand,
@@ -130,6 +134,7 @@ enum Command {
         command: cli::OpsCommand,
     },
     /// Apply a declarative JSON resource manifest.
+    #[command(after_help = "Example:\n  flowplane apply -f gateway.json --diff")]
     Apply {
         #[command(flatten)]
         command: cli::ApplyCommand,
@@ -484,5 +489,255 @@ mod tests {
         assert!(help.contains("flowplane config set-context prod"));
         assert!(help.contains("flowplane api create catalog"));
         assert!(help.contains("flowplane apply -f gateway.json --diff"));
+    }
+
+    #[test]
+    fn chk_help_examples_parse() {
+        // `chk:help-examples-parse` lint for CLI-R-06: every top-level + spine workflow command's
+        // --help carries >=1 copy-pasteable `flowplane ...` example, and every extracted example
+        // line PARSES via Cli::try_parse_from. Coverage is frozen and union-guarded: every leaf is
+        // classified SPINE (must carry an example) or EXEMPT (none required); the two sets are
+        // disjoint and their union must equal the live leaf set EXACTLY, so a new/removed command
+        // fails CI until it is classified. EXEMPT leaves are intentionally NOT required to carry an
+        // example — they are readers (get/list/status), single-target mutators (delete), and
+        // utilities (completion/version/serve/db migrate/openapi/schema/...) whose usage is obvious
+        // from `--help`. The union guard forces every FUTURE leaf to be classified one way or the
+        // other. Pure in-process (no temp dir / network) so it is inherently parallel-safe.
+
+        // 44 SPINE leaves (space-joined paths) — each must expose a parseable example.
+        const SPINE: &[&str] = &[
+            "auth login",
+            "config set-context",
+            "org create",
+            "org member add",
+            "team create",
+            "team member add",
+            "team grant add",
+            "cluster create",
+            "cluster update",
+            "listener create",
+            "listener update",
+            "route create",
+            "route update",
+            "route generate",
+            "api create",
+            "api spec reject",
+            "api spec publish",
+            "mcp enable",
+            "mcp disable",
+            "ai providers create",
+            "ai providers update",
+            "ai routes create",
+            "ai routes update",
+            "ai budgets create",
+            "ai budgets update",
+            "rate-limit domain create",
+            "rate-limit domain update",
+            "rate-limit policy create",
+            "rate-limit policy update",
+            "rate-limit override set",
+            "rate-limit override update",
+            "learn start",
+            "learn discover start",
+            "secret create",
+            "secret rotate",
+            "dataplane create",
+            "dataplane telemetry",
+            "dataplane bootstrap",
+            "dataplane cert register",
+            "dataplane cert issue",
+            "dataplane cert revoke",
+            "expose",
+            "unexpose",
+            "apply",
+        ];
+
+        // 77 EXEMPT leaves (space-joined paths) — no example required.
+        const EXEMPT: &[&str] = &[
+            "ai budgets delete",
+            "ai budgets get",
+            "ai budgets list",
+            "ai providers delete",
+            "ai providers get",
+            "ai providers list",
+            "ai routes delete",
+            "ai routes get",
+            "ai routes list",
+            "ai usage",
+            "api delete",
+            "api get",
+            "api list",
+            "api status",
+            "auth logout",
+            "auth token",
+            "auth whoami",
+            "cluster delete",
+            "cluster get",
+            "cluster list",
+            "completion",
+            "config get-contexts",
+            "config path",
+            "config show",
+            "config use-context",
+            "dataplane cert list",
+            "dataplane get",
+            "dataplane list",
+            "db migrate",
+            "learn cancel",
+            "learn discover generate-spec",
+            "learn discover list",
+            "learn discover status",
+            "learn discover stop",
+            "learn generate-spec",
+            "learn get",
+            "learn list",
+            "learn stop",
+            "listener delete",
+            "listener get",
+            "listener list",
+            "mcp connections",
+            "mcp status",
+            "openapi",
+            "ops trace",
+            "ops xds nacks",
+            "ops xds status",
+            "org delete",
+            "org get",
+            "org list",
+            "org member list",
+            "org member remove",
+            "rate-limit domain delete",
+            "rate-limit domain get",
+            "rate-limit domain list",
+            "rate-limit force-repush",
+            "rate-limit override delete",
+            "rate-limit override get",
+            "rate-limit policy delete",
+            "rate-limit policy get",
+            "rate-limit policy list",
+            "route apply",
+            "route delete",
+            "route get",
+            "route list",
+            "schema",
+            "secret get",
+            "secret list",
+            "serve",
+            "stats overview",
+            "team delete",
+            "team grant list",
+            "team grant remove",
+            "team list",
+            "team member list",
+            "team member remove",
+            "version",
+        ];
+
+        use std::collections::BTreeSet;
+
+        // Build the LIVE leaf set by recursively walking Cli::command() (EXCLUDING the root).
+        fn collect_leaves(cmd: &clap::Command, prefix: &str, out: &mut BTreeSet<String>) {
+            for sub in cmd.get_subcommands() {
+                let path = if prefix.is_empty() {
+                    sub.get_name().to_string()
+                } else {
+                    format!("{prefix} {}", sub.get_name())
+                };
+                if sub.get_subcommands().next().is_none() {
+                    out.insert(path);
+                } else {
+                    collect_leaves(sub, &path, out);
+                }
+            }
+        }
+
+        let root = Cli::command();
+        let mut live: BTreeSet<String> = BTreeSet::new();
+        collect_leaves(&root, "", &mut live);
+
+        let mut offenders: Vec<String> = Vec::new();
+
+        // --- Step 2: union guard — disjoint, and (SPINE ∪ EXEMPT) == live EXACTLY. -----------
+        let mut classified: BTreeSet<String> = BTreeSet::new();
+        for (label, list) in [("SPINE", SPINE), ("EXEMPT", EXEMPT)] {
+            for &leaf in list {
+                if !classified.insert(leaf.to_string()) {
+                    offenders.push(format!(
+                        "leaf `{leaf}` classified more than once (found again in {label}); \
+                         SPINE and EXEMPT must be disjoint"
+                    ));
+                }
+            }
+        }
+        let missing_from_classification: Vec<&String> = live.difference(&classified).collect();
+        let stale_in_lists: Vec<&String> = classified.difference(&live).collect();
+        for leaf in &missing_from_classification {
+            offenders.push(format!(
+                "leaf `{leaf}` is live but NOT classified — add it to SPINE or EXEMPT"
+            ));
+        }
+        for leaf in &stale_in_lists {
+            offenders.push(format!(
+                "leaf `{leaf}` is classified but NO LONGER live — remove it from SPINE/EXEMPT"
+            ));
+        }
+
+        // --- Step 3: every SPINE leaf exposes >=1 parseable `flowplane ...` example. ---------
+        for &leaf in SPINE {
+            // Navigate from the root via find_subcommand for each path segment.
+            let mut node = &root;
+            let mut resolved = true;
+            for seg in leaf.split_whitespace() {
+                match node.find_subcommand(seg) {
+                    Some(child) => node = child,
+                    None => {
+                        offenders.push(format!(
+                            "{leaf}: path does not resolve in the clap tree (segment `{seg}`)"
+                        ));
+                        resolved = false;
+                        break;
+                    }
+                }
+            }
+            if !resolved {
+                continue;
+            }
+
+            let after = node
+                .get_after_help()
+                .map(|s| s.to_string())
+                .unwrap_or_default();
+            let examples: Vec<&str> = after
+                .lines()
+                .filter(|line| line.trim_start().starts_with("flowplane"))
+                .collect();
+
+            if examples.is_empty() {
+                offenders.push(format!("{leaf}: no flowplane example in after_help"));
+                continue;
+            }
+
+            for line in examples {
+                let tokens: Vec<&str> = line.split_whitespace().collect();
+                if let Err(err) = Cli::try_parse_from(tokens) {
+                    offenders.push(format!(
+                        "{leaf}: example did not parse: {} ({:?})",
+                        line.trim(),
+                        err.kind()
+                    ));
+                }
+            }
+        }
+
+        // --- Step 4: collect ALL offenders, then assert empty with a naming message. ---------
+        assert!(
+            offenders.is_empty(),
+            "chk:help-examples-parse (CLI-R-06) found {} violation(s):\n  - {}\n\
+             \n  live leaf count = {}, classified leaf count = {}",
+            offenders.len(),
+            offenders.join("\n  - "),
+            live.len(),
+            classified.len(),
+        );
     }
 }

--- a/crates/flowplane/src/main.rs
+++ b/crates/flowplane/src/main.rs
@@ -3,7 +3,7 @@
 mod cli;
 mod serve;
 
-use clap::{CommandFactory, Parser, Subcommand};
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use clap_complete::Shell;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -170,7 +170,27 @@ fn main() {
 }
 
 fn run() -> anyhow::Result<()> {
-    let cli = Cli::parse();
+    // Capture the raw ArgMatches so we can ask clap whether `--token` was passed
+    // explicitly on the command line for `auth login`, as opposed to inherited from the
+    // ambient FLOWPLANE_TOKEN via the global `--token` flag (Fix 3 / F-2). `Cli::parse()`
+    // would discard the value-source we need.
+    let matches = Cli::command().get_matches();
+    let cli = match Cli::from_arg_matches(&matches) {
+        Ok(cli) => cli,
+        Err(err) => err.exit(),
+    };
+    // Only an explicit `--token <v>` (ValueSource::CommandLine) counts as a login input;
+    // an env-sourced token must not conflict with `--token-stdin`/`--device`/`--pkce`.
+    let auth_login_token_explicit = matches
+        .subcommand_matches("auth")
+        .and_then(|auth| auth.subcommand_matches("login"))
+        .map(|login| {
+            matches!(
+                login.value_source("token"),
+                Some(clap::parser::ValueSource::CommandLine)
+            )
+        })
+        .unwrap_or(false);
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
@@ -188,7 +208,11 @@ fn run() -> anyhow::Result<()> {
             );
             Ok(())
         }
-        Command::Auth { command } => runtime.block_on(cli::run_auth(cli.client, command)),
+        Command::Auth { command } => runtime.block_on(cli::run_auth(
+            cli.client,
+            command,
+            auth_login_token_explicit,
+        )),
         Command::Config { command } => cli::run_config(cli.client, command),
         Command::Org { command } => runtime.block_on(cli::run_org(cli.client, command)),
         Command::Team { command } => runtime.block_on(cli::run_team(cli.client, command)),
@@ -241,6 +265,66 @@ mod tests {
     #[test]
     fn command_tree_builds() {
         Cli::command().debug_assert();
+    }
+
+    /// Mirror of `run`'s detection: was `--token` passed explicitly on the command line for
+    /// `auth login` (vs. inherited from the ambient FLOWPLANE_TOKEN via the global flag)?
+    /// Fix 3 / F-2. Env-sourced detection is process-global and is covered by the black-box
+    /// integration matrix instead.
+    fn login_token_is_explicit(argv: &[&str]) -> bool {
+        let matches = Cli::command()
+            .try_get_matches_from(argv)
+            .expect("argv parses without env");
+        matches
+            .subcommand_matches("auth")
+            .and_then(|auth| auth.subcommand_matches("login"))
+            .map(|login| {
+                matches!(
+                    login.value_source("token"),
+                    Some(clap::parser::ValueSource::CommandLine)
+                )
+            })
+            .unwrap_or(false)
+    }
+
+    #[test]
+    fn explicit_token_flag_is_detected_as_command_line() {
+        assert!(login_token_is_explicit(&[
+            "flowplane",
+            "auth",
+            "login",
+            "--token",
+            "v"
+        ]));
+    }
+
+    #[test]
+    fn token_stdin_alone_is_not_an_explicit_token() {
+        assert!(!login_token_is_explicit(&[
+            "flowplane",
+            "auth",
+            "login",
+            "--token-stdin"
+        ]));
+    }
+
+    #[test]
+    fn device_flag_alone_is_not_an_explicit_token() {
+        assert!(!login_token_is_explicit(&[
+            "flowplane",
+            "auth",
+            "login",
+            "--device",
+            "--issuer",
+            "https://issuer.example",
+            "--client-id",
+            "x",
+        ]));
+    }
+
+    #[test]
+    fn bare_login_is_not_an_explicit_token() {
+        assert!(!login_token_is_explicit(&["flowplane", "auth", "login"]));
     }
 
     #[test]

--- a/crates/flowplane/src/serve.rs
+++ b/crates/flowplane/src/serve.rs
@@ -420,7 +420,10 @@ async fn setup_dev_mode(
     let token = issuer.mint_dev_user()?;
     // Dev-only by triple gate: the token grants access to the seeded local instance only
     // and dies with this process (per-boot key).
-    tracing::warn!(dev_token = %token, "dev bearer token (valid 1h, this boot only)");
+    tracing::warn!(
+        dev_token = %token,
+        "dev bearer token (default 24h, set FLOWPLANE_DEV_TOKEN_TTL to change; this boot only)"
+    );
     // Dev-only file sink (#156): a compose `init`/sibling container can't read another
     // container's stdout, so when an operator names a path we also write the raw token there.
     if let Some(path) = dev_token_path {

--- a/crates/flowplane/tests/cli_s1_envelope_kind.rs
+++ b/crates/flowplane/tests/cli_s1_envelope_kind.rs
@@ -1,0 +1,150 @@
+//! S1 — `-o json` envelope `kind` correctness (black-box).
+//!
+//! These tests drive the *built* `flowplane` binary as a subprocess and assert only against the
+//! documented success-envelope contract (`{schemaVersion, kind, data}`, CLI-R-15). They never
+//! look at CLI internals: every assertion is derived from the acceptance criteria, not the
+//! implementation.
+//!
+//! Contract under test (bead fpv2-86m.1): the envelope `kind` must be a correct, non-truncated,
+//! non-id value. Two endpoints were previously wrong and are now fixed:
+//!   * `mcp status` returned `kind:"statu"` (a truncated "status"); it MUST now be `"mcpStatus"`.
+//!   * `unexpose <name>` returned `kind:"<the resource name>"` (e.g. `"local"`); it MUST now be
+//!     `"mutationResult"` (a mutation action).
+//!
+//! Control (known-good): `cluster list -o json` → `kind:"clusterList"`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod common;
+
+use std::process::Output;
+
+use serde_json::Value;
+
+fn exit_code(out: &Output) -> i32 {
+    out.status
+        .code()
+        .unwrap_or_else(|| panic!("process terminated without an exit code (killed by signal?)"))
+}
+
+/// Parse stdout as the `{schemaVersion, kind, data}` success envelope, asserting exit 0 and that
+/// nothing leaked onto stderr.
+fn parse_success_envelope(out: &Output, ctx: &str) -> Value {
+    assert_eq!(
+        exit_code(out),
+        0,
+        "{ctx}: expected exit 0, got {:?}\nstdout: {}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        out.stderr.is_empty(),
+        "{ctx}: nothing must leak to stderr on success, got: {:?}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let v: Value = serde_json::from_slice(&out.stdout).unwrap_or_else(|e| {
+        panic!(
+            "{ctx}: stdout is not a JSON success envelope ({e}): {:?}",
+            String::from_utf8_lossy(&out.stdout)
+        )
+    });
+    let obj = v
+        .as_object()
+        .unwrap_or_else(|| panic!("{ctx}: envelope is not a JSON object: {v}"));
+    for k in ["schemaVersion", "kind", "data"] {
+        assert!(
+            obj.contains_key(k),
+            "{ctx}: envelope missing key `{k}`: {v}"
+        );
+    }
+    assert!(
+        obj["kind"].is_string(),
+        "{ctx}: kind must be a string, got {}",
+        obj["kind"]
+    );
+    v
+}
+
+// ---------------------------------------------------------------------------------------------
+// `mcp status -o json` → kind MUST be "mcpStatus" (and explicitly NOT the old truncated "statu").
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mcp_status_kind_is_mcp_status_not_truncated() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args(["mcp", "status", "--team", "payments", "-o", "json"])
+        .output()
+        .expect("run mcp status -o json");
+
+    let v = parse_success_envelope(&out, "mcp status -o json");
+    let kind = v["kind"].as_str().unwrap();
+    assert_ne!(
+        kind, "statu",
+        "regression: mcp status kind must not be the truncated \"statu\": {v}"
+    );
+    assert_eq!(
+        kind, "mcpStatus",
+        "mcp status -o json envelope kind must be \"mcpStatus\": {v}"
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// `unexpose <name> -o json` → kind MUST be "mutationResult" (and explicitly NOT the resource
+// name, which is the bug it previously echoed). `unexpose` is destructive → pass `--yes`
+// (subprocess stdin is non-TTY, else the confirm prompt exits 2). `<NAME>` is a positional.
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unexpose_kind_is_mutation_result_not_resource_name() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+
+    // A distinctive name so "kind must not equal the name" is a meaningful assertion.
+    let name = "local";
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args([
+            "unexpose", name, "--team", "payments", "--yes", "-o", "json",
+        ])
+        .output()
+        .expect("run unexpose <name> -o json");
+
+    let v = parse_success_envelope(&out, "unexpose local -o json");
+    let kind = v["kind"].as_str().unwrap();
+    assert_ne!(
+        kind, name,
+        "regression: unexpose kind must not echo the resource name \"{name}\": {v}"
+    );
+    // unexpose is a destructive mutation action → the stable `mutationResult` kind.
+    assert_eq!(
+        kind, "mutationResult",
+        "unexpose -o json envelope kind must be \"mutationResult\": {v}"
+    );
+}
+
+// ---------------------------------------------------------------------------------------------
+// Control: a known-good envelope kind — `cluster list -o json` → "clusterList".
+// ---------------------------------------------------------------------------------------------
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cluster_list_kind_is_cluster_list_control() {
+    let mock = common::start_mock().await;
+    let home = common::unique_tempdir();
+
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", mock.base_url())
+        .env("FLOWPLANE_TOKEN", "t")
+        .args(["cluster", "list", "--team", "payments", "-o", "json"])
+        .output()
+        .expect("run cluster list -o json");
+
+    let v = parse_success_envelope(&out, "cluster list -o json");
+    assert_eq!(
+        v["kind"], "clusterList",
+        "control: cluster list -o json envelope kind must be \"clusterList\": {v}"
+    );
+}

--- a/crates/flowplane/tests/cli_s2_error_model.rs
+++ b/crates/flowplane/tests/cli_s2_error_model.rs
@@ -13,7 +13,7 @@
 //!     404 and 400/validation → false.
 //!   * Auth hint (CLI-R-33): a 401 with no server `hint` still yields a `hint` mentioning
 //!     `flowplane auth login`; a 403 server `hint` naming resource/action survives.
-//!   * Exit-code table (CLI-R-31), full 0–7 range: 0 ok, 2 clap usage, 3 auth (401/403),
+//!   * Exit-code table (CLI-R-31), full 0–7 range: 0 ok, 2 usage/preflight, 3 auth (401/403),
 //!     4 not-found/conflict (404), 5 validation (400), 6 rate-limited (429),
 //!     7 server error (503) and transport/connection-refused.
 

--- a/crates/flowplane/tests/cli_s3_auth_login_token_source.rs
+++ b/crates/flowplane/tests/cli_s3_auth_login_token_source.rs
@@ -11,7 +11,7 @@
 //!     `--pkce`.
 //!   * `auth login` login methods (`--token <v>`, `--token-stdin`, `--device`/`--device-code`,
 //!     `--pkce`) are mutually exclusive. More than one explicit method →
-//!     `use only one login input: --token, --token-stdin, --device-code, or --pkce` (exit 1).
+//!     `use only one login input: --token, --token-stdin, --device-code, or --pkce` (exit 2).
 //!   * No method chosen and nothing available →
 //!     `pass --token, --token-stdin, --device-code, or configure OIDC for PKCE` (exit 1).
 //!   * On success the bearer token is written to the credentials file (path echoed as
@@ -113,7 +113,7 @@ fn env_unset_token_stdin_saves_stdin_value() {
     assert_eq!(saved_token(&out, "row2"), "stdin-tok-2");
 }
 
-// 3. env SET + explicit --token <v> + --token-stdin → exit 1; conflict. [explicit token conflicts]
+// 3. env SET + explicit --token <v> + --token-stdin → exit 2; conflict. [explicit token conflicts]
 #[test]
 fn env_set_explicit_token_and_stdin_conflicts() {
     let home = common::unique_tempdir();
@@ -124,7 +124,7 @@ fn env_set_explicit_token_and_stdin_conflicts() {
         Some("stdin-tok-3"),
     );
     assert!(!out.status.success(), "row3: must fail");
-    assert_eq!(out.status.code(), Some(1), "row3: exit code");
+    assert_eq!(out.status.code(), Some(2), "row3: exit code");
     let err = stderr_of(&out);
     assert!(
         err.contains(CONFLICT_MSG),
@@ -132,7 +132,7 @@ fn env_set_explicit_token_and_stdin_conflicts() {
     );
 }
 
-// 4. env UNSET + explicit --token <v> + --token-stdin → exit 1; conflict.
+// 4. env UNSET + explicit --token <v> + --token-stdin → exit 2; conflict.
 #[test]
 fn env_unset_explicit_token_and_stdin_conflicts() {
     let home = common::unique_tempdir();
@@ -143,7 +143,7 @@ fn env_unset_explicit_token_and_stdin_conflicts() {
         Some("stdin-tok-4"),
     );
     assert!(!out.status.success(), "row4: must fail");
-    assert_eq!(out.status.code(), Some(1), "row4: exit code");
+    assert_eq!(out.status.code(), Some(2), "row4: exit code");
     let err = stderr_of(&out);
     assert!(
         err.contains(CONFLICT_MSG),
@@ -240,7 +240,7 @@ fn env_set_pkce_attempts_network_not_conflict() {
     );
 }
 
-// 11. --device --pkce (env unset) → exit 1; conflict. [two real methods conflict]
+// 11. --device --pkce (env unset) → exit 2; conflict. [two real methods conflict]
 #[test]
 fn device_and_pkce_conflicts() {
     let home = common::unique_tempdir();
@@ -258,7 +258,7 @@ fn device_and_pkce_conflicts() {
         None,
     );
     assert!(!out.status.success(), "row11: must fail");
-    assert_eq!(out.status.code(), Some(1), "row11: exit code");
+    assert_eq!(out.status.code(), Some(2), "row11: exit code");
     let err = stderr_of(&out);
     assert!(
         err.contains(CONFLICT_MSG),
@@ -266,7 +266,7 @@ fn device_and_pkce_conflicts() {
     );
 }
 
-// 12. env SET + explicit --token v + --device → exit 1; conflict.
+// 12. env SET + explicit --token v + --device → exit 2; conflict.
 #[test]
 fn env_set_explicit_token_and_device_conflicts() {
     let home = common::unique_tempdir();
@@ -285,7 +285,7 @@ fn env_set_explicit_token_and_device_conflicts() {
         None,
     );
     assert!(!out.status.success(), "row12: must fail");
-    assert_eq!(out.status.code(), Some(1), "row12: exit code");
+    assert_eq!(out.status.code(), Some(2), "row12: exit code");
     let err = stderr_of(&out);
     assert!(
         err.contains(CONFLICT_MSG),

--- a/crates/flowplane/tests/cli_s3_auth_login_token_source.rs
+++ b/crates/flowplane/tests/cli_s3_auth_login_token_source.rs
@@ -1,0 +1,294 @@
+//! S3 — `auth login` credential-input precedence (black-box).
+//!
+//! These tests drive the *built* `flowplane` binary as a subprocess and assert only against the
+//! documented behavior contract for `auth login` (GH #193 F-2 / "Fix 3"). They never look at CLI
+//! internals: every assertion is derived from the acceptance matrix, not the implementation.
+//!
+//! Contract under test:
+//!   * The GLOBAL `--token` flag is bound to env `FLOWPLANE_TOKEN`, but an AMBIENT
+//!     `FLOWPLANE_TOKEN` in the environment MUST NOT count as an explicit login *method*. Only an
+//!     explicit `--token <v>` on the command line conflicts with `--token-stdin` / `--device` /
+//!     `--pkce`.
+//!   * `auth login` login methods (`--token <v>`, `--token-stdin`, `--device`/`--device-code`,
+//!     `--pkce`) are mutually exclusive. More than one explicit method →
+//!     `use only one login input: --token, --token-stdin, --device-code, or --pkce` (exit 1).
+//!   * No method chosen and nothing available →
+//!     `pass --token, --token-stdin, --device-code, or configure OIDC for PKCE` (exit 1).
+//!   * On success the bearer token is written to the credentials file (path echoed as
+//!     `token saved to <path>` on stdout) and exit is 0. The saved file content is exactly the
+//!     token string.
+//!   * An ambient `FLOWPLANE_TOKEN` with no method flags is a valid sole fallback (saved as-is).
+//!
+//! Observation technique: each case uses a UNIQUE recognizable token value per source
+//! (`flag-tok-*`, `stdin-tok-*`, `env-tok-*`) so the saved credential proves WHICH source won.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+mod common;
+
+use std::io::Write;
+use std::path::Path;
+use std::process::{Output, Stdio};
+
+const CONFLICT_MSG: &str =
+    "use only one login input: --token, --token-stdin, --device-code, or --pkce";
+const NOTHING_MSG: &str = "pass --token, --token-stdin, --device-code, or configure OIDC for PKCE";
+
+/// Parse the `token saved to <path>` line from stdout, then read+trim that file's content.
+/// Asserts exit 0. Returns the saved token string (trimmed).
+fn saved_token(out: &Output, ctx: &str) -> String {
+    assert!(
+        out.status.success(),
+        "{ctx}: auth login must exit 0, got {:?}; stderr: {:?}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let line = stdout
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("token saved to "))
+        .unwrap_or_else(|| {
+            panic!("{ctx}: stdout must contain `token saved to <path>`, got: {stdout:?}")
+        });
+    let path = line.trim();
+    let bytes =
+        std::fs::read(path).unwrap_or_else(|e| panic!("{ctx}: read saved credentials {path}: {e}"));
+    String::from_utf8_lossy(&bytes).trim().to_string()
+}
+
+fn stderr_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).to_string()
+}
+
+/// Run `auth login` with the given args, feeding `stdin_token` (if `Some`) to the child's stdin.
+/// `env_token` sets/omits the ambient `FLOWPLANE_TOKEN`.
+fn run_login(
+    home: &Path,
+    env_token: Option<&str>,
+    args: &[&str],
+    stdin_token: Option<&str>,
+) -> Output {
+    let mut cmd = common::flowplane_cmd(home);
+    cmd.arg("auth").arg("login");
+    cmd.args(args);
+    if let Some(tok) = env_token {
+        cmd.env("FLOWPLANE_TOKEN", tok);
+    }
+    match stdin_token {
+        Some(tok) => {
+            cmd.stdin(Stdio::piped());
+            cmd.stdout(Stdio::piped());
+            cmd.stderr(Stdio::piped());
+            let mut child = cmd.spawn().expect("spawn flowplane auth login");
+            child
+                .stdin
+                .take()
+                .expect("child stdin")
+                .write_all(tok.as_bytes())
+                .expect("write token to child stdin");
+            child.wait_with_output().expect("wait_with_output")
+        }
+        None => cmd.output().expect("run flowplane auth login"),
+    }
+}
+
+// 1. env SET + --token-stdin → exit 0; saved == stdin value (NOT env). [primary bug fix]
+#[test]
+fn env_set_token_stdin_saves_stdin_value() {
+    let home = common::unique_tempdir();
+    let out = run_login(
+        &home,
+        Some("env-tok-1"),
+        &["--token-stdin"],
+        Some("stdin-tok-1"),
+    );
+    assert_eq!(saved_token(&out, "row1"), "stdin-tok-1");
+}
+
+// 2. env UNSET + --token-stdin → exit 0; saved == stdin value.
+#[test]
+fn env_unset_token_stdin_saves_stdin_value() {
+    let home = common::unique_tempdir();
+    let out = run_login(&home, None, &["--token-stdin"], Some("stdin-tok-2"));
+    assert_eq!(saved_token(&out, "row2"), "stdin-tok-2");
+}
+
+// 3. env SET + explicit --token <v> + --token-stdin → exit 1; conflict. [explicit token conflicts]
+#[test]
+fn env_set_explicit_token_and_stdin_conflicts() {
+    let home = common::unique_tempdir();
+    let out = run_login(
+        &home,
+        Some("env-tok-3"),
+        &["--token", "flag-tok-3", "--token-stdin"],
+        Some("stdin-tok-3"),
+    );
+    assert!(!out.status.success(), "row3: must fail");
+    assert_eq!(out.status.code(), Some(1), "row3: exit code");
+    let err = stderr_of(&out);
+    assert!(
+        err.contains(CONFLICT_MSG),
+        "row3: stderr must contain conflict message, got: {err:?}"
+    );
+}
+
+// 4. env UNSET + explicit --token <v> + --token-stdin → exit 1; conflict.
+#[test]
+fn env_unset_explicit_token_and_stdin_conflicts() {
+    let home = common::unique_tempdir();
+    let out = run_login(
+        &home,
+        None,
+        &["--token", "flag-tok-4", "--token-stdin"],
+        Some("stdin-tok-4"),
+    );
+    assert!(!out.status.success(), "row4: must fail");
+    assert_eq!(out.status.code(), Some(1), "row4: exit code");
+    let err = stderr_of(&out);
+    assert!(
+        err.contains(CONFLICT_MSG),
+        "row4: stderr must contain conflict message, got: {err:?}"
+    );
+}
+
+// 5. env SET, NO method flags → exit 0; saved == env value. [env is a valid sole fallback]
+#[test]
+fn env_set_no_method_saves_env_value() {
+    let home = common::unique_tempdir();
+    let out = run_login(&home, Some("env-tok-5"), &[], None);
+    assert_eq!(saved_token(&out, "row5"), "env-tok-5");
+}
+
+// 6. env UNSET, NO method flags, no OIDC config → exit 1; "nothing available" message.
+#[test]
+fn env_unset_no_method_no_oidc_errors() {
+    let home = common::unique_tempdir();
+    let out = run_login(&home, None, &[], None);
+    assert!(!out.status.success(), "row6: must fail");
+    assert_eq!(out.status.code(), Some(1), "row6: exit code");
+    let err = stderr_of(&out);
+    assert!(
+        err.contains(NOTHING_MSG),
+        "row6: stderr must contain nothing-available message, got: {err:?}"
+    );
+}
+
+// 7. env UNSET + explicit --token <v> only → exit 0; saved == flag value.
+#[test]
+fn env_unset_explicit_token_only_saves_flag_value() {
+    let home = common::unique_tempdir();
+    let out = run_login(&home, None, &["--token", "flag-tok-7"], None);
+    assert_eq!(saved_token(&out, "row7"), "flag-tok-7");
+}
+
+// 8. env SET + explicit --token <v> only → exit 0; saved == flag value (flag beats env).
+#[test]
+fn env_set_explicit_token_only_saves_flag_value() {
+    let home = common::unique_tempdir();
+    let out = run_login(&home, Some("env-tok-8"), &["--token", "flag-tok-8"], None);
+    assert_eq!(saved_token(&out, "row8"), "flag-tok-8");
+}
+
+// 9. env SET + --device (unreachable OIDC) → non-zero exit; NOT a conflict error. [device path]
+#[test]
+fn env_set_device_attempts_network_not_conflict() {
+    let home = common::unique_tempdir();
+    let out = run_login(
+        &home,
+        Some("env-tok-9"),
+        &[
+            "--device",
+            "--issuer",
+            "http://127.0.0.1:1",
+            "--client-id",
+            "x",
+        ],
+        None,
+    );
+    assert!(!out.status.success(), "row9: must fail (no reachable OIDC)");
+    let err = stderr_of(&out);
+    assert!(
+        !err.contains(CONFLICT_MSG),
+        "row9: ambient env token must NOT count as a 2nd method; stderr: {err:?}"
+    );
+}
+
+// 10. env SET + --pkce (unreachable OIDC) → non-zero exit; NOT a conflict error. [pkce path]
+#[test]
+fn env_set_pkce_attempts_network_not_conflict() {
+    let home = common::unique_tempdir();
+    let out = run_login(
+        &home,
+        Some("env-tok-10"),
+        &[
+            "--pkce",
+            "--issuer",
+            "http://127.0.0.1:1",
+            "--client-id",
+            "x",
+        ],
+        None,
+    );
+    assert!(
+        !out.status.success(),
+        "row10: must fail (no reachable OIDC)"
+    );
+    let err = stderr_of(&out);
+    assert!(
+        !err.contains(CONFLICT_MSG),
+        "row10: ambient env token must NOT count as a 2nd method; stderr: {err:?}"
+    );
+}
+
+// 11. --device --pkce (env unset) → exit 1; conflict. [two real methods conflict]
+#[test]
+fn device_and_pkce_conflicts() {
+    let home = common::unique_tempdir();
+    let out = run_login(
+        &home,
+        None,
+        &[
+            "--device",
+            "--pkce",
+            "--issuer",
+            "http://127.0.0.1:1",
+            "--client-id",
+            "x",
+        ],
+        None,
+    );
+    assert!(!out.status.success(), "row11: must fail");
+    assert_eq!(out.status.code(), Some(1), "row11: exit code");
+    let err = stderr_of(&out);
+    assert!(
+        err.contains(CONFLICT_MSG),
+        "row11: stderr must contain conflict message, got: {err:?}"
+    );
+}
+
+// 12. env SET + explicit --token v + --device → exit 1; conflict.
+#[test]
+fn env_set_explicit_token_and_device_conflicts() {
+    let home = common::unique_tempdir();
+    let out = run_login(
+        &home,
+        Some("env-tok-12"),
+        &[
+            "--token",
+            "flag-tok-12",
+            "--device",
+            "--issuer",
+            "http://127.0.0.1:1",
+            "--client-id",
+            "x",
+        ],
+        None,
+    );
+    assert!(!out.status.success(), "row12: must fail");
+    assert_eq!(out.status.code(), Some(1), "row12: exit code");
+    let err = stderr_of(&out);
+    assert!(
+        err.contains(CONFLICT_MSG),
+        "row12: stderr must contain conflict message, got: {err:?}"
+    );
+}

--- a/crates/flowplane/tests/cli_s5_schema_fields.rs
+++ b/crates/flowplane/tests/cli_s5_schema_fields.rs
@@ -227,9 +227,13 @@ async fn fields_projects_list_items_inside_data() {
     );
     assert!(v["kind"].is_string(), "kind must survive projection: {v}");
 
-    let data = v["data"]
-        .as_array()
-        .unwrap_or_else(|| panic!("list `data` must be an array: {}", v["data"]));
+    // `cluster list` is Page-backed: --fields projects each item inside `data.items`.
+    let data = v["data"]["items"].as_array().unwrap_or_else(|| {
+        panic!(
+            "Page-backed list `data.items` must be an array: {}",
+            v["data"]
+        )
+    });
     assert!(
         !data.is_empty(),
         "mock list must return at least one item: {v}"

--- a/crates/flowplane/tests/cli_s7_coverage.rs
+++ b/crates/flowplane/tests/cli_s7_coverage.rs
@@ -784,3 +784,48 @@ fn chk_nonempty_about() {
          whitespace-only `about`: {offenders:?}"
     );
 }
+
+// =============================================================================================
+// Test 6 — chk:nonempty-arg-help (CLI-R-07): every flag and positional argument of every command
+// (root + every descendant) must render a non-empty `help` description. Walks the serialized clap
+// tree from `flowplane schema -o json` and FAILS, naming EVERY offender, if any arg has a
+// missing/null/empty/whitespace `help` — so adding a new flag/positional with no `///` doc summary
+// fails CI loudly.
+//
+// NOTE on clap globals: clap serializes GLOBAL args (output/server/team/revision/...) ONLY on the
+// ROOT command's `args`, never repeated on descendant subcommands. So walking each node's OWN
+// `args` and asserting non-empty help is correct and complete — globals are covered once at the
+// root, per-command args at their own node. The clap builtin `--help`/`--version` do NOT appear in
+// the schema, so there is nothing to exempt.
+// =============================================================================================
+#[test]
+fn chk_nonempty_arg_help() {
+    let schema = live_schema();
+    let command = root_command(&schema);
+
+    // Collect EVERY offending arg (do not stop at the first) so a developer sees the full list.
+    // Each offender is identified as "<command path> :: <arg name>" — the root uses `<root>`.
+    let mut offenders: Vec<String> = Vec::new();
+    for_each_command(command, |path, node| {
+        if let Some(args) = node["args"].as_array() {
+            for arg in args {
+                let ok = arg["help"]
+                    .as_str()
+                    .map(|s| !s.trim().is_empty())
+                    .unwrap_or(false); // null / non-string / absent all fail
+                if !ok {
+                    let where_ = if path.is_empty() { "<root>" } else { path };
+                    let arg_name = arg["name"].as_str().unwrap_or("<unnamed>");
+                    offenders.push(format!("{where_} :: {arg_name}"));
+                }
+            }
+        }
+    });
+
+    assert!(
+        offenders.is_empty(),
+        "CLI-R-07 chk:nonempty-arg-help: every flag and positional argument of every command must \
+         render a non-empty `help` description (add a `///` doc summary). Args with a \
+         missing/null/empty/whitespace-only `help`: {offenders:?}"
+    );
+}

--- a/crates/flowplane/tests/cli_s7_coverage.rs
+++ b/crates/flowplane/tests/cli_s7_coverage.rs
@@ -747,3 +747,40 @@ async fn output_format_and_quiet_are_honoured() {
         String::from_utf8_lossy(&quiet_out.stdout)
     );
 }
+
+// =============================================================================================
+// Test 5 — chk:nonempty-about (CLI-R-05): every command node (root + every descendant) must
+// render a non-empty one-line `about`. Walks the serialized clap tree from `flowplane schema
+// -o json` and FAILS, naming EVERY offender, if any node has a missing/null/empty/whitespace
+// `about` — so adding a command with no `///` doc summary fails CI loudly.
+// =============================================================================================
+#[test]
+fn chk_nonempty_about() {
+    let schema = live_schema();
+    let command = root_command(&schema);
+
+    // Collect EVERY offending command path (do not stop at the first) so a developer sees the
+    // full list. The root has path "" — label it explicitly for a readable message.
+    let mut offenders: Vec<String> = Vec::new();
+    for_each_command(command, |path, node| {
+        let ok = node["about"]
+            .as_str()
+            .map(|s| !s.trim().is_empty())
+            .unwrap_or(false); // null / non-string / absent all fail
+        if !ok {
+            let where_ = if path.is_empty() {
+                "<root>".to_string()
+            } else {
+                path.to_string()
+            };
+            offenders.push(where_);
+        }
+    });
+
+    assert!(
+        offenders.is_empty(),
+        "CLI-R-05 chk:nonempty-about: every command and sub-command must render a non-empty \
+         one-line `about` (add a `///` doc summary). Commands with a missing/null/empty/\
+         whitespace-only `about`: {offenders:?}"
+    );
+}

--- a/crates/flowplane/tests/cli_s7_coverage.rs
+++ b/crates/flowplane/tests/cli_s7_coverage.rs
@@ -402,7 +402,7 @@ async fn cluster_family_json_envelopes_are_frozen() {
             .expect("run cluster command")
     };
 
-    // cluster list → clusterList, data is the two-item array.
+    // cluster list → clusterList, data is the Page wrapper {items,limit,offset,total}.
     let list = run(vec![
         "cluster".into(),
         "list".into(),
@@ -416,10 +416,16 @@ async fn cluster_family_json_envelopes_are_frozen() {
         json!({
             "schemaVersion": 1,
             "kind": "clusterList",
-            "data": [
-                { "name": "alpha", "revision": 1, "service_name": "alpha-svc" },
-                { "name": "beta", "revision": 2, "service_name": "beta-svc" }
-            ]
+            // `cluster list` is Page-backed: data wraps items in {items,limit,offset,total}.
+            "data": {
+                "items": [
+                    { "name": "alpha", "revision": 1, "service_name": "alpha-svc" },
+                    { "name": "beta", "revision": 2, "service_name": "beta-svc" }
+                ],
+                "limit": 50,
+                "offset": 0,
+                "total": 2
+            }
         }),
         "cluster list -o json envelope drifted"
     );
@@ -732,8 +738,8 @@ async fn output_format_and_quiet_are_honoured() {
         "`--quiet` must not suppress the requested data envelope"
     );
     assert!(
-        quiet_env["data"].is_array(),
-        "`--quiet` data envelope must still carry the list array: {quiet_env}"
+        quiet_env["data"]["items"].is_array(),
+        "`--quiet` data envelope must still carry the list (Page-backed items): {quiet_env}"
     );
     // No trailing prose: stdout is a single parseable JSON document and nothing else.
     let mut docs = serde_json::Deserializer::from_slice(&quiet_out.stdout).into_iter::<Value>();

--- a/crates/flowplane/tests/common/mod.rs
+++ b/crates/flowplane/tests/common/mod.rs
@@ -64,6 +64,15 @@ pub async fn start_mock() -> MockServer {
             get(get_cluster)
                 .patch(update_cluster)
                 .delete(delete_cluster),
+        )
+        // MCP status reader — returns a small JSON object (fields are illustrative; only the
+        // object shape matters, so the CLI can render the envelope kind for `mcp status`).
+        .route("/api/v1/teams/{team}/mcp/status", get(mcp_status))
+        // `unexpose <name>` hits DELETE on the expose surface. It must return a JSON object body
+        // (NOT 204/empty) so the body path drives the envelope `kind` resolver for `unexpose`.
+        .route(
+            "/api/v1/teams/{team}/expose/{name}",
+            axum::routing::delete(delete_expose),
         );
 
     let listener = TcpListener::bind("127.0.0.1:0")
@@ -209,6 +218,22 @@ async fn delete_cluster(Path((_team, name)): Path<(String, String)>) -> Response
             .into_response();
     }
     StatusCode::NO_CONTENT.into_response()
+}
+
+/// MCP status reader: a small JSON **object** body (the exact fields are not contractual — only
+/// that it is an object the CLI can wrap in its `{schemaVersion, kind, data}` envelope).
+async fn mcp_status(Path(_team): Path<String>) -> (StatusCode, Json<Value>) {
+    (StatusCode::OK, Json(json!({ "enabled": true, "tools": 0 })))
+}
+
+/// `unexpose <name>` → DELETE on the expose surface. Returns 200 with a small JSON **object**
+/// body (deliberately NOT 204/empty) so the response-body path is what the CLI uses to resolve
+/// the envelope `kind`.
+async fn delete_expose(Path((_team, name)): Path<(String, String)>) -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::OK,
+        Json(json!({ "removed": true, "name": name })),
+    )
 }
 
 /// A loopback URL with no listener — connecting to it fails fast with "connection refused",

--- a/crates/flowplane/tests/common/mod.rs
+++ b/crates/flowplane/tests/common/mod.rs
@@ -89,10 +89,18 @@ pub async fn start_mock() -> MockServer {
 }
 
 async fn list_clusters(Path(_team): Path<String>) -> Json<Value> {
-    Json(json!([
-        { "name": "alpha", "revision": 1, "service_name": "alpha-svc" },
-        { "name": "beta", "revision": 2, "service_name": "beta-svc" }
-    ]))
+    // The real `cluster list` endpoint is Page-backed: `data` wraps the items in
+    // `{ items, limit, offset, total }` (fp-api `Page<T>`), not a bare array. The mock mirrors
+    // that so the fixture matches the server it stands in for (fpv2-86m.2 / F-1).
+    Json(json!({
+        "items": [
+            { "name": "alpha", "revision": 1, "service_name": "alpha-svc" },
+            { "name": "beta", "revision": 2, "service_name": "beta-svc" }
+        ],
+        "limit": 50,
+        "offset": 0,
+        "total": 2
+    }))
 }
 
 /// Error injection: a resource name like `err-404`/`err-429`/`err-503`/`err-401`/`err-403`

--- a/crates/fp-api/src/error.rs
+++ b/crates/fp-api/src/error.rs
@@ -53,10 +53,14 @@ impl IntoResponse for ApiError {
         let code = self.error.code;
 
         // Internal/invalid-config details go to logs (keyed by request id), never to the caller.
+        // The hint is logged too: for a misconfiguration (e.g. an unconfigured cert issuer) it
+        // carries the actionable prerequisite the operator needs, which the redacted client
+        // message omits (fpv2-86m.4 / #193 Obs-1).
         let message = if code == ErrorCode::Internal || code == ErrorCode::InvalidConfig {
             tracing::error!(
                 request_id = %self.request_id,
                 error.message = %self.error.message,
+                error.hint = self.error.hint.as_deref().unwrap_or(""),
                 "internal error"
             );
             "an internal error occurred; report the request_id to your operator".to_string()

--- a/crates/fp-core/src/dev.rs
+++ b/crates/fp-core/src/dev.rs
@@ -19,6 +19,25 @@ pub const DEV_SUBJECT: &str = "dev-user";
 pub const DEV_EMAIL: &str = "dev@flowplane.local";
 const DEV_KID: &str = "flowplane-dev-key";
 
+/// Default dev-user token lifetime (24h). Long enough that a local exploration session does not
+/// expire mid-use (#190); dev-only, so it never affects production token lifetimes.
+const DEV_TOKEN_DEFAULT_TTL_SECS: i64 = 86_400;
+
+/// Resolve the dev-user token lifetime from `FLOWPLANE_DEV_TOKEN_TTL` (seconds), defaulting to
+/// [`DEV_TOKEN_DEFAULT_TTL_SECS`]. Reads process env; the parse/validation is factored into the
+/// pure [`parse_dev_token_ttl`] so it is unit-testable without env mutation.
+fn dev_token_ttl_secs() -> i64 {
+    parse_dev_token_ttl(std::env::var("FLOWPLANE_DEV_TOKEN_TTL").ok().as_deref())
+}
+
+/// Pure parse: a positive integer wins; anything else (absent, non-numeric, ≤ 0) falls back to
+/// the 24h default.
+fn parse_dev_token_ttl(raw: Option<&str>) -> i64 {
+    raw.and_then(|v| v.trim().parse::<i64>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEV_TOKEN_DEFAULT_TTL_SECS)
+}
+
 /// In-process token issuer for dev mode. The key is generated per boot — dev tokens never
 /// survive a restart and can never validate against another instance.
 pub struct DevIssuer {
@@ -82,9 +101,12 @@ impl DevIssuer {
             .map_err(|e| DomainError::internal(format!("dev token mint failed: {e}")))
     }
 
-    /// Mint the standard dev-user token (1 hour).
+    /// Mint the standard dev-user token. Lifetime is configurable via `FLOWPLANE_DEV_TOKEN_TTL`
+    /// (seconds, dev-only) and defaults to 24h, so a local exploration session no longer dies
+    /// after an hour and forces a control-plane restart (#190). Dev-mode only; production builds
+    /// (`--no-default-features`) never reach this path, and the expiry-enforcement path is unchanged.
     pub fn mint_dev_user(&self) -> DomainResult<String> {
-        self.mint(DEV_SUBJECT, DEV_EMAIL, "Dev User", 3600)
+        self.mint(DEV_SUBJECT, DEV_EMAIL, "Dev User", dev_token_ttl_secs())
     }
 
     /// The validator configuration matching this issuer.
@@ -126,6 +148,45 @@ fn base64url(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
     use crate::oidc::OidcValidator;
+
+    #[test]
+    fn dev_token_ttl_parses_env_else_defaults_to_24h() {
+        // default when absent / invalid / non-positive.
+        assert_eq!(parse_dev_token_ttl(None), DEV_TOKEN_DEFAULT_TTL_SECS);
+        assert_eq!(parse_dev_token_ttl(Some("abc")), DEV_TOKEN_DEFAULT_TTL_SECS);
+        assert_eq!(parse_dev_token_ttl(Some("0")), DEV_TOKEN_DEFAULT_TTL_SECS);
+        assert_eq!(parse_dev_token_ttl(Some("-5")), DEV_TOKEN_DEFAULT_TTL_SECS);
+        // default is at least 24h (no more 1h forced restart).
+        assert!(DEV_TOKEN_DEFAULT_TTL_SECS >= 86_400);
+        // a valid positive override wins.
+        assert_eq!(parse_dev_token_ttl(Some("3600")), 3600);
+        assert_eq!(parse_dev_token_ttl(Some(" 7200 ")), 7200);
+    }
+
+    #[tokio::test]
+    async fn dev_user_token_lifetime_matches_resolved_ttl() {
+        // The minted dev-user token's exp-iat reflects the resolved TTL (>= 24h by default),
+        // proving mint_dev_user honours dev_token_ttl_secs() rather than the old hardcoded 1h.
+        let issuer = DevIssuer::generate().expect("keygen");
+        let token = issuer.mint_dev_user().expect("mint");
+        let payload = token.split('.').nth(1).expect("jwt payload segment");
+        let decoded = base64_url_decode(payload);
+        let claims: serde_json::Value = serde_json::from_slice(&decoded).expect("claims are JSON");
+        let iat = claims["iat"].as_i64().expect("iat");
+        let exp = claims["exp"].as_i64().expect("exp");
+        assert!(
+            exp - iat >= 86_400,
+            "default dev token lifetime must be >= 24h, got {}s",
+            exp - iat
+        );
+    }
+
+    fn base64_url_decode(s: &str) -> Vec<u8> {
+        use base64::Engine;
+        base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(s)
+            .expect("valid base64url")
+    }
 
     #[tokio::test]
     async fn dev_tokens_validate_through_the_production_path() {

--- a/crates/fp-core/src/dev.rs
+++ b/crates/fp-core/src/dev.rs
@@ -22,6 +22,7 @@ const DEV_KID: &str = "flowplane-dev-key";
 /// Default dev-user token lifetime (24h). Long enough that a local exploration session does not
 /// expire mid-use (#190); dev-only, so it never affects production token lifetimes.
 const DEV_TOKEN_DEFAULT_TTL_SECS: i64 = 86_400;
+const _: () = assert!(DEV_TOKEN_DEFAULT_TTL_SECS >= 86_400);
 
 /// Resolve the dev-user token lifetime from `FLOWPLANE_DEV_TOKEN_TTL` (seconds), defaulting to
 /// [`DEV_TOKEN_DEFAULT_TTL_SECS`]. Reads process env; the parse/validation is factored into the
@@ -156,8 +157,6 @@ mod tests {
         assert_eq!(parse_dev_token_ttl(Some("abc")), DEV_TOKEN_DEFAULT_TTL_SECS);
         assert_eq!(parse_dev_token_ttl(Some("0")), DEV_TOKEN_DEFAULT_TTL_SECS);
         assert_eq!(parse_dev_token_ttl(Some("-5")), DEV_TOKEN_DEFAULT_TTL_SECS);
-        // default is at least 24h (no more 1h forced restart).
-        assert!(DEV_TOKEN_DEFAULT_TTL_SECS >= 86_400);
         // a valid positive override wins.
         assert_eq!(parse_dev_token_ttl(Some("3600")), 3600);
         assert_eq!(parse_dev_token_ttl(Some(" 7200 ")), 7200);

--- a/crates/fp-core/src/services/dataplanes.rs
+++ b/crates/fp-core/src/services/dataplanes.rs
@@ -654,3 +654,33 @@ fn validate_trust_domain(value: &str) -> DomainResult<()> {
     }
     Ok(())
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::required_env_path;
+    use fp_domain::error::ErrorCode;
+
+    // Obs-1 (fpv2-86m.4): an unconfigured cert-issuer prerequisite must fail closed with a
+    // *reason* — the error names the missing env var and carries an actionable hint, so the
+    // operator log (fp-api logs message + hint) is actionable even though the client sees the
+    // redacted generic 500. Reads a guaranteed-unset var, so it is parallel-safe (no env mutation).
+    #[test]
+    fn unconfigured_cert_issuer_env_fails_with_named_reason() {
+        let err = required_env_path("FLOWPLANE_CERT_ISSUER_CA_CERT_PATH_DEFINITELY_UNSET_XQ7")
+            .expect_err("an unset env path must error");
+        assert_eq!(err.code, ErrorCode::InvalidConfig);
+        assert!(
+            err.message
+                .contains("FLOWPLANE_CERT_ISSUER_CA_CERT_PATH_DEFINITELY_UNSET_XQ7"),
+            "error message must name the missing env var: {}",
+            err.message
+        );
+        let hint = err.hint.unwrap_or_default();
+        assert!(
+            hint.contains("FLOWPLANE_CERT_ISSUER_CA_CERT_PATH")
+                && hint.contains("FLOWPLANE_CERT_ISSUER_CA_KEY_PATH"),
+            "hint must name the cert-issuer prerequisites: {hint}"
+        );
+    }
+}

--- a/docs/concepts/cli-contract.md
+++ b/docs/concepts/cli-contract.md
@@ -54,9 +54,10 @@ boolean instead of hard-coding a status list.
 
 The process exits `0` on success and a **specific code by failure class** otherwise — usage `2`,
 auth `3`, not-found/conflict `4`, validation `5`, rate-limited `6`, server/transport `7` — rather
-than a generic non-zero. A script can branch on `$?` alone, before parsing any JSON, and a CI job
-can distinguish "your input was wrong" (`2`/`5`) from "the server is down" (`7`). The codes mirror
-the error classes, so the exit code and the `code`/`retryable` fields always agree.
+than a generic non-zero. Usage `2` covers invalid flags/arguments and local preflight usage checks.
+A script can branch on `$?` alone, before parsing any JSON, and a CI job can distinguish "your input
+was wrong" (`2`/`5`) from "the server is down" (`7`). The codes mirror the error classes, so the
+exit code and the `code`/`retryable` fields always agree.
 
 ## Optimistic concurrency instead of last-write-wins
 

--- a/docs/how-to/create-tenant-org-and-team.md
+++ b/docs/how-to/create-tenant-org-and-team.md
@@ -23,6 +23,12 @@ dataplanes under." Every value you need is here.
 - Your CLI points at the control plane (`--server` / `FLOWPLANE_SERVER` / a saved
   context — see [CLI auth and contexts](cli-auth-and-contexts.md)).
 
+> **Using dev mode from Getting Started?** The seeded `dev-user` is an owner of
+> `dev-org` and a member of `default`, but it is **not** a platform admin and cannot run
+> `org create`. Use the seeded `dev-org` / `default` context for local gateway
+> exploration. This guide is for a non-dev context where you hold a real
+> platform-admin identity and need to provision an additional tenant org and team.
+
 ## 1. Create the tenant org
 
 Only a platform admin can create an organization. `name` is the immutable handle;
@@ -51,10 +57,11 @@ flowplane org member add edgeco --role owner --subject "auth0|6650f0..."
 This calls `POST /api/v1/orgs/{org}/members`. Pass exactly one of `--subject`,
 `--email`, or `--user-id`.
 
-> **Running everything yourself locally?** Add **your own** subject as the owner. You
+> **Running a local non-dev bootstrap?** Add **your own** subject as the owner. You
 > are then both the platform admin *and* the owner of `edgeco`; the team step below
 > authorizes through your `edgeco` org membership, not your platform role — the
-> platform role never grants tenant access.
+> platform role never grants tenant access. This is separate from dev mode's
+> seeded `dev-user`, which is not a platform admin.
 
 ## 3. Create a team in the tenant org
 

--- a/docs/how-to/global-rate-limit.md
+++ b/docs/how-to/global-rate-limit.md
@@ -181,8 +181,15 @@ Update and delete are concurrency-controlled: pass the current revision with the
 `flowplane rate-limit policy get --team default --domain checkout per-client` (the `revision`
 field); omitting `--revision` fails with `this operation requires the resource revision`.
 
-- **Update a limit:** edit `policy.json` (the body carries `spec` only on update), then
-  `flowplane rate-limit policy update --team default --domain checkout per-client --revision 1 --file policy.json`. The change reaches the RLS within the reconcile window (≤ 60 s).
+- **Update a limit:** write an update body with `spec` only (the policy name is the
+  positional `per-client`), then pass the current revision:
+
+  ```bash
+  echo '{"spec":{"descriptors":{"api_key":"acme"},"requests_per_unit":200,"unit":"minute"}}' > policy-update.json
+  flowplane rate-limit policy update --team default --domain checkout per-client --revision 1 --file policy-update.json
+  ```
+
+  The change reaches the RLS within the reconcile window (≤ 60 s).
 - **Per-team override:** raise/lower one team's limit without touching the policy. The `--file`
   flag takes a **path**, so write the body first:
 

--- a/docs/how-to/import-and-publish-openapi-spec.md
+++ b/docs/how-to/import-and-publish-openapi-spec.md
@@ -37,7 +37,7 @@ flowplane api create catalog --from-openapi openapi.json --team my-team \
   --route-config-id <id> --listener-id <id> --virtual-host <host> --route <route>
 ```
 
-After this the CLI prints a reminder that the tools are generated **but not served yet**. Confirm: an MCP `tools/list` for the team does **not** include the new `api_catalog-*` tools, and `mcp status`'s `dynamic_enabled_tool_count` does not rise for this API.
+After this the CLI prints a reminder that the tools are generated **but not served yet** (this reminder is shown only in the default human/table output; under `-o json`/`-o yaml` it is omitted so machine consumers get a clean envelope). Confirm: an MCP `tools/list` for the team does **not** include the new `api_catalog-*` tools, and `mcp status`'s `dynamic_enabled_tool_count` does not rise for this API.
 
 ## 2. Publish the imported spec version
 

--- a/docs/how-to/script-the-cli.md
+++ b/docs/how-to/script-the-cli.md
@@ -20,7 +20,7 @@ Reader commands print a **table** on an interactive terminal but switch to **JSO
 when stdout is not a terminal** — so a pipe just works, no flag needed:
 
 ```bash
-flowplane cluster list --team payments | jq '.data'
+flowplane cluster list --team payments | jq '.data.items'
 ```
 
 To be explicit (recommended in scripts so behavior never depends on the terminal), pass
@@ -30,23 +30,33 @@ To be explicit (recommended in scripts so behavior never depends on the terminal
 flowplane cluster list --team payments -o json
 ```
 
-Every success payload is wrapped in a stable, versioned envelope:
+Every success payload is wrapped in a stable, versioned envelope. `cluster list` is **paginated**,
+so its `data` is an object wrapping the rows in `items` (with `limit`/`offset`/`total`):
 
 ```json
 {
   "schemaVersion": 1,
   "kind": "clusterList",
-  "data": [
-    { "name": "alpha", "revision": 1, "service_name": "alpha-svc" },
-    { "name": "beta",  "revision": 2, "service_name": "beta-svc" }
-  ]
+  "data": {
+    "items": [
+      { "name": "alpha", "revision": 1, "service_name": "alpha-svc" },
+      { "name": "beta",  "revision": 2, "service_name": "beta-svc" }
+    ],
+    "limit": 50,
+    "offset": 0,
+    "total": 2
+  }
 }
 ```
 
 - `schemaVersion` — integer contract version of the envelope; branch on it if you parse defensively.
 - `kind` — what `data` holds (`cluster` for one object, `clusterList` for a list, `mutationResult`
-  for a delete, etc.).
-- `data` — the resource (object) or resources (array).
+  for a delete/action, etc.).
+- `data` — the resource (object), or the collection. **Two list shapes exist:** paginated lists
+  (most resources — clusters, listeners, routes, secrets, dataplanes, AI, rate-limit, …) wrap rows
+  in `data.items` as above; a few identity/org lists (`org list`, `team list`, `org member list`,
+  `team member list`, `team grant list`) return `data` as a **bare array**. When in doubt, branch on `.data | type`
+  (`"object"` → read `.data.items`, `"array"` → read `.data`).
 
 Pull a single value out with `jq`:
 
@@ -99,7 +109,8 @@ done
 ## 3. Project only the fields you need
 
 `--fields` trims reader output to a comma-separated key set, applied **inside** `data` (per item
-for lists). `schemaVersion` and `kind` always survive; absent keys are omitted:
+for lists — including each row of a paginated `data.items`). `schemaVersion` and `kind` always
+survive; absent keys are omitted:
 
 ```bash
 flowplane cluster list --team payments -o json --fields name,revision
@@ -109,10 +120,15 @@ flowplane cluster list --team payments -o json --fields name,revision
 {
   "schemaVersion": 1,
   "kind": "clusterList",
-  "data": [
-    { "name": "alpha", "revision": 1 },
-    { "name": "beta",  "revision": 2 }
-  ]
+  "data": {
+    "items": [
+      { "name": "alpha", "revision": 1 },
+      { "name": "beta",  "revision": 2 }
+    ],
+    "limit": 50,
+    "offset": 0,
+    "total": 2
+  }
 }
 ```
 
@@ -177,7 +193,7 @@ export FLOWPLANE_TOKEN=…           # highest-priority token source
 export FLOWPLANE_TEAM=payments
 export FLOWPLANE_TIMEOUT=15        # seconds
 
-flowplane cluster list -o json --quiet | jq '.data[].name'
+flowplane cluster list -o json --quiet | jq -r '.data.items[].name'
 ```
 
 Precedence for every value (including the token) is `flag > env > context > file > default` — see

--- a/docs/how-to/script-the-cli.md
+++ b/docs/how-to/script-the-cli.md
@@ -86,7 +86,7 @@ The full map (see [`../reference/cli.md#exit-codes`](../reference/cli.md#exit-co
 |------|---------|---------|
 | `0` | Success | — |
 | `1` | Generic / internal CLI error | Unclassified local failure |
-| `2` | Usage error | Invalid flags/arguments |
+| `2` | Usage error | Invalid flags/arguments and local preflight usage checks |
 | `3` | Auth | HTTP `401`, `403` |
 | `4` | Not found / conflict / precondition | HTTP `404`, `409`, `412` |
 | `5` | Validation | HTTP `400`, `422` |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,6 +6,8 @@ Exhaustive reference for the `flowplane` binary: global options, every top-level
 
 To drive the CLI from a script or agent, see the how-to [Script Flowplane from a shell or agent](../how-to/script-the-cli.md); for the reasoning behind the output envelope, exit codes, and `schema`, see [The CLI as a typed contract](../concepts/cli-contract.md).
 
+`flowplane --help` is self-sufficient: as of 2.1.0 every command and subcommand shows a one-line summary, every flag and positional shows help text, and the workflow ("spine") commands — resource `create`/`update`, `route generate`, `api create`, `expose`/`unexpose`/`apply`, the capture/discovery starters, `dataplane bootstrap`/`cert register`/`issue`/`revoke`, `secret create`/`rotate` — carry a copy-pasteable example in their `--help`. This page is the exhaustive reference; `--help` is the in-terminal quick path.
+
 ## Global options
 
 These flags are accepted on every command (`global = true`). Place them before or after the subcommand.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -127,7 +127,7 @@ separate from the success envelope above (it is **not** wrapped in `{schemaVersi
 |------|---------|---------|
 | `0` | Success | — |
 | `1` | Generic / internal CLI error | Unclassified local failure |
-| `2` | Usage error | Invalid flags/arguments (clap-native) |
+| `2` | Usage error | Invalid flags/arguments and local preflight usage checks |
 | `3` | Authentication / authorization | HTTP `401`, `403` |
 | `4` | Not found / conflict / precondition | HTTP `404`, `409`, `412` |
 | `5` | Validation | HTTP `400`, `422` |
@@ -161,7 +161,7 @@ Client auth helpers.
 | `auth whoami` | — |
 | `auth token` | — |
 | `auth logout` | — |
-| `auth login` | `--token <TOKEN>`, `--token-stdin`, `--device` (alias `--device-code`), `--pkce`, `--issuer <URL>`, `--client-id <ID>`, `--callback-url <URL>`, `--scope <SCOPE>` (default `openid email profile`) |
+| `auth login` | `--token <TOKEN>`, `--token-stdin`, `--device` (alias `--device-code`), `--pkce`, `--issuer <URL>`, `--client-id <ID>`, `--callback-url <URL>`, `--scope <SCOPE>` (default `openid email profile`). Login input methods are mutually exclusive; combining explicit methods exits `2`. |
 
 ### `config`
 Client configuration.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -33,6 +33,7 @@ Booleans accept `true`/`1`/`yes` and `false`/`0`/`no`. Invalid server values fai
 | `FLOWPLANE_DEV_MODE` | server | `false` | no ⁴ | In-process OIDC issuer + seeded resources; needs the `dev-oidc` build feature. |
 | `FLOWPLANE_DEV_MODE_ACK` | server | — | no ⁴ | In release builds, dev mode requires this to equal `yes-this-is-not-production`. |
 | `FLOWPLANE_DEV_TOKEN_PATH` | server | — | no | Dev mode only: also write the per-boot dev bearer token to this file (it is otherwise only logged), so a sibling/init container can read it. Ignored outside dev mode. |
+| `FLOWPLANE_DEV_TOKEN_TTL` | server | `86400` | no | Dev mode only: lifetime in **seconds** of the per-boot dev bearer token. Defaults to 24h so a local session does not expire mid-use; a non-numeric or non-positive value falls back to the default. Ignored outside dev mode; never affects production token lifetimes. |
 | `FLOWPLANE_BOOTSTRAP_TOKEN` | server | — | first boot ¹³ | Operator-supplied one-shot bootstrap token (≥ 32 chars after trimming). Seeds first-admin setup; the value is never logged. |
 | `FLOWPLANE_BOOTSTRAP_TOKEN_FILE` | server | — | first boot ¹³ | Path to read the bootstrap token from; **takes precedence** over `FLOWPLANE_BOOTSTRAP_TOKEN`. File delivery is safer than env. |
 | `FLOWPLANE_ALLOW_LOGGED_BOOTSTRAP_TOKEN` | server | — | no | Local-only escape hatch: the exact value `yes-this-is-local-only` re-enables generating and **logging** a token. Never set in production. |

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -85,10 +85,10 @@ Dev mode seeds one organization, team, and user:
 Dev mode mints a bearer token at startup and logs it once. Find the log line that looks like:
 
 ```text
-WARN ... dev_token=<long-token-string> dev bearer token (valid 1h, this boot only)
+WARN ... dev_token=<long-token-string> dev bearer token (default 24h, set FLOWPLANE_DEV_TOKEN_TTL to change; this boot only)
 ```
 
-The token is valid for this control-plane process only and expires after one hour. If you restart the server, grab the new token.
+The token is valid for this control-plane process only and, by default, expires after 24 hours (set `FLOWPLANE_DEV_TOKEN_TTL` in seconds to change it). If you restart the server, grab the new token.
 
 In a second terminal, point the CLI at the running server and export the token:
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -78,6 +78,11 @@ Dev mode seeds one organization, team, and user:
 | Team     | `default` |
 | User     | `dev-user`|
 
+The seeded `dev-user` is ready for this local tenant (`dev-org` / `default`) but
+is not a platform admin. Creating additional tenant organizations requires a
+bootstrapped platform-admin environment; for that operator workflow, see
+[create a tenant org and a team](../how-to/create-tenant-org-and-team.md).
+
 ---
 
 ## 3. Get a token and confirm authentication


### PR DESCRIPTION
## Summary

- Fixes the remaining v2.1.0 docs E2E QA gaps from #194.
- Clarifies dev-mode tenant/org/team setup boundaries from #195.
- Classifies explicit `flowplane auth login` method conflicts as usage errors with exit code `2` from #196, while preserving no-method/no-OIDC exit `1` and ambient `FLOWPLANE_TOKEN` behavior.
- Adds the release changelog traceability entry required by the lifecycle.

## Lifecycle / AIDF

- Followed `/Users/rajeevramani/workspace/projects/flowplane-private-vault/LIFECYCLE.md`.
- AIDF features completed for #194, #195, and #196.
- Human high-blast auth waiver recorded for `fpv2-oxg.1`.
- Claude AIDF plan review for #196: `VERDICT: APPROVE`.
- Claude AIDF slice review for #196: `VERDICT: APPROVE`.
- Beads closed: `fpv2-9gi`, `fpv2-0so`, `fpv2-oxg`.

## Validation

- `cargo fmt --check`
- `cargo test -p flowplane --test cli_s3_auth_login_token_source --test cli_s2_error_model`
- `cargo clippy -p flowplane --all-targets`
- `python3 scripts/ci/check-docs-boundary.py`
- `git diff --check`

Closes #194
Closes #195
Closes #196
