### PR TITLE
Docs: add adoption evaluation spine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,3 +149,7 @@ jobs:
         run: python3 scripts/ci/check-docs-boundary.py --self-test
       - name: Docs boundary (user docs must stand alone, #116)
         run: python3 scripts/ci/check-docs-boundary.py
+      - name: Docs jargon self-test
+        run: python3 scripts/ci/check-docs-jargon.py --self-test
+      - name: Docs jargon (public docs must not expose planning labels)
+        run: python3 scripts/ci/check-docs-jargon.py

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The [documentation home](docs/README.md) is organised by [Diátaxis](https://dia
 |--------------|------------|
 | Try Flowplane without cloning the repo | [Evaluate without cloning](docs/tutorials/evaluate-no-clone.md) |
 | Evaluate a production-shaped platform setup | [Evaluate a production-shaped platform setup](docs/how-to/evaluate-platform.md) |
+| Delegate API onboarding to a team | [Onboard an API team](docs/how-to/onboard-api-team.md) |
 | Stand up a gateway from a clean checkout | [Getting Started](docs/tutorials/getting-started.md) |
 | Protect a route with JWT auth + rate limit | [JWT auth & rate limit](docs/how-to/jwt-auth-rate-limit-route.md) |
 | Cap a route globally across all Envoys | [Enable global rate limiting](docs/how-to/global-rate-limit.md) |

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The [documentation home](docs/README.md) is organised by [Diátaxis](https://dia
 | Understand tenancy, grants, and xDS | [Tenancy, grants & the xDS pipeline](docs/concepts/tenancy-grants-xds.md) |
 | Understand global rate limiting | [Global rate limiting](docs/concepts/global-rate-limiting.md) |
 
-Reference: [CLI](docs/reference/cli.md) · [Configuration](docs/reference/configuration.md) · [REST API](docs/reference/rest-api.md) · [Filters](docs/reference/filters.md) · [Errors](docs/reference/errors.md)
+Reference: [CLI](docs/reference/cli.md) · [Configuration](docs/reference/configuration.md) · [REST API](docs/reference/rest-api.md) · [Filters](docs/reference/filters.md) · [Errors](docs/reference/errors.md) · [Adoption issue map](docs/reference/adoption-evaluation-issue-map.md)
 
 ## Building and Testing
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The [documentation home](docs/README.md) is organised by [Diátaxis](https://dia
 | You want to… | Start here |
 |--------------|------------|
 | Try Flowplane without cloning the repo | [Evaluate without cloning](docs/tutorials/evaluate-no-clone.md) |
-| Evaluate a production-shaped platform setup | [Production Readiness](docs/how-to/production-readiness.md), [Configure OIDC](docs/how-to/configure-oidc-provider.md), and [Bootstrap the first platform admin](docs/how-to/bootstrap-platform.md) |
+| Evaluate a production-shaped platform setup | [Evaluate a production-shaped platform setup](docs/how-to/evaluate-platform.md) |
 | Stand up a gateway from a clean checkout | [Getting Started](docs/tutorials/getting-started.md) |
 | Protect a route with JWT auth + rate limit | [JWT auth & rate limit](docs/how-to/jwt-auth-rate-limit-route.md) |
 | Cap a route globally across all Envoys | [Enable global rate limiting](docs/how-to/global-rate-limit.md) |

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ docker compose -f compose.eval.yml exec flowplane-eval \
 docker compose -f compose.eval.yml down -v
 ```
 
+Next, continue the no-clone evaluation with [Evaluate Flowplane without cloning the repo](docs/tutorials/evaluate-no-clone.md) to try the CLI, import an OpenAPI document, publish it, and verify the generated API tools.
+
 > The `:${VER}-eval` image is **for evaluation only** — it runs dev mode (in-process OIDC issuer +
 > seeded resources + a dev bearer token on disk) and binds every port to `127.0.0.1`. It is **never**
 > an operator/production base and is never tagged `:latest`. The hardened, publishable image is
@@ -150,7 +152,7 @@ The [documentation home](docs/README.md) is organised by [Diátaxis](https://dia
 
 | You want to… | Start here |
 |--------------|------------|
-| Try Flowplane without cloning the repo | [Quick Start (no clone)](#quick-start-no-clone-no-rust-toolchain) |
+| Try Flowplane without cloning the repo | [Evaluate without cloning](docs/tutorials/evaluate-no-clone.md) |
 | Evaluate a production-shaped platform setup | [Production Readiness](docs/how-to/production-readiness.md) and [Bootstrap the first platform admin](docs/how-to/bootstrap-platform.md) |
 | Stand up a gateway from a clean checkout | [Getting Started](docs/tutorials/getting-started.md) |
 | Protect a route with JWT auth + rate limit | [JWT auth & rate limit](docs/how-to/jwt-auth-rate-limit-route.md) |

--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ published **evaluation** image and stands up the whole stack — Postgres, the d
 demo upstream, and Envoy — then routes a real request through the gateway. No repo checkout, no
 `cargo build`.
 
-> Set `VER` to the release you want (e.g. `1.0.0`). The image is **multi-arch**: a plain `docker pull`
-> resolves the native `linux/amd64` or `linux/arm64` variant — no `--platform` flag, no emulation.
+> Set `VER` to a published release. The example below uses `2.1.0`, whose evaluator bundle and
+> `:${VER}-eval` image are published for `linux/amd64` and `linux/arm64`. For newer releases,
+> use the version shown on the GitHub Releases page. The image is **multi-arch**: a plain
+> `docker pull` resolves the native variant — no `--platform` flag, no emulation.
 
 ```bash
-VER=1.0.0
+VER=2.1.0
 
 # 1. Fetch the evaluator bundle at the matching release tag (the only file you need)
 curl -fsSLO https://raw.githubusercontent.com/rajeevramani/flowplane/v${VER}/compose.eval.yml
@@ -148,6 +150,8 @@ The [documentation home](docs/README.md) is organised by [Diátaxis](https://dia
 
 | You want to… | Start here |
 |--------------|------------|
+| Try Flowplane without cloning the repo | [Quick Start (no clone)](#quick-start-no-clone-no-rust-toolchain) |
+| Evaluate a production-shaped platform setup | [Production Readiness](docs/how-to/production-readiness.md) and [Bootstrap the first platform admin](docs/how-to/bootstrap-platform.md) |
 | Stand up a gateway from a clean checkout | [Getting Started](docs/tutorials/getting-started.md) |
 | Protect a route with JWT auth + rate limit | [JWT auth & rate limit](docs/how-to/jwt-auth-rate-limit-route.md) |
 | Cap a route globally across all Envoys | [Enable global rate limiting](docs/how-to/global-rate-limit.md) |

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The [documentation home](docs/README.md) is organised by [Diátaxis](https://dia
 | You want to… | Start here |
 |--------------|------------|
 | Try Flowplane without cloning the repo | [Evaluate without cloning](docs/tutorials/evaluate-no-clone.md) |
-| Evaluate a production-shaped platform setup | [Production Readiness](docs/how-to/production-readiness.md) and [Bootstrap the first platform admin](docs/how-to/bootstrap-platform.md) |
+| Evaluate a production-shaped platform setup | [Production Readiness](docs/how-to/production-readiness.md), [Configure OIDC](docs/how-to/configure-oidc-provider.md), and [Bootstrap the first platform admin](docs/how-to/bootstrap-platform.md) |
 | Stand up a gateway from a clean checkout | [Getting Started](docs/tutorials/getting-started.md) |
 | Protect a route with JWT auth + rate limit | [JWT auth & rate limit](docs/how-to/jwt-auth-rate-limit-route.md) |
 | Cap a route globally across all Envoys | [Enable global rate limiting](docs/how-to/global-rate-limit.md) |

--- a/crates/fp-api/src/dataplanes_api.rs
+++ b/crates/fp-api/src/dataplanes_api.rs
@@ -205,7 +205,7 @@ pub struct EnvoyConfigQuery {
     /// Dataplane private key path as seen by Envoy.
     #[serde(default)]
     pub key_path: Option<String>,
-    /// Control-plane/client-CA bundle path as seen by Envoy.
+    /// CA bundle Envoy uses to verify the control-plane xDS server certificate.
     #[serde(default)]
     pub ca_path: Option<String>,
 }

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -133,8 +133,12 @@ flowplane --out .local/aws-dp-cert.json dataplane cert issue edge-local --team <
 
 jq -r '.certificate_pem' .local/aws-dp-cert.json > .local/aws-dp.crt
 jq -r '.private_key_pem' .local/aws-dp-cert.json > .local/aws-dp.key
-jq -r '.ca_certificate_pem' .local/aws-dp-cert.json > .local/aws-dp-ca.crt
+jq -r '.ca_certificate_pem' .local/aws-dp-cert.json > .local/aws-dp-client-chain-ca.crt
 chmod 600 .local/aws-dp.key
+
+# `ca_certificate_pem` is the dataplane client-chain CA. Use a separate xDS
+# server-trust CA bundle for `--ca-path`: the CA that validates xds.getflowplane.io.
+printf '%s' "$CP_XDS_SERVER_CA_PEM" > .local/aws-xds-server-ca.crt
 
 flowplane --out .local/aws-envoy.yaml dataplane bootstrap edge-local \
   --team <team> \
@@ -143,7 +147,7 @@ flowplane --out .local/aws-envoy.yaml dataplane bootstrap edge-local \
   --xds-port 18000 \
   --cert-path "$PWD/.local/aws-dp.crt" \
   --key-path "$PWD/.local/aws-dp.key" \
-  --ca-path "$PWD/.local/aws-dp-ca.crt"
+  --ca-path "$PWD/.local/aws-xds-server-ca.crt"
 ```
 
 Then run Envoy locally with the generated bootstrap and apply a simple route to verify xDS delivery.

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -7,7 +7,7 @@ plane:
 - RDS PostgreSQL in private subnets.
 - Public API through an ALB on HTTPS 443, forwarding to the task over HTTPS 8080.
 - Public xDS through an NLB on TCP 18000, preserving mTLS through to the Flowplane process.
-- NAT egress for private ECS tasks to reach external OIDC/JWKS providers such as Auth0.
+- NAT egress for private ECS tasks to reach external OIDC/JWKS providers.
 - No `FLOWPLANE_API_INSECURE=true`.
 
 The module intentionally does not manage Cloudflare DNS. Use the outputs to create records under
@@ -51,8 +51,8 @@ control_plane_image = "<account>.dkr.ecr.us-east-1.amazonaws.com/flowplane:<tag>
 
 api_certificate_arn = "arn:aws:acm:us-east-1:<account>:certificate/..."
 
-oidc_issuer   = "https://<tenant>.us.auth0.com/"
-oidc_audience = "<auth0-native-app-client-id>"
+oidc_issuer   = "https://your-issuer.example.com"
+oidc_audience = "your-api-audience"
 
 xds_ingress_cidrs = ["<your-public-ip>/32"]
 
@@ -66,13 +66,19 @@ cert_issuer_ca_cert_secret_arn   = "arn:aws:secretsmanager:..."
 cert_issuer_ca_key_secret_arn    = "arn:aws:secretsmanager:..."
 ```
 
-You can source OIDC values from `internal/.env.prod-local`:
+Set OIDC values from your identity provider. These are operator-provided deployment inputs, not
+repo-local files:
 
 ```bash
-set -a; source internal/.env.prod-local; set +a
-export TF_VAR_oidc_issuer="$FLOWPLANE_OIDC_ISSUER"
-export TF_VAR_oidc_audience="$FLOWPLANE_OIDC_AUDIENCE"
+export TF_VAR_oidc_issuer="https://your-issuer.example.com"
+export TF_VAR_oidc_audience="your-api-audience"
 ```
+
+`TF_VAR_oidc_issuer` must match the issuer in accepted tokens. `TF_VAR_oidc_audience` must match
+the Flowplane API audience configured in your IdP. For the full provider-neutral OIDC contract,
+including CLI client, callback URL, device-code support, scopes, JWKS override, CA bundle, and
+first-admin subject discovery, see
+[`docs/how-to/configure-oidc-provider.md`](../../docs/how-to/configure-oidc-provider.md).
 
 If you change `aws_region`, also change `availability_zones` to AZ names in that region. The module
 keeps AZs explicit so planning does not require `ec2:DescribeAvailabilityZones`.
@@ -123,7 +129,7 @@ flowplane auth login --device-code \
   --scope "openid email profile"
 
 flowplane dataplane create edge-local --team <team>
-flowplane --out .local/aws-dp-cert.json cert issue edge-local --team <team>
+flowplane --out .local/aws-dp-cert.json dataplane cert issue edge-local --team <team>
 
 jq -r '.certificate_pem' .local/aws-dp-cert.json > .local/aws-dp.crt
 jq -r '.private_key_pem' .local/aws-dp-cert.json > .local/aws-dp.key

--- a/deploy/aws/local.auto.tfvars.example
+++ b/deploy/aws/local.auto.tfvars.example
@@ -7,8 +7,8 @@ control_plane_image = "<account>.dkr.ecr.us-east-1.amazonaws.com/flowplane:<tag>
 
 api_certificate_arn = "arn:aws:acm:us-east-1:<account>:certificate/<id>"
 
-oidc_issuer   = "https://<tenant>.us.auth0.com/"
-oidc_audience = "<auth0-native-app-client-id>"
+oidc_issuer   = "https://your-issuer.example.com"
+oidc_audience = "your-api-audience"
 
 api_ingress_cidrs = ["0.0.0.0/0"]
 xds_ingress_cidrs = ["<your-public-ip>/32"]

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -40,7 +40,7 @@ variable "availability_zones" {
 }
 
 variable "enable_nat_gateway" {
-  description = "Create NAT egress for private ECS tasks. Required for external OIDC/JWKS providers such as Auth0 unless another egress path exists."
+  description = "Create NAT egress for private ECS tasks. Required for external OIDC/JWKS providers unless another egress path exists."
   type        = bool
   default     = true
 }
@@ -91,7 +91,7 @@ variable "api_certificate_arn" {
 }
 
 variable "oidc_issuer" {
-  description = "OIDC issuer URL. Auth0 is the verified provider, but this remains provider-agnostic."
+  description = "OIDC issuer URL."
   type        = string
 }
 

--- a/docs/how-to/ai-gateway-route-budget.md
+++ b/docs/how-to/ai-gateway-route-budget.md
@@ -55,7 +55,7 @@ This POSTs to `/api/v1/teams/{team}/ai/providers` and returns the provider view,
 
 ## 2. Create a route to the provider
 
-The route body is `{ "name", "spec" }`, where `spec` is the `AiRouteSpec`: a `listener_port`, a `path` (defaults to `/v1/chat/completions`, the only supported path in S10), and one or more `backends`. Each `AiRouteBackend` references a `provider_id`, optionally restricts which `models` it serves (empty = catch-all), and carries a `weight` (1–1000, default 1) and `priority` (default 0). Use `model_override` to rewrite the client's `model` to a specific upstream model.
+The route body is `{ "name", "spec" }`, where `spec` is the `AiRouteSpec`: a `listener_port`, a `path` (defaults to `/v1/chat/completions`, currently the only supported path), and one or more `backends`. Each `AiRouteBackend` references a `provider_id`, optionally restricts which `models` it serves (empty = catch-all), and carries a `weight` (1–1000, default 1) and `priority` (default 0). Use `model_override` to rewrite the client's `model` to a specific upstream model.
 
 `route.json`:
 

--- a/docs/how-to/ai-gateway-route-budget.md
+++ b/docs/how-to/ai-gateway-route-budget.md
@@ -14,6 +14,8 @@ The control plane must be running with `FLOWPLANE_SECRET_ENCRYPTION_KEY` set (a 
 
 With that key set, create a secret holding the provider API key — `flowplane secret create --file secret.json` — and note its UUID for `credential_secret_id` below.
 
+Request verification in step 4 needs a connected dataplane that can receive the materialized listener over xDS. The `flowplane ai routes create` command creates the cluster, route config, and listener in the control plane; it does not start Envoy. For a production-shaped setup, use a dataplane registered over mTLS by the platform team (see [Register a dataplane and connect its agent over mTLS](register-dataplane-mtls.md) and [Evaluate a production-shaped platform setup](evaluate-platform.md)).
+
 `secret.json` (the `secret` value is **standard base64** of the raw provider API key — produce it with `printf %s "$API_KEY" | base64`):
 
 ```json
@@ -130,7 +132,15 @@ flowplane ai budgets update chat-budget --file budget-enforce.json --revision <n
 
 ## 4. Verify
 
-Send a chat request through the listener port from the route (`19000` above). The request body must include a `model`; Flowplane routes it to an eligible backend and forwards to the provider:
+Before sending traffic, verify that a dataplane is connected and Envoy accepted the generated xDS resources:
+
+```bash
+flowplane stats overview --team <team>
+flowplane ops xds status --team <team>
+flowplane ops xds nacks --team <team>
+```
+
+Run the `curl` from a host that can reach the dataplane listener. In the local example below, that listener is reachable at `127.0.0.1:19000`; in a platform evaluation, use the listener address the platform team provides. The request body must include a `model`; Flowplane routes it to an eligible backend and forwards to the provider through Envoy:
 
 ```bash
 curl http://127.0.0.1:19000/v1/chat/completions \

--- a/docs/how-to/aws-secure-deployment.md
+++ b/docs/how-to/aws-secure-deployment.md
@@ -88,7 +88,7 @@ aws secretsmanager create-secret \
 
 Pass the secret's ARN to the module via `bootstrap_token_secret_arn`; it is injected into the CP task as `FLOWPLANE_BOOTSTRAP_TOKEN`. (If the secret uses a customer-managed KMS key, also add that key to `secret_kms_key_arns`.) On first boot the CP seeds the token's hash and logs a confirmation **without** the value.
 
-Then initialize the platform admin once, using the **same** token and your verified Auth0/OIDC subject:
+Then initialize the platform admin once, using the **same** token and your verified OIDC subject:
 
 ```bash
 curl -fsS -X POST https://cp.getflowplane.io/api/v1/bootstrap/initialize \
@@ -97,7 +97,7 @@ curl -fsS -X POST https://cp.getflowplane.io/api/v1/bootstrap/initialize \
   -d '{
         "org_name": "platform",
         "org_display_name": "Platform",
-        "admin_subject": "auth0|...",
+        "admin_subject": "<oidc-sub-of-first-admin>",
         "admin_email": "you@example.com"
       }'
 ```

--- a/docs/how-to/aws-secure-deployment.md
+++ b/docs/how-to/aws-secure-deployment.md
@@ -138,8 +138,16 @@ Write the PEM values to files:
 ```bash
 jq -r '.certificate_pem' .local/aws-dp-cert.json > .local/aws-dp.crt
 jq -r '.private_key_pem' .local/aws-dp-cert.json > .local/aws-dp.key
-jq -r '.ca_certificate_pem' .local/aws-dp-cert.json > .local/aws-dp-ca.crt
+jq -r '.ca_certificate_pem' .local/aws-dp-cert.json > .local/aws-dp-client-chain-ca.crt
 chmod 600 .local/aws-dp.key
+```
+
+`ca_certificate_pem` is the dataplane **client-chain CA** from the issue response. It is the CA the control plane trusts for the dataplane client certificate; it is not the CA Envoy uses to verify the control plane's xDS server certificate.
+
+Write the xDS **server-trust CA** to a separate file. This is the CA bundle that validates the certificate served by `xds.getflowplane.io`, from the same PKI material that produced your xDS server certificate secret:
+
+```bash
+printf '%s' "$CP_XDS_SERVER_CA_PEM" > .local/aws-xds-server-ca.crt
 ```
 
 Generate the local Envoy bootstrap:
@@ -152,7 +160,7 @@ flowplane --out .local/aws-envoy.yaml dataplane bootstrap edge-local \
   --xds-port 18000 \
   --cert-path "$PWD/.local/aws-dp.crt" \
   --key-path "$PWD/.local/aws-dp.key" \
-  --ca-path "$PWD/.local/aws-dp-ca.crt"
+  --ca-path "$PWD/.local/aws-xds-server-ca.crt"
 ```
 
 Run Envoy locally with `.local/aws-envoy.yaml`, then apply a simple route/listener and confirm the dataplane receives xDS without NACKs.

--- a/docs/how-to/aws-secure-deployment.md
+++ b/docs/how-to/aws-secure-deployment.md
@@ -1,5 +1,7 @@
 # AWS Secure Deployment Runbook
 
+> Audience: platform-engineers, operators · Status: stable
+
 This runbook is the concrete AWS packaging of Flowplane's provider-agnostic deployment invariants; it is self-contained — every step and value needed to stand up the environment is here.
 
 The target is a strict secure smoke environment:

--- a/docs/how-to/bootstrap-platform.md
+++ b/docs/how-to/bootstrap-platform.md
@@ -4,7 +4,7 @@
 
 A fresh, non-dev Flowplane control plane starts **uninitialized**: it has no platform organization and no admin. You initialize it once, with a one-shot **bootstrap token** that you supply — the control plane never generates or logs it.
 
-This page is self-contained: every value you need is here.
+Before starting, configure your OIDC provider and find the first admin's immutable subject. See [configure an OIDC provider](configure-oidc-provider.md).
 
 ## 1. Choose a bootstrap token
 
@@ -44,7 +44,9 @@ Then start the server normally (`flowplane serve`). On an uninitialized instance
 
 ## 3. Initialize the platform
 
-Call the public bootstrap endpoint once, passing the token as a bearer credential. `admin_subject` is the OIDC `sub` of your first admin (the identity your IdP will assert):
+Call the public bootstrap endpoint once, passing the token as a bearer credential. `admin_subject` is the OIDC `sub` of your first admin (the identity your IdP will assert). Use the exact `sub` string from your IdP; do not use email, username, or display name:
+
+If you do not yet know the subject, copy the stable user identifier from your IdP's user profile, decode the intended admin's own ID token locally and read `sub`, or call your IdP's userinfo endpoint with that user's own access token. Do not paste production tokens into third-party websites.
 
 ```bash
 curl -fsS -X POST https://<control-plane>/api/v1/bootstrap/initialize \
@@ -64,6 +66,7 @@ A success response returns the new `org_id` and `admin_user_id`. The token is no
 
 - Re-running the same `POST /api/v1/bootstrap/initialize` returns a conflict — the instance is initialized.
 - Your admin can now authenticate through your OIDC issuer and reach authenticated endpoints.
+- `flowplane auth whoami` shows the bootstrapped user as a platform admin after OIDC login.
 
 ## Next step
 
@@ -75,3 +78,4 @@ Bootstrap creates only the **platform org** (governance only — it cannot host 
 - **Server won't start, "a different bootstrap token is already active":** another replica was given a different token. Use one identical token across all replicas.
 - **"token is too short":** the token must be ≥ 32 characters after trimming whitespace.
 - **`401` on initialize:** the token is wrong, expired (24 h), or already used. Restart an uninitialized instance with a fresh token, or confirm you are sending the exact value you seeded.
+- **OIDC login works but the user is not platform admin:** the `admin_subject` used during bootstrap did not match the OIDC `sub` claim for that login. Check the subject discovery steps in [configure an OIDC provider](configure-oidc-provider.md).

--- a/docs/how-to/cli-auth-and-contexts.md
+++ b/docs/how-to/cli-auth-and-contexts.md
@@ -84,9 +84,9 @@ For each setting, the CLI walks these sources in order and uses the first one pr
 - **Server**: `--server` flag / `FLOWPLANE_SERVER` env → current context → config file `base_url` → default `http://127.0.0.1:8080`.
 - **Org**: `--org` flag → `FLOWPLANE_ORG` env → current context → config file `org`.
 - **Team**: `--team` flag → `FLOWPLANE_TEAM` env → current context → config file `team`.
-- **Token**: `FLOWPLANE_TOKEN` env → current context token → config file `token` → credentials file (`~/.flowplane/credentials`).
+- **Token**: `--token` flag / `FLOWPLANE_TOKEN` env → current context token → config file `token` → credentials file (`~/.flowplane/credentials`).
 
-The rule of thumb: **flag > env > config file**. The active context is whatever `--context` names, otherwise the `current_context` saved by `use-context`.
+The rule of thumb: **flag > env > selected context > config file > credentials/default**. The active context is whatever `--context` names, otherwise the `current_context` saved by `use-context`.
 
 ## Verify
 

--- a/docs/how-to/configure-oidc-provider.md
+++ b/docs/how-to/configure-oidc-provider.md
@@ -1,0 +1,126 @@
+# How-to: configure an OIDC provider
+
+> Audience: operators, platform-engineers · Status: stable
+
+Flowplane accepts user tokens from any OpenID Connect provider that publishes a discovery document and JWKS. The control plane validates identity; authorization still comes from Flowplane org membership, team membership, and grants.
+
+Use this page before bootstrapping the first platform admin. You need two OIDC integrations:
+
+- a control-plane API audience that Flowplane validates on every request;
+- a public CLI client that users can use with PKCE and, if supported by your IdP, device authorization.
+
+Do not use Flowplane dev mode for production identity. In non-dev deployments, authenticated endpoints fail closed when OIDC is missing or invalid.
+
+## 1. Create the API audience
+
+In your IdP, create or identify the API/resource that will issue tokens for Flowplane.
+
+Record:
+
+| Value | Flowplane setting | Notes |
+|-------|-------------------|-------|
+| Issuer URL | `FLOWPLANE_OIDC_ISSUER` | The exact issuer value in tokens and discovery metadata, for example `https://idp.example.com/realms/platform`. |
+| Audience | `FLOWPLANE_OIDC_AUDIENCE` | The expected `aud` claim for Flowplane API tokens. |
+| JWKS URI | `FLOWPLANE_OIDC_JWKS_URI` | Optional. Leave unset when discovery returns the correct `jwks_uri`. Set only when your IdP requires an override. |
+| CA bundle | `FLOWPLANE_OIDC_CA_BUNDLE` | Optional PEM bundle path for private enterprise roots or TLS-intercepting egress proxies. Invalid bundles fail startup closed. |
+
+The issuer and audience must be configured together on the control plane. With neither configured and dev mode off, authenticated endpoints return `503`; with only one configured, startup fails.
+
+## 2. Create the CLI client
+
+Create an OIDC/OAuth client for the `flowplane auth login` command.
+
+Required client properties:
+
+| Property | Value |
+|----------|-------|
+| Client type | Public/native client. Do not require a client secret for CLI login. |
+| Redirect URI | `http://127.0.0.1:8976/callback` unless you set `FLOWPLANE_OIDC_CALLBACK_URL` and register that exact callback. |
+| Grant types | Authorization code with PKCE. Device authorization is optional but recommended for headless operators. |
+| Scopes | At least `openid`; `email profile` are recommended so Flowplane can display useful user metadata. |
+| Audience/resource | Configure your IdP so issued tokens include the Flowplane API audience from step 1. |
+
+Record the CLI client id as `FLOWPLANE_OIDC_CLIENT_ID`. The CLI reads:
+
+```bash
+export FLOWPLANE_OIDC_ISSUER="https://idp.example.com/realms/platform"
+export FLOWPLANE_OIDC_CLIENT_ID="<flowplane-cli-client-id>"
+export FLOWPLANE_OIDC_SCOPE="openid email profile"
+export FLOWPLANE_OIDC_CALLBACK_URL="http://127.0.0.1:8976/callback"
+```
+
+Use device flow when your IdP advertises `device_authorization_endpoint`:
+
+```bash
+flowplane auth login --device-code \
+  --issuer "$FLOWPLANE_OIDC_ISSUER" \
+  --client-id "$FLOWPLANE_OIDC_CLIENT_ID" \
+  --scope "$FLOWPLANE_OIDC_SCOPE"
+```
+
+Use PKCE browser login otherwise:
+
+```bash
+flowplane auth login --pkce \
+  --issuer "$FLOWPLANE_OIDC_ISSUER" \
+  --client-id "$FLOWPLANE_OIDC_CLIENT_ID" \
+  --callback-url "$FLOWPLANE_OIDC_CALLBACK_URL" \
+  --scope "$FLOWPLANE_OIDC_SCOPE"
+```
+
+## 3. Configure the control plane
+
+Set OIDC on every control-plane replica:
+
+```bash
+export FLOWPLANE_OIDC_ISSUER="https://idp.example.com/realms/platform"
+export FLOWPLANE_OIDC_AUDIENCE="<flowplane-api-audience>"
+```
+
+Optional overrides:
+
+```bash
+export FLOWPLANE_OIDC_JWKS_URI="https://idp.example.com/realms/platform/protocol/openid-connect/certs"
+export FLOWPLANE_OIDC_CA_BUNDLE="/etc/flowplane/trust/enterprise-ca.pem"
+```
+
+Only set `FLOWPLANE_OIDC_CA_BUNDLE` when the control plane must trust a private or intercepted TLS path to fetch OIDC discovery and JWKS. The bundle adds trust; it does not disable normal certificate validation.
+
+## 4. Find the first admin's OIDC subject
+
+`admin_subject` is the immutable OIDC `sub` claim for the first platform admin. It is not an email address, display name, username, or group name.
+
+Use one of these safe methods:
+
+- In your IdP admin UI, open the user profile and copy the stable user identifier that the IdP emits as `sub`.
+- Run a temporary OIDC login for the intended admin and inspect that user's own ID token with a local JWT decoder. Decode only tokens from your own account; do not paste production tokens into third-party websites.
+- If your IdP has a userinfo endpoint, call it with the intended admin's own access token and copy the `sub` field from the response.
+
+Keep a note of the exact string for bootstrap:
+
+```text
+admin_subject = "<oidc-sub-of-first-admin>"
+```
+
+The value is safe to store in configuration management as an identifier, but it is still account metadata. Do not use a real subject in public examples.
+
+## 5. Verify after bootstrap
+
+After [bootstrapping the first platform admin](bootstrap-platform.md), log in as that same user and confirm Flowplane resolved the platform-admin identity:
+
+```bash
+flowplane auth login --device-code \
+  --issuer "$FLOWPLANE_OIDC_ISSUER" \
+  --client-id "$FLOWPLANE_OIDC_CLIENT_ID"
+
+flowplane auth whoami
+```
+
+If login succeeds but `whoami` does not show platform-admin access, re-check the exact `sub` used during bootstrap. Email and display-name changes do not affect `sub`; using email as `admin_subject` will not match the OIDC identity.
+
+## Troubleshooting
+
+- **Authenticated endpoints return `503`:** the control plane is running without a complete OIDC issuer/audience pair and dev mode is off. Configure both `FLOWPLANE_OIDC_ISSUER` and `FLOWPLANE_OIDC_AUDIENCE`.
+- **Startup fails on OIDC config:** check that issuer and audience are set together and that `FLOWPLANE_OIDC_CA_BUNDLE`, if set, points to a readable PEM bundle.
+- **CLI says the provider has no device endpoint:** use `flowplane auth login --pkce`, or enable device authorization for the CLI client in your IdP.
+- **Tokens validate at the IdP but Flowplane rejects them:** confirm the token issuer equals `FLOWPLANE_OIDC_ISSUER`, the audience includes `FLOWPLANE_OIDC_AUDIENCE`, and the control plane can fetch discovery and JWKS.

--- a/docs/how-to/create-tenant-org-and-team.md
+++ b/docs/how-to/create-tenant-org-and-team.md
@@ -50,7 +50,7 @@ that, the org's own owners/admins manage membership.
 Identify the user by their immutable OIDC subject (preferred), or by email:
 
 ```bash
-flowplane org member add edgeco --role owner --subject "auth0|6650f0..."
+flowplane org member add edgeco --role owner --subject <oidc-sub-of-first-owner>
 # or:  flowplane org member add edgeco --role owner --email you@example.com
 ```
 
@@ -104,3 +104,5 @@ tenant orgs and send no selector; the fix is the same: name the tenant org with
 
 - [Register a dataplane and connect its agent over mTLS](register-dataplane-mtls.md)
   — create a dataplane under the `edgeco` / `payments` org+team you just made.
+- [Manage users, teams, and grants](manage-users-teams-and-grants.md)
+  — add API-team users and grant least-privilege access inside the tenant org.

--- a/docs/how-to/evaluate-platform.md
+++ b/docs/how-to/evaluate-platform.md
@@ -125,7 +125,7 @@ At the end of this evaluation, the platform team owns:
 - dataplane registration policy and certificate issuance policy;
 - production xDS and diagnostics network paths.
 
-API teams should receive a control-plane URL, org/team names, granted permissions, and a CLI login path. The API-team self-service flow is covered separately by the API-team onboarding guide.
+API teams should receive a control-plane URL, org/team names, granted permissions, and a CLI login path. The API-team self-service flow is covered in [Onboard an API team](onboard-api-team.md).
 
 ## References
 
@@ -133,6 +133,8 @@ API teams should receive a control-plane URL, org/team names, granted permission
 - [Configure an OIDC provider](configure-oidc-provider.md)
 - [Bootstrap the first platform admin](bootstrap-platform.md)
 - [Create a tenant org and a team](create-tenant-org-and-team.md)
+- [Manage users, teams, and grants](manage-users-teams-and-grants.md)
+- [Onboard an API team](onboard-api-team.md)
 - [Register a dataplane and connect its agent over mTLS](register-dataplane-mtls.md)
 - [Configuration reference](../reference/configuration.md)
 - [CLI reference](../reference/cli.md)

--- a/docs/how-to/evaluate-platform.md
+++ b/docs/how-to/evaluate-platform.md
@@ -1,0 +1,140 @@
+# How-to: evaluate a production-shaped platform setup
+
+> Audience: platform-engineers, operators · Status: stable
+
+This runbook is the platform evaluation spine. It links the canonical setup and reference pages in the order an outside platform team needs them: control plane, identity, bootstrap, tenant/team, dataplane mTLS, health/readiness/xDS, and observability.
+
+Use this when you are evaluating whether Flowplane can be deployed, governed, and delegated inside an organization. It does not replace the canonical task pages it links to.
+
+## Prerequisites
+
+You need:
+
+- a Flowplane release image or binary for the control plane;
+- PostgreSQL and TLS material for the API and xDS listeners;
+- OIDC provider values from [Configure an OIDC provider](configure-oidc-provider.md);
+- a high-entropy bootstrap token delivered by `FLOWPLANE_BOOTSTRAP_TOKEN_FILE` or `FLOWPLANE_BOOTSTRAP_TOKEN`;
+- a `flowplane` CLI installed on the operator workstation;
+- a dataplane host that can run Envoy and `fp-agent`.
+
+Use placeholders in examples until you substitute your own values. Do not put real tokens, private keys, or certificate PEM bodies in public docs, issue comments, or shell history.
+
+## 1. Start the control plane in production shape
+
+Follow [Production Readiness](production-readiness.md) for the control-plane environment. At minimum the first boot needs:
+
+- database URL;
+- secret-encryption key material;
+- API TLS certificate and key;
+- xDS server certificate, key, and dataplane client CA;
+- OIDC issuer and audience;
+- bootstrap token file or token value.
+
+After migration and startup, verify the root operational endpoints:
+
+```bash
+curl -fsS https://cp.example/healthz
+curl -fsS https://cp.example/readyz
+curl -fsS https://cp.example/metrics | head
+```
+
+`/healthz`, `/readyz`, and `/metrics` are public operational endpoints. They prove the process is reachable; they do not prove tenant access or xDS delivery.
+
+## 2. Connect OIDC and bootstrap the first platform admin
+
+Use [Configure an OIDC provider](configure-oidc-provider.md) to set the issuer, audience, optional JWKS override, CLI client, callback URL, device-code support, scopes, and optional CA bundle.
+
+Then use [Bootstrap the first platform admin](bootstrap-platform.md). The bootstrap call consumes the one-shot operator-supplied token and creates the platform org and first platform admin.
+
+Verify the admin identity:
+
+```bash
+flowplane auth login --device-code \
+  --issuer https://issuer.example \
+  --client-id flowplane-cli
+
+flowplane config set-context platform \
+  --server https://cp.example
+
+flowplane config use-context platform
+flowplane auth whoami
+```
+
+The platform org is governance-only. It cannot host tenant teams, dataplanes, or gateway resources.
+
+## 3. Create a tenant org and team
+
+Follow [Create a tenant org and a team](create-tenant-org-and-team.md). The important boundary is:
+
+- platform admin can create tenant orgs and seed the first owner;
+- tenant teams own dataplanes and gateway resources;
+- platform-admin status is not a tenant bypass.
+
+Save an operator context for the tenant team:
+
+```bash
+flowplane config set-context edgeco-payments \
+  --server https://cp.example \
+  --org edgeco \
+  --team payments
+
+flowplane config use-context edgeco-payments
+flowplane team list --org edgeco
+```
+
+## 4. Register and connect a dataplane over mTLS
+
+Use [Register a dataplane and connect its agent over mTLS](register-dataplane-mtls.md). That page remains the canonical mTLS dataplane runbook.
+
+The expected direction is outbound from the dataplane to the control plane:
+
+- Envoy opens ADS/SDS streams to the control-plane xDS listener.
+- `fp-agent` reports dataplane diagnostics to the control plane.
+- The control plane does not call Envoy admin as a product path.
+- Envoy admin remains local to the dataplane and is a manual diagnostic surface.
+
+Verify the dataplane:
+
+```bash
+curl -fsS http://127.0.0.1:19902/healthz
+
+flowplane dataplane get edge-gateway-1 --team payments
+flowplane stats overview --team payments
+flowplane ops xds status --team payments
+flowplane ops xds nacks --team payments
+```
+
+`dataplane get` should show an advancing heartbeat once `fp-agent` reports. `stats overview` should count the dataplane as live. `ops xds status` / `ops xds nacks` should show whether Envoy accepted or rejected the pushed xDS resources.
+
+## 5. Verify observability
+
+Confirm metrics are scrapeable from the control plane:
+
+```bash
+curl -fsS https://cp.example/metrics | grep -E 'fp_api_requests_total|fp_xds_ads_streams_opened_total|fp_db_pool_'
+```
+
+Use [Observability Alert Pack](../reference/observability-alerts.md) as the baseline metric inventory, alert set, and dashboard panel list. Keep alert labels low-cardinality; do not add team, org, dataplane, route, budget, tool, or agent labels unless you have accepted the cardinality cost.
+
+## 6. Decide what the platform owns
+
+At the end of this evaluation, the platform team owns:
+
+- control-plane deployment, database, TLS, OIDC, bootstrap, backup/restore, and observability;
+- tenant org creation and first-owner handoff;
+- dataplane registration policy and certificate issuance policy;
+- production xDS and diagnostics network paths.
+
+API teams should receive a control-plane URL, org/team names, granted permissions, and a CLI login path. The API-team self-service flow is covered separately by the API-team onboarding guide.
+
+## References
+
+- [Production Readiness](production-readiness.md)
+- [Configure an OIDC provider](configure-oidc-provider.md)
+- [Bootstrap the first platform admin](bootstrap-platform.md)
+- [Create a tenant org and a team](create-tenant-org-and-team.md)
+- [Register a dataplane and connect its agent over mTLS](register-dataplane-mtls.md)
+- [Configuration reference](../reference/configuration.md)
+- [CLI reference](../reference/cli.md)
+- [REST API reference](../reference/rest-api.md)
+- [Observability Alert Pack](../reference/observability-alerts.md)

--- a/docs/how-to/global-rate-limit.md
+++ b/docs/how-to/global-rate-limit.md
@@ -14,7 +14,7 @@ shaped this way (separate process, namespaced counters, fail modes), read
 
 **Prerequisites**
 
-- A running control plane and a real Envoy joined over xDS — the [getting-started tutorial](../tutorials/getting-started.md) gets you here, including a listener (`edge`), a route-config (`api-routes`), and a cluster (e.g. `httpbin`) that traffic already flows to.
+- A running control plane and a real Envoy joined over xDS, with a listener, route-config, and cluster that already route traffic. The [getting-started tutorial](../tutorials/getting-started.md) gets you here with the `local` resource set on listener port `10001`; the examples below use sample names such as `edge`, `api-routes`, and `httpbin`, so substitute your actual resource names.
 - The CLI authenticated against your control plane (`flowplane auth …` or `FLOWPLANE_SERVER`/`FLOWPLANE_TOKEN`) — see [CLI auth & contexts](cli-auth-and-contexts.md). Examples below use team `default`.
 - The `flowplane-rls` binary built/available (`cargo build --bin flowplane-rls`, or your release artifact).
 
@@ -160,7 +160,7 @@ curl -fsS http://127.0.0.1:9901/config_dump | grep -oE '[0-9a-f-]{36}\|[0-9a-f-]
 # 16d8d7aa-7842-8166-88ac-c72392a9d771|04c9f1e3-3f4f-8e5d-8f75-5c5bb671fd58|checkout
 ```
 
-(`9901` is the Envoy admin port from your bootstrap.) Then send traffic through the gateway. The
+(`9901` is the Envoy admin port from your bootstrap.) Then send traffic through the gateway listener. Replace `10000` with your listener port; the getting-started tutorial uses `10001`. The
 first 100 requests in the minute pass; the 101st is rate-limited:
 
 ```bash

--- a/docs/how-to/manage-users-teams-and-grants.md
+++ b/docs/how-to/manage-users-teams-and-grants.md
@@ -1,0 +1,127 @@
+# How-to: manage users, teams, and grants
+
+> Audience: platform-engineers, operators · Status: stable
+
+Use this runbook to move from a tenant org to users, team membership, and least-privilege grants. It is the lifecycle companion to [Create a tenant org and a team](create-tenant-org-and-team.md) and [Onboard an API team](onboard-api-team.md).
+
+## Ownership model
+
+Flowplane has three separate administration layers:
+
+- platform admin creates tenant orgs and can seed the first tenant owner;
+- tenant org owners/admins manage org members, teams, team members, and team grants inside their own org;
+- API-team users exercise only the team grants they have been given, unless they are also org owners/admins.
+
+The platform org is governance-only. It cannot host tenant teams, dataplanes, or gateway resources, and platform-admin status does not grant tenant-resource access.
+
+## 1. Add users to the tenant org
+
+The user must sign in once before they can be added by email or subject. Add them to the tenant org with the smallest org role that fits:
+
+```bash
+flowplane org member add edgeco --email api-dev@example.com --role member
+flowplane org member list edgeco
+```
+
+Use `--subject <oidc-sub>` instead of `--email` when you need to bind the exact immutable OIDC subject:
+
+```bash
+flowplane org member add edgeco --subject <oidc-sub-of-api-dev> --role member
+```
+
+Use `admin` or `owner` only for people who should manage teams and grants across the tenant org. Org admins and owners have implicit access to tenant resources in their org; ordinary API-team users should use explicit team grants.
+
+## 2. Create or select the team
+
+Create the team while selecting the tenant org:
+
+```bash
+flowplane team create payments --org edgeco --display-name "Payments"
+flowplane team list --org edgeco
+```
+
+Team names are tenant-scoped. Keep API teams in tenant orgs, never in the platform org.
+
+## 3. Add team members
+
+Add org users to the team:
+
+```bash
+flowplane team member add api-dev@example.com --org edgeco --team payments
+flowplane team member list --org edgeco --team payments
+```
+
+Team membership lets the team roster be managed and inspected. Resource access still comes from org-admin status or explicit grants.
+
+## 4. Grant the API-team workflow
+
+Grant the smallest resource/action set for the task. For a user who imports an OpenAPI document, publishes it, and verifies MCP tools:
+
+```bash
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource api-definitions --action create
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource api-definitions --action read
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource api-definitions --action update
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource mcp-tools --action read
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource mcp-tools --action update
+```
+
+Add gateway modeling grants only if the API team will create or update the route/listener resources themselves:
+
+```bash
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource clusters --action create
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource clusters --action read
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource route-configs --action create
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource route-configs --action read
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource listeners --action create
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource listeners --action read
+```
+
+For learning/discovery, add the learning-session actions the workflow needs:
+
+```bash
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource learning-sessions --action create
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource learning-sessions --action read
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource learning-sessions --action execute
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource learning-sessions --action delete
+```
+
+The grant vocabulary is closed. Tenant resource strings are `clusters`, `route-configs`, `listeners`, `filters`, `secrets`, `dataplanes`, `proxy-certificates`, `agents`, `grants`, `api-definitions`, `learning-sessions`, `mcp-tools`, `rate-limits`, `ai-providers`, `ai-routes`, `ai-budgets`, `ai-usage`, and `stats`. Actions are `read`, `create`, `update`, `delete`, and `execute`. Governance resources such as `organizations`, `users`, `teams`, `audit`, and `platform` cannot be granted at team scope.
+
+## 5. Audit and revoke
+
+List grants before and after changes:
+
+```bash
+flowplane team grant list --org edgeco --team payments
+```
+
+Revoke by grant id:
+
+```bash
+flowplane team grant remove <grant-id> --org edgeco --team payments
+```
+
+Remove team membership when the user no longer belongs on the team:
+
+```bash
+flowplane team member remove <user-id> --org edgeco --team payments
+```
+
+Remove org membership only after checking that you are not removing the last owner:
+
+```bash
+flowplane org member remove edgeco <user-id>
+```
+
+## 6. Handoff to the API team
+
+Give the API team:
+
+- control-plane URL;
+- tenant org and team names;
+- OIDC CLI login values;
+- the grants they received;
+- whether a listener binding already exists;
+- which guide to follow next: [Onboard an API team](onboard-api-team.md).
+
+Do not send bootstrap tokens, bearer tokens, private keys, provider API keys, or certificate PEM bodies in the handoff.

--- a/docs/how-to/onboard-api-team.md
+++ b/docs/how-to/onboard-api-team.md
@@ -1,0 +1,142 @@
+# How-to: onboard an API team
+
+> Audience: api-teams, platform-engineers · Status: stable
+
+Use this guide when a platform team has already deployed Flowplane and wants an API team to self-serve one API without platform-admin credentials. The path starts from the handoff values the platform team provides and ends with a published API spec and verified MCP tools.
+
+This page is the handoff spine. It links to the canonical task pages for CLI auth, OpenAPI import, learning, gateway resource bodies, and dataplane mTLS instead of duplicating them.
+
+## Prerequisites
+
+You need these values from the platform team:
+
+- control-plane URL, for example `https://cp.example`;
+- tenant org name, for example `edgeco`;
+- team name, for example `payments`;
+- OIDC CLI login values: issuer URL, CLI client id, scopes, and whether device-code or browser login is enabled;
+- confirmation that your identity has been added to the org and team;
+- grants for the resources you need in this team.
+
+For a simple API onboarding evaluation, ask for these team grants:
+
+```bash
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource api-definitions --action create
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource api-definitions --action read
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource api-definitions --action update
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource mcp-tools --action read
+flowplane team grant add api-dev@example.com --org edgeco --team payments --resource mcp-tools --action update
+```
+
+If the API team will create gateway resources or route-generation plans, also ask for the relevant `clusters`, `route-configs`, and `listeners` `create/read/update` grants. If they will learn from traffic, ask for `learning-sessions` `create/read/execute/delete` as needed. If they only publish against a platform-provided listener binding, they do not need broad dataplane or platform-admin rights.
+
+Flowplane deliberately separates these roles:
+
+- platform teams own the control plane, OIDC, bootstrap, tenant creation, dataplane registration policy, certificate policy, and production xDS paths;
+- tenant org owners/admins own org membership, team membership, and team grants;
+- API teams own API import or learning, publish gates, and tool verification inside their team scope.
+
+Platform-admin status is not a tenant bypass. The platform org cannot host tenant teams, dataplanes, or gateway resources.
+
+## 1. Log in and select the tenant team
+
+Use the login method your platform team enabled. Device-code login is common for CLI-only evaluation:
+
+```bash
+flowplane auth login --device-code \
+  --issuer https://issuer.example \
+  --client-id flowplane-cli
+```
+
+Create a context that includes the control-plane URL, tenant org, and team:
+
+```bash
+flowplane config set-context edgeco-payments \
+  --server https://cp.example \
+  --org edgeco \
+  --team payments
+
+flowplane config use-context edgeco-payments
+flowplane auth whoami
+```
+
+`auth whoami` should show the authenticated user, the active tenant org, and the grants available to this identity. If it reports that an org selector is required, keep `--org edgeco` in the context or pass it on commands.
+
+For the full auth and context behavior, see [CLI auth and contexts](cli-auth-and-contexts.md).
+
+## 2. Verify team access
+
+Confirm that the tenant org and team are visible:
+
+```bash
+flowplane team list --org edgeco
+flowplane team member list --team payments
+flowplane team grant list --team payments
+```
+
+Then check whether gateway resources already exist:
+
+```bash
+flowplane cluster list --team payments
+flowplane route list --team payments
+flowplane listener list --team payments
+```
+
+If these commands return `403`, use the error's `(resource, action)` hint to request the smallest missing grant. If the team is not found, confirm the org/team names and that your identity is a member of the tenant org.
+
+## 3. Choose the API onboarding path
+
+Use one of these paths:
+
+- If you already have an OpenAPI document, follow [Import and publish an OpenAPI spec](import-and-publish-openapi-spec.md).
+- If you need Flowplane to infer the spec from traffic, follow [Learn and publish an API spec version](learn-and-publish-api-spec.md).
+
+If tools must be callable, the API needs a listener binding. That can be a platform-provided route/listener pair, resources created by the API team, or a route generated from the API spec. The public gateway body examples are in [REST API reference: gateway resource request bodies](../reference/rest-api.md#gateway-resource-request-bodies).
+
+Publishing an API spec makes MCP tools listed and authorized. Actual upstream calls still go through Envoy; the control plane returns invocation descriptors and does not proxy request traffic.
+
+## 4. Publish and verify tools
+
+After import or learning, publish the reviewed spec version:
+
+```bash
+flowplane api spec publish catalog 1 --team payments --reason "API team evaluation"
+```
+
+Verify what became callable:
+
+```bash
+flowplane api status catalog --team payments
+flowplane mcp status --team payments
+```
+
+Success looks like:
+
+- the API status shows a published spec version;
+- `tool_count` is greater than zero;
+- `mcp status` shows the team's dynamic enabled tool count increased;
+- tool calls have a listener/dataplane route if they need to invoke the upstream through Envoy.
+
+If publishing succeeds but a tool call fails with no listener/dataplane route, ask the platform team for the listener binding details or the grants needed to create/bind a listener.
+
+## 5. Verify the dataplane path when needed
+
+For a production-shaped evaluation, the platform team should already have registered and connected a dataplane over mTLS. Ask for the listener address clients can reach and the `stats:read` grant if you are expected to run team-scoped diagnostics:
+
+```bash
+flowplane stats overview --team payments
+flowplane ops xds status --team payments
+flowplane ops xds nacks --team payments
+```
+
+Those checks prove the control plane is serving xDS state and Envoy is accepting or rejecting it. The canonical dataplane setup task is [Register a dataplane and connect its agent over mTLS](register-dataplane-mtls.md).
+
+## Handoff back to platform
+
+Send the platform team these results:
+
+- the API name and published spec version;
+- the `api status` and `mcp status` output;
+- any missing `(resource, action)` grant from `403` errors;
+- whether a listener binding exists and which dataplane/listener address was used for smoke traffic.
+
+Do not share bearer tokens, provider API keys, bootstrap tokens, private keys, or certificate PEM bodies in the handoff.

--- a/docs/how-to/production-readiness.md
+++ b/docs/how-to/production-readiness.md
@@ -1,11 +1,15 @@
 # Production Readiness
 
-This is the S12f operator entry point. It describes the shipped v1.0 system only: no new product behavior, no dashboard renderer, and no normal workflow that depends on Envoy admin.
+> Audience: operators, platform-engineers · Status: stable
+
+This is the operator entry point for a production-shaped Flowplane deployment. It describes the control plane, dataplane, identity, bootstrap, the Rate Limit Service (`flowplane-rls`), and operating checks using public docs only.
 
 ## Evidence
 
 - Secret KEK rotation: [`secret-kek-rotation.md`](secret-kek-rotation.md)
-- Engineering evidence — release packaging, the failure-mode matrix, the adversarial surface map, and the dev-dataplane walkthrough — lives in the internal engineering docs: [`../../internal/README.md`](../../internal/README.md).
+- OIDC setup and first-admin subject discovery: [`configure-oidc-provider.md`](configure-oidc-provider.md)
+- First platform admin bootstrap: [`bootstrap-platform.md`](bootstrap-platform.md)
+- Configuration reference: [`../reference/configuration.md`](../reference/configuration.md)
 
 ## Deployment Shape
 
@@ -14,18 +18,24 @@ Deploy the control plane and dataplane bundle separately.
 Control plane:
 
 ```bash
-FLOWPLANE_DATABASE_URL=postgres://user:pass@postgres/flowplane \
-FLOWPLANE_SECRET_ENCRYPTION_KEY=<32-byte-or-base64-key> \
-FLOWPLANE_API_TLS_CERT=/etc/flowplane/tls/api.crt \
-FLOWPLANE_API_TLS_KEY=/etc/flowplane/tls/api.key \
-FLOWPLANE_XDS_TLS_CERT=/etc/flowplane/tls/xds.crt \
-FLOWPLANE_XDS_TLS_KEY=/etc/flowplane/tls/xds.key \
-FLOWPLANE_XDS_TLS_CLIENT_CA=/etc/flowplane/tls/dp-ca.crt \
-FLOWPLANE_OIDC_ISSUER=https://issuer.example \
-FLOWPLANE_OIDC_AUDIENCE=flowplane \
+export FLOWPLANE_DATABASE_URL=postgres://user:pass@postgres/flowplane
+export FLOWPLANE_SECRET_ENCRYPTION_KEY=<32-byte-or-base64-key>
+export FLOWPLANE_BOOTSTRAP_TOKEN_FILE=/run/secrets/flowplane-bootstrap-token
+export FLOWPLANE_API_TLS_CERT=/etc/flowplane/tls/api.crt
+export FLOWPLANE_API_TLS_KEY=/etc/flowplane/tls/api.key
+export FLOWPLANE_XDS_TLS_CERT=/etc/flowplane/tls/xds.crt
+export FLOWPLANE_XDS_TLS_KEY=/etc/flowplane/tls/xds.key
+export FLOWPLANE_XDS_TLS_CLIENT_CA=/etc/flowplane/tls/dp-ca.crt
+export FLOWPLANE_OIDC_ISSUER=https://issuer.example
+export FLOWPLANE_OIDC_AUDIENCE=flowplane
+
 flowplane db migrate
 flowplane serve
 ```
+
+On the first boot of an uninitialized non-dev control plane, provide a high-entropy bootstrap token with `FLOWPLANE_BOOTSTRAP_TOKEN_FILE` (preferred) or `FLOWPLANE_BOOTSTRAP_TOKEN`. The server stores only a hash, does not log the value, and fails closed if no token is supplied. Use [Bootstrap the first platform admin](bootstrap-platform.md) to consume it once.
+
+Production authentication requires a real OIDC issuer/audience pair. `FLOWPLANE_DEV_MODE` and `FLOWPLANE_ALLOW_LOGGED_BOOTSTRAP_TOKEN` are local-only escape hatches and must not be set in production.
 
 Dataplane:
 
@@ -60,10 +70,12 @@ Server process:
 | Database | `FLOWPLANE_DATABASE_URL` or `DATABASE_URL`, `FLOWPLANE_DB_MAX_CONNECTIONS` |
 | Secret encryption | `FLOWPLANE_SECRET_ENCRYPTION_KEY`, `FLOWPLANE_SECRET_ENCRYPTION_KEY_ID`, `FLOWPLANE_SECRET_ENCRYPTION_KEYS` |
 | Auth | `FLOWPLANE_OIDC_ISSUER`, `FLOWPLANE_OIDC_AUDIENCE`, `FLOWPLANE_OIDC_JWKS_URI`, `FLOWPLANE_OIDC_CA_BUNDLE` (operator CA for an IdP behind a TLS-intercepting proxy; additive trust, fail-closed at startup) |
+| Bootstrap | `FLOWPLANE_BOOTSTRAP_TOKEN_FILE` (preferred) or `FLOWPLANE_BOOTSTRAP_TOKEN` for first boot only |
 | Dev only | `FLOWPLANE_DEV_MODE`, `FLOWPLANE_DEV_MODE_ACK` |
 | Observability | `FLOWPLANE_LOG`, `FLOWPLANE_LOG_FORMAT`, `FLOWPLANE_OTLP_ENDPOINT` |
 | MCP | `FLOWPLANE_MCP_ALLOWED_ORIGINS` |
 | Throttling/discovery | `FLOWPLANE_TENANT_WRITE_LIMIT_PER_MIN`, `FLOWPLANE_DISCOVERY_ALLOWED_DESTINATIONS` |
+| Rate Limit Service (`flowplane-rls`) | `FLOWPLANE_RLS_GRPC_URL`, `FLOWPLANE_RLS_ADMIN_URL`, `FLOWPLANE_RLS_RECONCILE_SECS`; in production also set the `FLOWPLANE_DATAPLANE_TLS_*` triad for the Envoy-to-RLS hop |
 | Dataplane cert issuer | `FLOWPLANE_CERT_ISSUER_CA_CERT_PATH`, `FLOWPLANE_CERT_ISSUER_CA_KEY_PATH`, `FLOWPLANE_CERT_ISSUER_TRUST_DOMAIN` |
 | Upstream TLS trust | `FLOWPLANE_UPSTREAM_CA_BUNDLE` (CA bundle path **in the Envoy/dataplane container** used to verify materialized TLS upstreams; default `/etc/ssl/certs/ca-certificates.crt`) |
 
@@ -98,15 +110,15 @@ AI providers, routes, budgets, and usage are runtime product config through the 
 
 | Symptom | Signals | Action |
 | --- | --- | --- |
-| CP unavailable | `/healthz` fails, API unavailable | Check process logs, TLS material, listener bind, and DB reachability. Restart CP. Existing DPs keep last-applied config. |
+| CP unavailable | `/healthz` fails, API unavailable | Check process logs, TLS material, listener bind, bootstrap token on first boot, OIDC config, and DB reachability. Restart CP. Existing DPs keep last-applied config. |
 | DB degraded/down | `/readyz` fails, `fp_db_pool_*` saturation, DB connection errors | Restore DB connectivity. Expect REST mutations to fail while DB is down. Run `flowplane db migrate` after restore before serving traffic. |
 | xDS NACK/quarantine | `fp_xds_nacks_total`, `fp_xds_quarantined_resources_total`, translation failure counters | Inspect the rejected resource in CP logs/audit. Fix the persisted CP resource and republish; do not patch Envoy admin directly. |
 | Dataplane disconnect churn | `fp_xds_ads_streams_closed_total` rising faster than opens | Check DP network path to CP xDS, mTLS cert validity, and agent/Envoy process health. |
 | Outbox lag/failures | `fp_outbox_pending_events`, `fp_outbox_oldest_pending_age_seconds`, `fp_outbox_handler_failures_total` | Check DB health and CP logs. Restart CP if the consumer is wedged; outbox redelivery is expected after recovery. |
-| Auth spike | `fp_authn_failures_total`, `fp_authz_denied_total`, audit rows | For authn, check IdP/JWKS/token expiry. For authz, check grants/team context and suspicious probing. |
+| Auth spike | `fp_authn_failures_total`, `fp_authz_denied_total`, audit rows | For authn, check IdP/JWKS/audience/token expiry. For authz, check grants/team context and suspicious probing. |
 | AI budget exhaustion | `fp_ai_budget_threshold_crossings_total{mode="enforcing",result="exhausted"}` | Compare expected usage to configured budget; raise budget or reduce traffic. |
 | Capture drops | `fp_capture_dropped_total` | Check capture source health and configured discovery/capture constraints. |
-| Release package validation | `SHA256SUMS`, `flowplane-*.oci.tar`, binary `file` output | Verify checksums and static binary signal (release-packaging details are in the internal engineering docs); rebuild artifacts if any hash differs. |
+| Release package validation | `SHA256SUMS`, `flowplane-*.oci.tar`, binary `file` output | Verify checksums and static binary signal; rebuild artifacts if any hash differs. |
 
 ## Backup And Restore Drill
 
@@ -178,4 +190,4 @@ scripts/release/package-release.sh
 FLOWPLANE_PACKAGE_IMAGE=1 scripts/release/package-release.sh
 ```
 
-The failure-mode matrix and adversarial surface map (in the internal engineering docs) are release evidence, not day-to-day operator runbooks.
+For deployment-specific details, use the relevant public runbook such as [AWS secure deployment](aws-secure-deployment.md). Keep release evidence separate from day-to-day operator runbooks.

--- a/docs/how-to/production-readiness.md
+++ b/docs/how-to/production-readiness.md
@@ -9,6 +9,8 @@ This is the operator entry point for a production-shaped Flowplane deployment. I
 - Secret KEK rotation: [`secret-kek-rotation.md`](secret-kek-rotation.md)
 - OIDC setup and first-admin subject discovery: [`configure-oidc-provider.md`](configure-oidc-provider.md)
 - First platform admin bootstrap: [`bootstrap-platform.md`](bootstrap-platform.md)
+- Platform evaluation sequence: [`evaluate-platform.md`](evaluate-platform.md)
+- Observability baseline: [`../reference/observability-alerts.md`](../reference/observability-alerts.md)
 - Configuration reference: [`../reference/configuration.md`](../reference/configuration.md)
 
 ## Deployment Shape

--- a/docs/how-to/register-dataplane-mtls.md
+++ b/docs/how-to/register-dataplane-mtls.md
@@ -4,7 +4,7 @@
 
 This how-to walks one task end to end: **register a dataplane, issue its mTLS client certificate, and connect `fp-agent`.** It assumes you already run Flowplane day to day and have a working CLI context (server URL, org, team, token).
 
-It assumes the control plane is already running with xDS mTLS configured. The xDS listener is **always** mTLS in production — there is no plaintext mode off loopback. If you have not stood that up yet, do the [Getting started tutorial](../tutorials/getting-started.md) first and set the `FLOWPLANE_XDS_TLS_*` triad as described in the [configuration reference](../reference/configuration.md).
+It assumes the control plane is already running with xDS mTLS configured. The xDS listener is **always** mTLS in production — there is no plaintext mode off loopback. If you have not stood that up yet, start with [Production Readiness](production-readiness.md) and set the `FLOWPLANE_XDS_TLS_*` triad as described in the [configuration reference](../reference/configuration.md). For local from-source practice only, use the [Getting started tutorial](../tutorials/getting-started.md).
 
 ## Prerequisites
 

--- a/docs/how-to/script-the-cli.md
+++ b/docs/how-to/script-the-cli.md
@@ -189,16 +189,18 @@ file or context, and silence chrome with `--quiet`:
 
 ```bash
 export FLOWPLANE_SERVER=https://fp.example.com
-export FLOWPLANE_TOKEN=…           # highest-priority token source
+export FLOWPLANE_TOKEN=…           # below --token, above context/config/credentials
 export FLOWPLANE_TEAM=payments
 export FLOWPLANE_TIMEOUT=15        # seconds
 
 flowplane cluster list -o json --quiet | jq -r '.data.items[].name'
 ```
 
-Precedence for every value (including the token) is `flag > env > context > file > default` — see
-[`../reference/configuration.md`](../reference/configuration.md). `--quiet` removes progress and
-human-readable summaries, leaving only the requested data envelope on stdout.
+Precedence for every value is `flag > env > context > file > default`. Token resolution adds the
+saved credentials file as the final token-only fallback: `--token` / `FLOWPLANE_TOKEN` → context
+token → config-file token → `~/.flowplane/credentials`. See [`../reference/cli.md`](../reference/cli.md).
+`--quiet` removes progress and human-readable summaries, leaving only the requested data envelope
+on stdout.
 
 ## Verify
 

--- a/docs/how-to/secret-kek-rotation.md
+++ b/docs/how-to/secret-kek-rotation.md
@@ -1,5 +1,7 @@
 # Secret KEK Rotation
 
+> Audience: operators, platform-engineers · Status: stable
+
 Flowplane encrypts stored `SecretSpec` values with AES-256-GCM. Each secret row stores the `encryption_key_id` used for that ciphertext.
 
 ## Environment Contract

--- a/docs/reference/adoption-evaluation-issue-map.md
+++ b/docs/reference/adoption-evaluation-issue-map.md
@@ -21,7 +21,7 @@ This reference maps the 2.1.1 adoption/evaluation documentation issues to the pu
 | #211 | Added the user, team, and grant lifecycle runbook. | [Manage users, teams, and grants](../how-to/manage-users-teams-and-grants.md) |
 | #212 | Added API-team self-service onboarding and platform handoff guidance. | [Onboard an API team](../how-to/onboard-api-team.md) |
 | #213 | Made the platform/API-team ownership model explicit for evaluation and rollout. | [Evaluate a production-shaped platform setup](../how-to/evaluate-platform.md), [Onboard an API team](../how-to/onboard-api-team.md) |
-| #214 | Normalized missing how-to metadata banners and cross-links after the spine pages landed. | [AWS secure deployment](../how-to/aws-secure-deployment.md), [Secret KEK Rotation](../how-to/secret-kek-rotation.md), [README Documentation](../../README.md#documentation) |
+| #214 | Removed internal milestone labels from public docs and added a CI guard for future jargon leaks. | [CLI reference](cli.md), [AI gateway route and budget](../how-to/ai-gateway-route-budget.md), [Observability Alert Pack](observability-alerts.md) |
 | #215 | Completed final consistency and verification polish for the adoption spine. | This map, [README Documentation](../../README.md#documentation), [Documentation home](../README.md) |
 | #216 | Moved observability alert content into the Diataxis reference tree and linked it from platform docs. | [Observability Alert Pack](observability-alerts.md), [Production Readiness](../how-to/production-readiness.md), [Evaluate a production-shaped platform setup](../how-to/evaluate-platform.md) |
 

--- a/docs/reference/adoption-evaluation-issue-map.md
+++ b/docs/reference/adoption-evaluation-issue-map.md
@@ -1,0 +1,28 @@
+# Adoption Evaluation Issue Map
+
+> Audience: operators, platform-engineers, api-teams · Status: stable
+
+This reference maps the 2.1.1 adoption/evaluation documentation issues to the public docs that close or carry them. It is a release-oriented index, not a task guide.
+
+| Issue | Treatment | Public docs and examples |
+| --- | --- | --- |
+| #199 | Replaced the stale top-level `cert issue` path with the nested dataplane certificate command. | [AWS secure deployment](../how-to/aws-secure-deployment.md), `deploy/aws/README.md` |
+| #200 | Repaired the no-clone quick start release selection and evaluator artifact path. | [README Quick Start](../../README.md#quick-start-no-clone-no-rust-toolchain), [Evaluate without cloning](../tutorials/evaluate-no-clone.md) |
+| #201 | Documented the first-boot bootstrap token requirement for non-dev control planes. | [Production Readiness](../how-to/production-readiness.md), [Bootstrap the first platform admin](../how-to/bootstrap-platform.md) |
+| #202 | Refreshed production readiness around current config, Rate Limit Service (`flowplane-rls`), and public operator links. | [Production Readiness](../how-to/production-readiness.md), [Configuration reference](configuration.md) |
+| #203 | Corrected prerequisite wording where task docs referenced mismatched starter resources. | [Enable global rate limiting](../how-to/global-rate-limit.md), [Getting Started](../tutorials/getting-started.md) |
+| #204 | Removed maintainer-local `internal/.env.prod-local` sourcing from evaluator deployment steps. | [AWS secure deployment](../how-to/aws-secure-deployment.md), `deploy/aws/README.md` |
+| #205 | Documented token precedence consistently, including `--token` and the saved credentials fallback. | [CLI reference](cli.md), [CLI auth and contexts](../how-to/cli-auth-and-contexts.md), [Script the CLI](../how-to/script-the-cli.md) |
+| #206 | Added the required dataplane/listener prerequisite before AI gateway request verification. | [AI gateway route and budget](../how-to/ai-gateway-route-budget.md), [Register dataplane mTLS](../how-to/register-dataplane-mtls.md) |
+| #207 | Added provider-neutral OIDC setup guidance. | [Configure an OIDC provider](../how-to/configure-oidc-provider.md) |
+| #208 | Documented how to use the immutable OIDC `sub` as `admin_subject`. | [Configure an OIDC provider](../how-to/configure-oidc-provider.md), [Bootstrap the first platform admin](../how-to/bootstrap-platform.md) |
+| #209 | Added public request-body examples for clusters, listeners, and route configs. | [REST API reference](rest-api.md#gateway-resource-request-bodies) |
+| #210 | Added a production-shaped control-plane/data-plane evaluation spine. | [Evaluate a production-shaped platform setup](../how-to/evaluate-platform.md) |
+| #211 | Added the user, team, and grant lifecycle runbook. | [Manage users, teams, and grants](../how-to/manage-users-teams-and-grants.md) |
+| #212 | Added API-team self-service onboarding and platform handoff guidance. | [Onboard an API team](../how-to/onboard-api-team.md) |
+| #213 | Made the platform/API-team ownership model explicit for evaluation and rollout. | [Evaluate a production-shaped platform setup](../how-to/evaluate-platform.md), [Onboard an API team](../how-to/onboard-api-team.md) |
+| #214 | Normalized missing how-to metadata banners and cross-links after the spine pages landed. | [AWS secure deployment](../how-to/aws-secure-deployment.md), [Secret KEK Rotation](../how-to/secret-kek-rotation.md), [README Documentation](../../README.md#documentation) |
+| #215 | Completed final consistency and verification polish for the adoption spine. | This map, [README Documentation](../../README.md#documentation), [Documentation home](../README.md) |
+| #216 | Moved observability alert content into the Diataxis reference tree and linked it from platform docs. | [Observability Alert Pack](observability-alerts.md), [Production Readiness](../how-to/production-readiness.md), [Evaluate a production-shaped platform setup](../how-to/evaluate-platform.md) |
+
+The public task pages linked here are completable without a source checkout, `internal/`, `spec/`, or generated files from the repository. Deployment examples listed outside `docs/` are self-contained and do not depend on private artifacts.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -141,7 +141,7 @@ separate from the success envelope above (it is **not** wrapped in `{schemaVersi
 ---
 
 ### `serve`
-Run the control-plane server (REST + MCP; xDS from S5). No subcommands or args.
+Run the control-plane server for the REST API, MCP, and xDS. No subcommands or args.
 
 ### `db`
 Database operations.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -203,7 +203,7 @@ Team management.
 | `team grant remove <GRANT_ID>` | `--team <TEAM>`, positional `grant_id` |
 
 ### `cluster`
-Gateway clusters. Uses the shared resource subcommand set.
+Gateway clusters. Uses the shared resource subcommand set. `create` and `update` read the REST body from `--file`; see [gateway resource request bodies](rest-api.md#gateway-resource-request-bodies).
 
 | Subcommand | Args / Flags |
 |------------|--------------|
@@ -214,10 +214,10 @@ Gateway clusters. Uses the shared resource subcommand set.
 | `cluster delete <NAME>` | `--team <TEAM>`, positional `name` |
 
 ### `listener`
-Gateway listeners. Same shared resource subcommand set as `cluster` (`list`, `get`, `create`, `update`, `delete`) with identical flags.
+Gateway listeners. Same shared resource subcommand set as `cluster` (`list`, `get`, `create`, `update`, `delete`) with identical flags. `create` and `update` read the REST body from `--file`; see [gateway resource request bodies](rest-api.md#gateway-resource-request-bodies).
 
 ### `route`
-Route configs.
+Route configs. `create` and `update` read the REST body from `--file`; see [gateway resource request bodies](rest-api.md#gateway-resource-request-bodies).
 
 | Subcommand | Args / Flags |
 |------------|--------------|

--- a/docs/reference/observability-alerts.md
+++ b/docs/reference/observability-alerts.md
@@ -71,5 +71,5 @@ Use one production dashboard with these panels:
 
 - The serve-owned sampler is read-only. It does not advance outbox cursors and does not contact dataplanes.
 - `fp_outbox_pending_events` and `fp_outbox_oldest_pending_age_seconds` are currently emitted for the `xds-snapshot` consumer.
-- `fp_xds_snapshot_rebuilds_total` emits no labels; an earlier slice carried a `team` label that was dropped for cardinality. Do not add per-team labels to new S12 metrics.
+- `fp_xds_snapshot_rebuilds_total` emits no labels. Do not add per-team labels to this metric or future rebuild-family metrics without an explicit cardinality decision.
 - The ADS stream counters count authenticated ADS streams only. Failed authentication is covered by xDS/API logs and the existing authn/authz surfaces, not these lifecycle counters.

--- a/docs/reference/observability-alerts.md
+++ b/docs/reference/observability-alerts.md
@@ -1,6 +1,8 @@
 # Observability Alert Pack
 
-This pack is the S12b operator baseline for v1.0 production readiness. It uses the metrics that exist in the current control-plane and data-plane-adjacent services, plus the low-cardinality hardening metrics added for S12. Dashboards and alerts should keep labels bounded: do not add team, org, dataplane, route, budget, tool, or agent labels unless a later issue explicitly accepts the cardinality cost.
+> Audience: operators, platform-engineers · Status: stable
+
+This reference is the operator baseline for production alerting. It uses the metrics that exist in the current control-plane and data-plane-adjacent services. Dashboards and alerts should keep labels bounded: do not add team, org, dataplane, route, budget, tool, or agent labels unless a later issue explicitly accepts the cardinality cost.
 
 Native OpenTelemetry `gen_ai.*` semantic-convention meters are deferred for v1.0. Flowplane emits pragmatic counters for shipped AI budget behavior instead.
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -166,6 +166,169 @@ Grouped by resource. Per-field request/response schemas are in the generated Ope
 | PATCH  | `/api/v1/teams/{team}/route-configs/{name}` |
 | DELETE | `/api/v1/teams/{team}/route-configs/{name}` |
 
+#### Gateway resource request bodies
+
+`cluster`, `listener`, and `route` CLI `create`/`update` commands send these same REST bodies from `--file`. `POST` bodies include `name`; `PATCH` bodies omit `name` and replace the full `spec`. `PATCH` and `DELETE` also require `If-Match` with the current `revision`.
+
+| Resource | Create body | Update body | What it models |
+|----------|-------------|-------------|----------------|
+| Cluster | `{"name":"<name>","spec":{...}}` | `{"spec":{...}}` | Upstream endpoints, load-balancing policy, upstream TLS/protocol, health and resilience settings. |
+| Route config | `{"name":"<name>","spec":{...}}` | `{"spec":{...}}` | Virtual hosts, host domains, route matchers, route actions, retries, rewrites, and per-route or per-vhost filter overrides. |
+| Listener | `{"name":"<name>","spec":{...}}` | `{"spec":{...}}` | Dataplane bind address/port, public base URL, downstream protocol/TLS, bound route config, HTTP filters, and access logs. |
+
+Minimal cluster body:
+
+```json
+{
+  "name": "orders-upstream",
+  "spec": {
+    "endpoints": [
+      { "host": "orders.default.svc.cluster.local", "port": 8080 }
+    ],
+    "lb_policy": "round-robin",
+    "connect_timeout_secs": 5,
+    "use_tls": false
+  }
+}
+```
+
+Cluster body with weighted endpoints and explicit upstream TLS:
+
+```json
+{
+  "name": "catalog-upstream",
+  "spec": {
+    "endpoints": [
+      { "host": "catalog-a.internal", "port": 8443, "weight": 80 },
+      { "host": "catalog-b.internal", "port": 8443, "weight": 20 }
+    ],
+    "lb_policy": "least-request",
+    "least_request": { "choice_count": 2 },
+    "connect_timeout_secs": 3,
+    "use_tls": true,
+    "upstream_tls": {
+      "sni": "catalog.internal",
+      "auto_sni_san_validation": true,
+      "insecure_skip_verify": false
+    },
+    "protocol": "http2"
+  }
+}
+```
+
+Minimal route config body:
+
+```json
+{
+  "name": "orders-routes",
+  "spec": {
+    "virtual_hosts": [
+      {
+        "name": "default",
+        "domains": ["*"],
+        "routes": [
+          {
+            "name": "all",
+            "match": { "prefix": { "prefix": "/" } },
+            "action": { "cluster": "orders-upstream" }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Route config body with host matching, header/query matching, weighted clusters, rewrite, timeout, and retries:
+
+```json
+{
+  "name": "catalog-routes",
+  "spec": {
+    "virtual_hosts": [
+      {
+        "name": "catalog",
+        "domains": ["catalog.example.com"],
+        "routes": [
+          {
+            "name": "items",
+            "match": { "prefix": { "prefix": "/items" } },
+            "headers": [
+              { "name": "x-api-version", "type": "exact", "value": "2" }
+            ],
+            "query_parameters": [
+              { "name": "preview", "type": "present", "value": true }
+            ],
+            "action": {
+              "weighted_clusters": [
+                { "cluster": "catalog-primary", "weight": 90 },
+                { "cluster": "catalog-canary", "weight": 10 }
+              ],
+              "prefix_rewrite": "/v2/items",
+              "timeout_secs": 10,
+              "retry_policy": {
+                "retry_on": "5xx,connect-failure",
+                "num_retries": 2,
+                "per_try_timeout_secs": 3,
+                "retriable_status_codes": [502, 503]
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Minimal listener body bound to a route config:
+
+```json
+{
+  "name": "orders-http",
+  "spec": {
+    "address": "0.0.0.0",
+    "port": 10001,
+    "public_base_url": "http://127.0.0.1:10001",
+    "protocol": "http",
+    "route_config": "orders-routes"
+  }
+}
+```
+
+HTTPS listener body using SDS secret names and a file access log:
+
+```json
+{
+  "name": "catalog-https",
+  "spec": {
+    "address": "0.0.0.0",
+    "port": 10443,
+    "public_base_url": "https://catalog.example.com",
+    "protocol": "https",
+    "route_config": "catalog-routes",
+    "tls_context": {
+      "tls_certificate_sds_secret_name": "catalog-server-cert",
+      "validation_context_sds_secret_name": "client-ca",
+      "require_client_certificate": false
+    },
+    "access_logs": [
+      { "path": "/var/log/envoy/catalog-access.log" }
+    ]
+  }
+}
+```
+
+Field notes:
+
+- Resource names and references such as `route_config` and `cluster` are team-scoped names. The service layer resolves references within the same team and rejects unknown or cross-team targets.
+- Listener ports must be `1024` or higher because dataplanes run unprivileged.
+- `public_base_url` is product metadata used for invocation descriptors. It is not the Envoy bind address; use `address` and `port` for the listener bind.
+- Route matchers are externally tagged JSON objects: `{"prefix":{"prefix":"/"}}`, `{"exact":{"path":"/healthz"}}`, `{"template":{"template":"/items/{id}"}}`, or `{"regex":{"pattern":"^/v[0-9]+/items$"}}`.
+- `action` must choose one target style: `cluster`, `weighted_clusters`, `redirect`, or `direct_response`.
+- Upstream TLS is explicit. `use_tls: true` enables TLS, and `upstream_tls` supplies verification/SNI details. `insecure_skip_verify` defaults to `false` and disables verification only when set to `true`.
+- The `expose` shortcut creates this same chain for you: one cluster, one route config, and one listener.
+
 ### Rate limiting
 
 Team-scoped rate-limit domains, the policies within each, and an optional per-team override of a

--- a/docs/tutorials/evaluate-no-clone.md
+++ b/docs/tutorials/evaluate-no-clone.md
@@ -1,0 +1,154 @@
+# Evaluate Flowplane without cloning the repo
+
+> Audience: newcomers, api-teams · Status: stable
+
+This tutorial takes you from a clean machine to a working Flowplane evaluation using only published artifacts. You will start the evaluation bundle, route a request through Envoy, use the `flowplane` CLI inside the published image, import a small OpenAPI document, publish it, and verify that API tools became visible.
+
+You need Docker Compose or Podman Compose and `curl`. The examples use `docker compose`; if you use Podman Compose, replace that command with your local Podman Compose equivalent. You do not need Rust, a source checkout, `./target/debug/flowplane`, `internal/`, or `spec/`.
+
+The evaluation bundle runs dev mode: an in-process identity issuer, seeded `dev-org` / `default` resources, a dev bearer token, Postgres, a demo upstream, and Envoy. It binds host ports to `127.0.0.1` and is not a production shape.
+
+## 1. Start the published evaluator bundle
+
+Use a published release. This example uses `2.1.0`, whose eval compose file and multi-arch eval image are published:
+
+```bash
+VER=2.1.0
+
+curl -fsSLO https://raw.githubusercontent.com/rajeevramani/flowplane/v${VER}/compose.eval.yml
+
+FLOWPLANE_EVAL_IMAGE=ghcr.io/rajeevramani/flowplane:${VER}-eval \
+  docker compose -f compose.eval.yml up -d --no-build
+```
+
+Wait until the services are healthy, then send a request through Envoy:
+
+```bash
+curl http://127.0.0.1:10000/
+```
+
+Expected body:
+
+```text
+hello from the flowplane eval demo upstream
+```
+
+That request reached the demo upstream through Envoy on `127.0.0.1:10000`; the control plane did not proxy the request.
+
+## 2. Confirm CLI authentication
+
+The eval image includes the `flowplane` CLI. The control-plane container writes a dev token to `/shared/dev-token`; use it only for this local evaluation stack:
+
+```bash
+docker compose -f compose.eval.yml exec flowplane-eval \
+  sh -c 'FLOWPLANE_TOKEN=$(cat /shared/dev-token) flowplane auth whoami'
+```
+
+For the remaining commands, run the CLI inside the eval container and set the seeded org/team context:
+
+```bash
+docker compose -f compose.eval.yml exec flowplane-eval \
+  sh -c 'FLOWPLANE_TOKEN=$(cat /shared/dev-token) FLOWPLANE_ORG=dev-org FLOWPLANE_TEAM=default flowplane cluster list'
+
+docker compose -f compose.eval.yml exec flowplane-eval \
+  sh -c 'FLOWPLANE_TOKEN=$(cat /shared/dev-token) FLOWPLANE_ORG=dev-org FLOWPLANE_TEAM=default flowplane listener list'
+
+docker compose -f compose.eval.yml exec flowplane-eval \
+  sh -c 'FLOWPLANE_TOKEN=$(cat /shared/dev-token) FLOWPLANE_ORG=dev-org FLOWPLANE_TEAM=default flowplane route list'
+```
+
+You should see the resources created by the evaluator bundle. They are the durable gateway resources that produce Envoy config: a cluster, a route config, a listener, and a dataplane record.
+
+## 3. Import a small OpenAPI document
+
+Create the sample document inside the eval container and import it as an API definition:
+
+```bash
+docker compose -f compose.eval.yml exec -T flowplane-eval sh <<'EOF'
+cat >/tmp/catalog-openapi.json <<'JSON'
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Catalog",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/items/{id}": {
+      "get": {
+        "operationId": "getItem",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Item found"
+          }
+        }
+      }
+    }
+  }
+}
+JSON
+
+FLOWPLANE_TOKEN=$(cat /shared/dev-token) \
+FLOWPLANE_ORG=dev-org \
+FLOWPLANE_TEAM=default \
+flowplane api create catalog --from-openapi /tmp/catalog-openapi.json --team default
+EOF
+```
+
+Importing creates the API definition, an imported spec version, and generated tool rows. Those generated artifacts are inert until you publish the spec version. In this fresh evaluation stack, the first import creates spec version `1`; `flowplane api status catalog --team default` shows the version state after publish.
+
+## 4. Publish the spec and verify tools
+
+Publish imported spec version `1`:
+
+```bash
+docker compose -f compose.eval.yml exec flowplane-eval \
+  sh -c 'FLOWPLANE_TOKEN=$(cat /shared/dev-token) FLOWPLANE_ORG=dev-org FLOWPLANE_TEAM=default flowplane api spec publish catalog 1 --team default --reason "eval import"'
+```
+
+Verify the API status:
+
+```bash
+docker compose -f compose.eval.yml exec flowplane-eval \
+  sh -c 'FLOWPLANE_TOKEN=$(cat /shared/dev-token) FLOWPLANE_ORG=dev-org FLOWPLANE_TEAM=default flowplane api status catalog --team default'
+```
+
+Confirm the output shows a published spec and a non-zero tool count. Then check the MCP tool summary:
+
+```bash
+docker compose -f compose.eval.yml exec flowplane-eval \
+  sh -c 'FLOWPLANE_TOKEN=$(cat /shared/dev-token) FLOWPLANE_ORG=dev-org FLOWPLANE_TEAM=default flowplane mcp status --team default'
+```
+
+The published OpenAPI operation is now represented as a generated API tool for the `default` team. Tool execution requires a listener route binding; importing without one is still useful for evaluating the API lifecycle and tool generation gate. To bind an API to a listener route at import time, see [Import and publish an OpenAPI spec](../how-to/import-and-publish-openapi-spec.md).
+
+## 5. Decide what you learned
+
+At this point you have proven:
+
+- a published Flowplane eval artifact can start without a source checkout;
+- a request can route through Envoy;
+- the CLI can authenticate and inspect gateway resources;
+- an OpenAPI document can become an API definition;
+- generated API tools remain inert until the spec is published;
+- `api status` and `mcp status` show what became served for the team.
+
+For deeper evaluation:
+
+- [Import and publish an OpenAPI spec](../how-to/import-and-publish-openapi-spec.md) covers route bindings and generated tool callability.
+- [Learn and publish an API spec version](../how-to/learn-and-publish-api-spec.md) covers learning from captured traffic.
+- [Authenticate the CLI and point it at the right server/org/team](../how-to/cli-auth-and-contexts.md) covers non-eval CLI contexts.
+- [Register a dataplane and connect its agent over mTLS](../how-to/register-dataplane-mtls.md) shows the production dataplane identity path.
+
+## Tear down
+
+```bash
+docker compose -f compose.eval.yml down -v
+```

--- a/docs/tutorials/evaluate-no-clone.md
+++ b/docs/tutorials/evaluate-no-clone.md
@@ -57,7 +57,7 @@ docker compose -f compose.eval.yml exec flowplane-eval \
   sh -c 'FLOWPLANE_TOKEN=$(cat /shared/dev-token) FLOWPLANE_ORG=dev-org FLOWPLANE_TEAM=default flowplane route list'
 ```
 
-You should see the resources created by the evaluator bundle. They are the durable gateway resources that produce Envoy config: a cluster, a route config, a listener, and a dataplane record.
+You should see the resources created by the evaluator bundle. They are the durable gateway resources that produce Envoy config: a cluster, a route config, a listener, and a dataplane record. To inspect or create those resources directly, use the [gateway resource request body examples](../reference/rest-api.md#gateway-resource-request-bodies).
 
 ## 3. Import a small OpenAPI document
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -149,7 +149,7 @@ The flags map directly to the request the server receives:
 - `--port` is the listener port — this is the port Envoy will listen on, and it must match the `curl` you run in step 7 (`10001` here),
 - `--public-base-url` is the address clients use to reach the listener; keep it consistent with `--port` (`http://127.0.0.1:10001`). For real deployments set it to the dataplane listener address clients can actually reach, or omit it.
 
-On success the command prints a table describing the created resources, including a `curl_url` of `http://127.0.0.1:10001/` and the `cluster`, `route_config`, and `listener` it created.
+On success the command prints a table describing the created resources, including a `curl_url` of `http://127.0.0.1:10001/` and the `cluster`, `route_config`, and `listener` it created. To model the same topology by hand, see the [gateway resource request body examples](../reference/rest-api.md#gateway-resource-request-bodies).
 
 (Optional intermediate check — confirm the control plane holds the resources:)
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -10,7 +10,7 @@ Dev mode runs an in-process identity issuer, seeds local resources, and serves t
 
 > **Just want to try Flowplane?** You don't need this tutorial. The fastest path uses the published
 > evaluation image and a single `docker compose` file — no clone, no Rust toolchain — and routes a
-> real request in four commands. See **[Quick Start (no clone)](../../README.md#quick-start-no-clone-no-rust-toolchain)**.
+> real request through Envoy. See **[Evaluate Flowplane without cloning the repo](evaluate-no-clone.md)**.
 > This tutorial is the **from-source / contributor** path: build the binary yourself and drive the
 > control plane directly, which is what you want when hacking on Flowplane itself.
 

--- a/scripts/ci/check-docs-jargon.py
+++ b/scripts/ci/check-docs-jargon.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Reject internal planning jargon in public Markdown docs.
+
+The public docs must stand alone for readers who have not seen Flowplane's
+issue tracker, Beads graph, vault, or implementation slice plan. This check is
+intentionally scoped to tracked public Markdown only:
+
+  * README.md
+  * docs/**/*.md
+  * deploy/aws/**/*.md, including the top-level deploy/aws/README.md
+
+Run:  scripts/ci/check-docs-jargon.py             # check the tree
+      scripts/ci/check-docs-jargon.py --self-test # run parser self-checks
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+FENCE_RE = re.compile(r"^\s*(```|~~~)")
+
+
+@dataclass(frozen=True)
+class Marker:
+    name: str
+    pattern: re.Pattern[str]
+
+
+MARKERS = (
+    Marker("internal slice label", re.compile(r"\bS(?!3\b)[0-9]+[a-z]*\b")),
+    Marker("Beads issue id", re.compile(r"\bfpv2-[A-Za-z0-9.-]+\b")),
+    Marker("Beads planning term", re.compile(r"\bbeads?\b", re.IGNORECASE)),
+)
+
+
+def _git_ls_files() -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout.splitlines()
+
+
+def public_markdown_files(paths: list[str] | None = None) -> list[str]:
+    tracked = paths if paths is not None else _git_ls_files()
+    out: list[str] = []
+    for path in tracked:
+        normalized = path.replace(os.sep, "/")
+        if normalized == "README.md":
+            out.append(normalized)
+        elif normalized.startswith("docs/") and normalized.endswith(".md"):
+            out.append(normalized)
+        elif normalized.startswith("deploy/aws/") and normalized.endswith(".md"):
+            out.append(normalized)
+    return sorted(out)
+
+
+def find_violations(path: str, text: str) -> list[tuple[int, str, str]]:
+    violations: list[tuple[int, str, str]] = []
+    in_fence = False
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        for marker in MARKERS:
+            match = marker.pattern.search(line)
+            if match:
+                violations.append((line_no, marker.name, match.group(0)))
+    return violations
+
+
+def check_tree() -> int:
+    failures = 0
+    for rel_path in public_markdown_files():
+        path = os.path.join(REPO_ROOT, rel_path)
+        with open(path, encoding="utf-8") as fh:
+            text = fh.read()
+        for line_no, name, token in find_violations(rel_path, text):
+            print(f"{rel_path}:{line_no}: {name} -> {token}")
+            failures += 1
+    if failures:
+        print(f"\n{failures} docs-jargon violation(s). Public docs must not expose internal planning labels.", file=sys.stderr)
+        return 1
+    print("docs jargon OK: no internal planning markers in public Markdown.")
+    return 0
+
+
+def self_test() -> int:
+    sample_paths = [
+        "README.md",
+        "docs/reference/cli.md",
+        "deploy/aws/README.md",
+        "deploy/aws/nested/example.md",
+        "deploy/gcp/README.md",
+        "internal/README.md",
+        "spec/README.md",
+        "CHANGELOG.md",
+    ]
+    assert public_markdown_files(sample_paths) == [
+        "README.md",
+        "deploy/aws/README.md",
+        "deploy/aws/nested/example.md",
+        "docs/reference/cli.md",
+    ]
+    assert find_violations("docs/x.md", "xDS from S5")
+    assert find_violations("docs/x.md", "new S12b metrics")
+    assert not find_violations("docs/x.md", "AWS S3 bucket")
+    assert find_violations("docs/x.md", "tracked by fpv2-214")
+    assert find_violations("docs/x.md", "the Beads graph")
+    assert not find_violations("docs/x.md", "```\nxDS from S5\n```")
+    print("self-test OK")
+    return 0
+
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv:
+        sys.exit(self_test())
+    sys.exit(check_tree())


### PR DESCRIPTION
## Summary

This PR adds the public adoption/evaluation documentation spine and closes the follow-up documentation verification gaps found during runtime/doc review.

It is docs-only: no runtime behavior, schema, API, Terraform behavior, or release artifact changes are intended.

## What Changed

- Added/reshaped the developer and platform evaluation docs so outsiders can evaluate Flowplane without cloning the repo.
- Fixed production/evaluator documentation blockers around OIDC, bootstrap token, AWS secure deployment, xDS CA wording, AI gateway prerequisites, and API-team onboarding.
- Added the adoption issue map and corrected follow-up docs verification issues.
- Added a CI docs-jargon check to prevent internal planning labels from leaking into public docs.

## Release Handling

- No new runtime images or binaries are published by this PR.
- No new tag is requested for this PR.
- The docs were verified against the published `2.1.0` artifacts where runtime verification was required.
- README runtime examples remain pinned to `VER=2.1.0` unless a future runtime release publishes newer artifacts.

## Validation

- `python3 scripts/ci/check-docs-jargon.py --self-test`
- `python3 scripts/ci/check-docs-jargon.py`
- `python3 scripts/ci/check-docs-boundary.py --self-test`
- `python3 scripts/ci/check-docs-boundary.py`
- `python3 -m py_compile scripts/ci/check-docs-jargon.py`
- `git diff --check`
- AIDF Claude review gates: approved for implemented slices

## Closed Issues

Closes #199
Closes #200
Closes #201
Closes #202
Closes #203
Closes #204
Closes #205
Closes #206
Closes #207
Closes #208
Closes #209
Closes #210
Closes #211
Closes #212
Closes #213
Closes #214
Closes #215
Closes #216
Closes #217
Closes #218
