### PR TITLE
chore(release): bump workspace version to 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,7 +762,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flowplane"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "flowplane-rls"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "axum",
  "envoy-types",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "fp-agent"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "fp-api"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "axum",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "fp-core"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "fp-domain"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "base64",
  "chrono",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "fp-storage"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "fp-domain",
  "metrics",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "fp-xds"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.92"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Bumps the Flowplane workspace package version from `2.0.0` to `2.1.0`.
- Updates `Cargo.lock` so all Flowplane workspace crates resolve as `2.1.0`.

## Lifecycle

Follows `/Users/rajeevramani/workspace/projects/flowplane-private-vault/LIFECYCLE.md` §4.1 release-cut step 2. The release changelog and release audit records for `2.1.0` are already present from the prior release QA work.

## Validation

- `cargo metadata --format-version 1 --no-deps`
- `cargo check --workspace --all-targets`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets`
- `python3 scripts/ci/check-docs-boundary.py`
- `git diff --check`
