### PR TITLE
Add adoption docs and split-node release readiness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,48 @@ jobs:
       - name: Hardened image sanity (binary runs in the slim image)
         run: |
           docker run --rm --entrypoint /usr/local/bin/flowplane flowplane:hardened-smoke --help >/dev/null
+          docker run --rm --entrypoint /usr/local/bin/flowplane-agent flowplane:hardened-smoke --help >/dev/null
+          docker run --rm --entrypoint /usr/local/bin/fp-agent flowplane:hardened-smoke --help >/dev/null
+          set +e
+          docker run --rm \
+            --entrypoint /usr/bin/timeout \
+            -e FLOWPLANE_RLS_GRPC_LISTEN=127.0.0.1:0 \
+            -e FLOWPLANE_RLS_ADMIN_LISTEN=127.0.0.1:0 \
+            flowplane:hardened-smoke \
+            3 /usr/local/bin/flowplane-rls
+          rls_status=$?
+          set -e
+          [ "$rls_status" -eq 124 ] || { echo "::error::flowplane-rls smoke exited with $rls_status"; exit 1; }
+
+      - name: Build binary release artifact
+        env:
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "$PWD:/src" \
+            -w /src \
+            -e FLOWPLANE_RELEASE_VERSION="$VERSION" \
+            -e FLOWPLANE_RELEASE_HOST="linux-${{ matrix.arch }}" \
+            rust:1.94.1-bookworm \
+            bash scripts/release/package-release.sh
+          root="target/release-artifacts/flowplane-v${VERSION}"
+          mkdir -p "${{ runner.temp }}/release-assets"
+          cp "$root/flowplane-${VERSION}-linux-${{ matrix.arch }}.tar.gz" "${{ runner.temp }}/release-assets/"
+          cp "$root/flowplane-${VERSION}.cargo-metadata.sbom.json" \
+            "${{ runner.temp }}/release-assets/flowplane-${VERSION}-linux-${{ matrix.arch }}.cargo-metadata.sbom.json"
+          (
+            cd "${{ runner.temp }}/release-assets"
+            if command -v sha256sum >/dev/null 2>&1; then
+              sha256sum \
+                "flowplane-${VERSION}-linux-${{ matrix.arch }}.tar.gz" \
+                "flowplane-${VERSION}-linux-${{ matrix.arch }}.cargo-metadata.sbom.json"
+            else
+              shasum -a 256 \
+                "flowplane-${VERSION}-linux-${{ matrix.arch }}.tar.gz" \
+                "flowplane-${VERSION}-linux-${{ matrix.arch }}.cargo-metadata.sbom.json"
+            fi
+          ) > "${{ runner.temp }}/release-assets/SHA256SUMS-linux-${{ matrix.arch }}"
 
       # --- Push each image by digest (cached layers from the load builds above) ---
 
@@ -178,6 +220,13 @@ jobs:
         with:
           name: digests-${{ matrix.arch }}
           path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+
+      - name: Upload binary release assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-assets-${{ matrix.arch }}
+          path: ${{ runner.temp }}/release-assets/*
           if-no-files-found: error
 
   manifest:
@@ -246,9 +295,28 @@ jobs:
             echo "$out" | grep -q "linux/amd64" || { echo "::error::$ref missing linux/amd64"; exit 1; }
             echo "$out" | grep -q "linux/arm64" || { echo "::error::$ref missing linux/arm64"; exit 1; }
           done
-      - name: Attach compose.eval.yml as a release asset (stable no-clone download URL)
+      - name: Download binary release assets
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          pattern: binary-assets-*
+          merge-multiple: true
+
+      - name: Assemble release checksums
+        run: |
+          set -euo pipefail
+          cat release-assets/SHA256SUMS-linux-amd64 release-assets/SHA256SUMS-linux-arm64 > release-assets/SHA256SUMS
+          test -s release-assets/SHA256SUMS
+          test -f release-assets/flowplane-${{ needs.resolve-version.outputs.version }}-linux-amd64.tar.gz
+          test -f release-assets/flowplane-${{ needs.resolve-version.outputs.version }}-linux-arm64.tar.gz
+
+      - name: Attach release assets (stable no-clone download URLs)
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.resolve-version.outputs.version }}
-          files: compose.eval.yml
+          files: |
+            compose.eval.yml
+            release-assets/*.tar.gz
+            release-assets/*.sbom.json
+            release-assets/SHA256SUMS
           fail_on_unmatched_files: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/Containerfile.eval
+++ b/Containerfile.eval
@@ -9,14 +9,17 @@ FROM rust:1.94.1-bookworm AS build
 WORKDIR /src
 COPY . .
 RUN cargo build --release --locked -p flowplane --bin flowplane \
-    && cargo build --release --locked -p fp-agent --bin fp-agent
+    && cargo build --release --locked -p fp-agent --bin flowplane-agent \
+    && cargo build --release --locked -p flowplane-rls --bin flowplane-rls
 
 FROM debian:bookworm-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates libssl3 \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=build /src/target/release/flowplane /usr/local/bin/flowplane
-COPY --from=build /src/target/release/fp-agent /usr/local/bin/fp-agent
+COPY --from=build /src/target/release/flowplane-agent /usr/local/bin/flowplane-agent
+COPY --from=build /src/target/release/flowplane-rls /usr/local/bin/flowplane-rls
+RUN ln -s /usr/local/bin/flowplane-agent /usr/local/bin/fp-agent
 USER 65532:65532
 EXPOSE 8080 18000
 ENTRYPOINT ["/usr/local/bin/flowplane"]

--- a/Containerfile.release
+++ b/Containerfile.release
@@ -2,14 +2,17 @@ FROM rust:1.94.1-bookworm AS build
 WORKDIR /src
 COPY . .
 RUN cargo build --release --locked -p flowplane --bin flowplane --no-default-features \
-    && cargo build --release --locked -p fp-agent --bin fp-agent
+    && cargo build --release --locked -p fp-agent --bin flowplane-agent \
+    && cargo build --release --locked -p flowplane-rls --bin flowplane-rls
 
 FROM debian:bookworm-slim
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates libssl3 \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=build /src/target/release/flowplane /usr/local/bin/flowplane
-COPY --from=build /src/target/release/fp-agent /usr/local/bin/fp-agent
+COPY --from=build /src/target/release/flowplane-agent /usr/local/bin/flowplane-agent
+COPY --from=build /src/target/release/flowplane-rls /usr/local/bin/flowplane-rls
+RUN ln -s /usr/local/bin/flowplane-agent /usr/local/bin/fp-agent
 USER 65532:65532
 EXPOSE 8080 18000
 ENTRYPOINT ["/usr/local/bin/flowplane"]

--- a/crates/fp-agent/Cargo.toml
+++ b/crates/fp-agent/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 publish.workspace = true
 
 [[bin]]
-name = "fp-agent"
+name = "flowplane-agent"
 path = "src/main.rs"
 
 [dependencies]

--- a/crates/fp-agent/src/main.rs
+++ b/crates/fp-agent/src/main.rs
@@ -24,7 +24,7 @@ const DEFAULT_QUEUE_CAP: usize = 256;
 
 #[derive(Parser, Debug)]
 #[command(
-    name = "fp-agent",
+    name = "flowplane-agent",
     version,
     about = "Flowplane dataplane telemetry relay"
 )]

--- a/docs/how-to/evaluate-platform.md
+++ b/docs/how-to/evaluate-platform.md
@@ -15,7 +15,9 @@ You need:
 - OIDC provider values from [Configure an OIDC provider](configure-oidc-provider.md);
 - a high-entropy bootstrap token delivered by `FLOWPLANE_BOOTSTRAP_TOKEN_FILE` or `FLOWPLANE_BOOTSTRAP_TOKEN`;
 - a `flowplane` CLI installed on the operator workstation;
-- a dataplane host that can run Envoy and `fp-agent`.
+- a dataplane host that can run Envoy and `flowplane-agent`.
+
+Install `flowplane`, `flowplane-agent`, and `flowplane-rls` from the published release archive as shown in [Production Readiness](production-readiness.md). Do not use a source checkout for this evaluation path.
 
 Use placeholders in examples until you substitute your own values. Do not put real tokens, private keys, or certificate PEM bodies in public docs, issue comments, or shell history.
 
@@ -89,7 +91,7 @@ Use [Register a dataplane and connect its agent over mTLS](register-dataplane-mt
 The expected direction is outbound from the dataplane to the control plane:
 
 - Envoy opens ADS/SDS streams to the control-plane xDS listener.
-- `fp-agent` reports dataplane diagnostics to the control plane.
+- `flowplane-agent` reports dataplane diagnostics to the control plane.
 - The control plane does not call Envoy admin as a product path.
 - Envoy admin remains local to the dataplane and is a manual diagnostic surface.
 
@@ -104,7 +106,7 @@ flowplane ops xds status --team payments
 flowplane ops xds nacks --team payments
 ```
 
-`dataplane get` should show an advancing heartbeat once `fp-agent` reports. `stats overview` should count the dataplane as live. `ops xds status` / `ops xds nacks` should show whether Envoy accepted or rejected the pushed xDS resources.
+`dataplane get` should show an advancing heartbeat once `flowplane-agent` reports. `stats overview` should count the dataplane as live. `ops xds status` / `ops xds nacks` should show whether Envoy accepted or rejected the pushed xDS resources.
 
 ## 5. Verify observability
 

--- a/docs/how-to/global-rate-limit.md
+++ b/docs/how-to/global-rate-limit.md
@@ -16,7 +16,7 @@ shaped this way (separate process, namespaced counters, fail modes), read
 
 - A running control plane and a real Envoy joined over xDS, with a listener, route-config, and cluster that already route traffic. The [getting-started tutorial](../tutorials/getting-started.md) gets you here with the `local` resource set on listener port `10001`; the examples below use sample names such as `edge`, `api-routes`, and `httpbin`, so substitute your actual resource names.
 - The CLI authenticated against your control plane (`flowplane auth …` or `FLOWPLANE_SERVER`/`FLOWPLANE_TOKEN`) — see [CLI auth & contexts](cli-auth-and-contexts.md). Examples below use team `default`.
-- The `flowplane-rls` binary built/available (`cargo build --bin flowplane-rls`, or your release artifact).
+- The `flowplane-rls` binary installed from a published Flowplane release artifact, as shown in [Production Readiness](production-readiness.md).
 
 The descriptor key in this guide is `api_key`, derived from an `x-api-key` request header; the
 limit is **100 requests/minute per distinct `api_key`**.
@@ -31,6 +31,8 @@ FLOWPLANE_RLS_GRPC_LISTEN=127.0.0.1:50051 \
 FLOWPLANE_RLS_ADMIN_LISTEN=127.0.0.1:8081 \
   flowplane-rls
 ```
+
+For a split-node deployment, bind these listeners on the RLS host interface that the control plane and Envoy can reach, and open the matching ports described in [Production Readiness](production-readiness.md#ports-and-network-paths). Keep the admin listener reachable only from the control-plane network.
 
 Expected startup log — a `flowplane-rls starting` line carrying both bind addresses (the exact
 prefix/format depends on the tracing setup; `grpc=` and `admin=` fields appear):

--- a/docs/how-to/production-readiness.md
+++ b/docs/how-to/production-readiness.md
@@ -17,6 +17,27 @@ This is the operator entry point for a production-shaped Flowplane deployment. I
 
 Deploy the control plane and dataplane bundle separately.
 
+Install the published operator binaries on the control-plane host, operator workstation, and dataplane host. Pick the archive for the host architecture:
+
+```bash
+VER=2.1.1
+ARCH=linux-amd64   # or linux-arm64
+BASE="https://github.com/rajeevramani/flowplane/releases/download/v${VER}"
+
+curl -fLO "${BASE}/flowplane-${VER}-${ARCH}.tar.gz"
+curl -fLO "${BASE}/SHA256SUMS"
+grep "flowplane-${VER}-${ARCH}.tar.gz" SHA256SUMS | sha256sum -c -
+tar -xzf "flowplane-${VER}-${ARCH}.tar.gz"
+
+sudo install -m 0755 "flowplane-${VER}-${ARCH}/bin/flowplane" /usr/local/bin/flowplane
+sudo install -m 0755 "flowplane-${VER}-${ARCH}/bin/flowplane-agent" /usr/local/bin/flowplane-agent
+sudo install -m 0755 "flowplane-${VER}-${ARCH}/bin/flowplane-rls" /usr/local/bin/flowplane-rls
+```
+
+Use `shasum -a 256 -c` instead of `sha256sum -c` on systems that do not provide `sha256sum`. The release archive also includes `bin/fp-agent` as a one-release compatibility alias, but public operator commands use `flowplane-agent`.
+
+The published `2.1.1` binary archives are Linux `amd64` and Linux `arm64`. Use a Linux host for the installed CLI, or run the published container image with an entrypoint override when your operator workstation is not Linux.
+
 Control plane:
 
 ```bash
@@ -42,23 +63,49 @@ Production authentication requires a real OIDC issuer/audience pair. `FLOWPLANE_
 Dataplane:
 
 ```bash
-FLOWPLANE_SERVER=https://cp.example \
-FLOWPLANE_TOKEN=<operator-token> \
-FLOWPLANE_PACKAGE_DATAPLANE=1 \
-FLOWPLANE_PACKAGE_TEAM=default \
-FLOWPLANE_PACKAGE_DATAPLANE_NAME=edge-1 \
-FLOWPLANE_PACKAGE_DATAPLANE_MODE=mtls \
-FLOWPLANE_PACKAGE_XDS_HOST=cp.example \
-FLOWPLANE_PACKAGE_XDS_PORT=18000 \
-FLOWPLANE_PACKAGE_CERT_PATH=/etc/flowplane/tls/tls.crt \
-FLOWPLANE_PACKAGE_KEY_PATH=/etc/flowplane/tls/tls.key \
-FLOWPLANE_PACKAGE_CA_PATH=/etc/flowplane/tls/ca.crt \
-scripts/release/package-release.sh
+flowplane --out /etc/flowplane/envoy/envoy.yaml \
+  dataplane bootstrap edge-1 --team <team> --mode mtls \
+  --xds-host cp.example --xds-port 18000 \
+  --cert-path /etc/flowplane/dp/client.crt \
+  --key-path /etc/flowplane/dp/client.key \
+  --ca-path /etc/flowplane/dp/server-ca.crt
 ```
 
-Run Envoy and `fp-agent` beside each other in the dataplane network. The dataplane dials the control plane over xDS/diagnostics; the control plane must not dial Envoy admin as a product path. Envoy admin stays loopback-only and is a manual diagnostic fallback.
+Run Envoy with that bootstrap and run `flowplane-agent` beside it in the dataplane network. The dataplane dials the control plane over xDS/diagnostics; the control plane must not dial Envoy admin as a product path. Envoy admin stays loopback-only and is a manual diagnostic fallback. The canonical certificate issuance and agent flags are in [Register a dataplane and connect its agent over mTLS](register-dataplane-mtls.md).
 
-Upgrade order is independent: upgrade CP first or DP first within the supported Envoy line. Existing dataplanes keep serving last-applied config during a CP restart; new dataplanes cannot join until the CP is back.
+## Ports And Network Paths
+
+| Path | Default | Direction | Notes |
+| --- | --- | --- | --- |
+| Operator/API traffic to CP | `FLOWPLANE_API_ADDR`, usually `:8080` behind TLS/load balancer | operators/API teams -> CP | Terminate public TLS before or at the CP API. Do not expose plaintext production API. |
+| Dataplane xDS/diagnostics to CP | `FLOWPLANE_XDS_ADDR`, default `:18000` | Envoy/agent -> CP | Production is mTLS-or-off. Non-loopback deployments must use the xDS TLS triad. |
+| CP to PostgreSQL | database URL | CP -> PostgreSQL | Database must not be directly internet-addressable. |
+| CP to RLS admin | `FLOWPLANE_RLS_ADMIN_URL`, commonly `http://rls.example:8081` | CP -> RLS | Used by the RLS reconcile worker to push policy. |
+| Envoy to RLS gRPC | `FLOWPLANE_RLS_GRPC_URL`, commonly `rls.example:50051` | Envoy -> RLS | Use the dataplane TLS triad for production Envoy-to-RLS mTLS when enabled. |
+| Envoy listener traffic | listener config | clients -> Envoy | Request traffic never passes through the control plane. |
+| Envoy admin | `127.0.0.1:9901` | dataplane-local only | Keep loopback-only. Product diagnostics go through `flowplane-agent`. |
+| Agent health | `127.0.0.1:19902` | dataplane-local only | Use for local process health checks on the dataplane host. |
+
+## Upgrade, Rollback, And Version Skew
+
+For the `2.1.1` split-node release path, run the control plane, CLI, `flowplane-agent`, and `flowplane-rls` from the same `2.1.1` artifact set. Short-lived skew during a rolling restart is acceptable for replacing one process at a time, but do not plan a long-lived mixed-version CP/agent/RLS deployment until a later compatibility policy says so.
+
+Upgrade:
+
+1. Back up PostgreSQL and active/retired secret-encryption keys.
+2. Download and verify the new release archive and image digests.
+3. Upgrade the control plane and run `flowplane db migrate`.
+4. Upgrade `flowplane-agent` and `flowplane-rls` on dataplane/RLS hosts.
+5. Regenerate dataplane bootstrap only when CP xDS host, port, mode, or cert paths changed.
+6. Verify `/healthz`, `/readyz`, `flowplane stats overview`, `flowplane ops xds status`, agent `/healthz`, and RLS `/healthz`/`/readyz`.
+
+Rollback:
+
+1. Keep the prior release archive/image available before upgrading.
+2. If no database migration ran, roll back CP/agent/RLS binaries together and restart.
+3. If a database migration ran and rollback is required, restore the matching database backup and KEK material before starting the old CP.
+4. Existing dataplanes keep serving their last-applied Envoy config during a CP restart; new dataplanes cannot join until the CP is back.
+5. If xDS host, port, mode, or cert paths changed during the failed upgrade, regenerate bootstrap before reconnecting the dataplane.
 
 ## Configuration Reference
 
@@ -120,7 +167,10 @@ AI providers, routes, budgets, and usage are runtime product config through the 
 | Auth spike | `fp_authn_failures_total`, `fp_authz_denied_total`, audit rows | For authn, check IdP/JWKS/audience/token expiry. For authz, check grants/team context and suspicious probing. |
 | AI budget exhaustion | `fp_ai_budget_threshold_crossings_total{mode="enforcing",result="exhausted"}` | Compare expected usage to configured budget; raise budget or reduce traffic. |
 | Capture drops | `fp_capture_dropped_total` | Check capture source health and configured discovery/capture constraints. |
-| Release package validation | `SHA256SUMS`, `flowplane-*.oci.tar`, binary `file` output | Verify checksums and static binary signal; rebuild artifacts if any hash differs. |
+| Release package validation | GitHub Release assets, image digests, `SHA256SUMS` | Verify published artifacts before deployment; rebuild only through the release process if any artifact is missing or inconsistent. |
+| Split-node TLS failure | Agent/RLS logs show TLS name, CA, or client-certificate errors | Check CP xDS server cert SAN vs `FLOWPLANE_AGENT_TLS_SERVER_NAME`, server-trust CA, issued client cert/key, and CP `FLOWPLANE_XDS_TLS_CLIENT_CA`. |
+| Remote bootstrap still points at localhost | Envoy bootstrap contains `127.0.0.1` or `localhost` for `xds_cluster` | Regenerate bootstrap with `--xds-host <cp-xds-host>` and verify the generated file before starting Envoy. |
+| RLS unreachable | Route returns 5xx/429 behavior does not match policy, RLS health fails, CP RLS reconcile errors | Check CP `FLOWPLANE_RLS_ADMIN_URL`, Envoy-facing `FLOWPLANE_RLS_GRPC_URL`, firewall rules, and dataplane TLS settings for the Envoy-to-RLS hop. |
 
 ## Backup And Restore Drill
 
@@ -180,16 +230,13 @@ flowplane route apply <plan-id> --team <team>
 
 flowplane dataplane bootstrap edge-1 --team <team> --mode mtls \
   --xds-host cp.example --xds-port 18000 \
-  --cert-path /etc/flowplane/tls/tls.crt \
-  --key-path /etc/flowplane/tls/tls.key \
-  --ca-path /etc/flowplane/tls/ca.crt
+  --cert-path /etc/flowplane/dp/client.crt \
+  --key-path /etc/flowplane/dp/client.key \
+  --ca-path /etc/flowplane/dp/server-ca.crt
 
 flowplane mcp status --team <team>
 flowplane mcp connections --team <team>
 flowplane mcp enable --api api_get-catalog --team <team>
-
-scripts/release/package-release.sh
-FLOWPLANE_PACKAGE_IMAGE=1 scripts/release/package-release.sh
 ```
 
 For deployment-specific details, use the relevant public runbook such as [AWS secure deployment](aws-secure-deployment.md). Keep release evidence separate from day-to-day operator runbooks.

--- a/docs/how-to/register-dataplane-mtls.md
+++ b/docs/how-to/register-dataplane-mtls.md
@@ -2,7 +2,7 @@
 
 > Audience: operators · Status: stable
 
-This how-to walks one task end to end: **register a dataplane, issue its mTLS client certificate, and connect `fp-agent`.** It assumes you already run Flowplane day to day and have a working CLI context (server URL, org, team, token).
+This how-to walks one task end to end: **register a dataplane, issue its mTLS client certificate, and connect `flowplane-agent`.** It assumes you already run Flowplane day to day and have a working CLI context (server URL, org, team, token).
 
 It assumes the control plane is already running with xDS mTLS configured. The xDS listener is **always** mTLS in production — there is no plaintext mode off loopback. If you have not stood that up yet, start with [Production Readiness](production-readiness.md) and set the `FLOWPLANE_XDS_TLS_*` triad as described in the [configuration reference](../reference/configuration.md). For local from-source practice only, use the [Getting started tutorial](../tutorials/getting-started.md).
 
@@ -11,6 +11,8 @@ It assumes the control plane is already running with xDS mTLS configured. The xD
 The control plane is up with the xDS mTLS triad set (`FLOWPLANE_XDS_TLS_CERT` / `_KEY` / `_CLIENT_CA`), and — for the `issue` step below — the cert-issuer triad `FLOWPLANE_CERT_ISSUER_CA_CERT_PATH` and `FLOWPLANE_CERT_ISSUER_CA_KEY_PATH` (optionally `FLOWPLANE_CERT_ISSUER_TRUST_DOMAIN`, default `flowplane.local`) is set **on the control-plane process**. See the [configuration reference](../reference/configuration.md).
 
 A **tenant org and a team must already exist** — a dataplane is registered under a team (`--team payments` below), and the platform org cannot host one. If you have only just bootstrapped the platform admin, first [create a tenant org and a team](create-tenant-org-and-team.md). Note that selecting the platform org for a tenant operation (`--org platform`) is rejected with `org_selector_required` (D-014): use your tenant org.
+
+The dataplane host must have Envoy and `flowplane-agent` installed. Install `flowplane-agent` from the published Flowplane release archive as shown in [Production Readiness](production-readiness.md).
 
 ## 1. Register the dataplane
 
@@ -88,12 +90,12 @@ echo "$CP_XDS_SERVER_CA_PEM" > /etc/flowplane/dp/server-ca.crt
 
 > If your dataplane already has externally-issued certs, use `dataplane cert register` / `POST /api/v1/teams/{team}/proxy-certificates` instead to register the SPIFFE binding without minting a key. (Optional background — not needed to finish this task: the certificate lifecycle design, SPIFFE format, and revocation internals are in the design records linked under Further reading.)
 
-## 3. Run `fp-agent`
+## 3. Run `flowplane-agent`
 
 Point the agent at the control-plane diagnostics gRPC endpoint, give it the dataplane UUID from step 1, pass its client cert and key from step 2, and pass the **server-trust CA** (the CA for the CP's xDS server cert). The TLS cert/key/CA flags are **all-or-none** — supply all three or none.
 
 ```bash
-fp-agent \
+flowplane-agent \
   --cp-endpoint https://cp.example.com:18000 \
   --dataplane-id 7b1f0a2c-... \
   --tls-cert-path /etc/flowplane/dp/client.crt \

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2,7 +2,7 @@
 
 > Audience: operators, platform-engineers · Status: stable
 
-Every `FLOWPLANE_*` variable read by the control plane (`server`), the rate-limit service (`rls`, the `flowplane-rls` binary), the dataplane agent (`agent`), and the CLI. Each variable appears once; the **Component** column says which process reads it.
+Every `FLOWPLANE_*` variable read by the control plane (`server`), the rate-limit service (`rls`, the `flowplane-rls` binary), the dataplane agent (`agent`, the `flowplane-agent` binary), and the CLI. Each variable appears once; the **Component** column says which process reads it.
 
 **Precedence**
 
@@ -81,7 +81,7 @@ Booleans accept `true`/`1`/`yes` and `false`/`0`/`no`. Invalid server values fai
 
 ## Constraints
 
-Enforcement timing varies: rows ¹–⁵ are validated at **server startup** (`flowplane serve`); rows ⁶, ¹⁰–¹² at **agent startup** (`fp-agent`); rows ⁷–⁹ at **use time** when the secret encrypt/decrypt/snapshot paths run (not at server startup). A violation yields an `invalid_config` (or, for a missing key, `unavailable`) error.
+Enforcement timing varies: rows ¹–⁵ are validated at **server startup** (`flowplane serve`); rows ⁶, ¹⁰–¹² at **agent startup** (`flowplane-agent`); rows ⁷–⁹ at **use time** when the secret encrypt/decrypt/snapshot paths run (not at server startup). A violation yields an `invalid_config` (or, for a missing key, `unavailable`) error.
 
 | # | Variable(s) | Constraint |
 |---|-------------|------------|

--- a/internal/dev-dataplane.md
+++ b/internal/dev-dataplane.md
@@ -232,9 +232,9 @@ Recent xDS NACKs:
 ./target/debug/flowplane ops xds nacks
 ```
 
-This manual dev path starts Envoy directly, without `fp-agent`. Request counters may not increase until the agent-backed diagnostics path is included in a later local lifecycle wrapper. The normal operator path is still Flowplane diagnostics (`stats`, `ops xds status`, `ops xds nacks`), not direct Envoy admin access.
+This manual dev path starts Envoy directly, without `flowplane-agent`. Request counters may not increase until the agent-backed diagnostics path is included in a later local lifecycle wrapper. The normal operator path is still Flowplane diagnostics (`stats`, `ops xds status`, `ops xds nacks`), not direct Envoy admin access.
 
-Envoy admin is loopback-only local debugging. Do not treat `curl :9901/config_dump` as a product or operator workflow; in the intended DP unit, `fp-agent` is the only component that scrapes Envoy admin and relays curated telemetry to the CP.
+Envoy admin is loopback-only local debugging. Do not treat `curl :9901/config_dump` as a product or operator workflow; in the intended DP unit, `flowplane-agent` is the only component that scrapes Envoy admin and relays curated telemetry to the CP.
 
 If traffic does not flow, check in this order:
 

--- a/internal/prod-local-runbook.md
+++ b/internal/prod-local-runbook.md
@@ -310,7 +310,7 @@ export FLOWPLANE_XDS_TLS_CLIENT_CA="$PWD/.local/prod/tls/dp-ca.crt"
 
 The xDS server cert/key identify the control plane. The client CA validates dataplane client certs. Dataplane certs must also be registered in Flowplane through the dataplane/proxy-certificate path; mTLS chain validity alone is not enough to authorize a dataplane.
 
-Use this only when you are testing Envoy or `fp-agent`. For API/auth/governance validation, keeping xDS disabled is expected and simpler.
+Use this only when you are testing Envoy or `flowplane-agent`. For API/auth/governance validation, keeping xDS disabled is expected and simpler.
 
 ## Troubleshooting
 

--- a/internal/release/release-packaging.md
+++ b/internal/release/release-packaging.md
@@ -28,7 +28,7 @@ Pass signal: `file` reports a statically linked binary, or Linux `ldd` prints `n
 
 Outputs are written under `target/release-artifacts/flowplane-v<version>/`:
 
-- `flowplane-<version>-<host>.tar.gz` with `flowplane` and `fp-agent` binaries.
+- `flowplane-<version>-<host>.tar.gz` with `flowplane`, `flowplane-agent`, and `flowplane-rls` binaries.
 - `flowplane-<version>.cargo-metadata.sbom.json` as the dependency SBOM source artifact.
 - `SHA256SUMS` for generated files.
 - `release-manifest.md` recording artifact choices and pass/fail notes.

--- a/scripts/release/package-release.sh
+++ b/scripts/release/package-release.sh
@@ -37,20 +37,27 @@ if [ -n "$TARGET" ]; then
 fi
 
 cargo build "${BUILD_ARGS[@]}" -p flowplane --bin flowplane --no-default-features
-cargo build "${BUILD_ARGS[@]}" -p fp-agent --bin fp-agent
+cargo build "${BUILD_ARGS[@]}" -p fp-agent --bin flowplane-agent
+cargo build "${BUILD_ARGS[@]}" -p flowplane-rls --bin flowplane-rls
 
 cp "$TARGET_DIR/flowplane" "$ARTIFACT_DIR/bin/"
-cp "$TARGET_DIR/fp-agent" "$ARTIFACT_DIR/bin/"
+cp "$TARGET_DIR/flowplane-agent" "$ARTIFACT_DIR/bin/"
+cp "$TARGET_DIR/flowplane-rls" "$ARTIFACT_DIR/bin/"
+ln -s flowplane-agent "$ARTIFACT_DIR/bin/fp-agent"
 cargo metadata --format-version 1 > "$ROOT/flowplane-$VERSION.cargo-metadata.sbom.json"
 
 cat > "$ARTIFACT_DIR/release-manifest.md" <<EOF
 # Flowplane $VERSION Release Manifest
 
 - CP binary: \`bin/flowplane\`
-- DP sidecar binary: \`bin/fp-agent\`
+- DP sidecar binary: \`bin/flowplane-agent\`
+- DP sidecar compatibility alias: \`bin/fp-agent\` (deprecated; use \`flowplane-agent\`)
+- Rate Limit Service binary: \`bin/flowplane-rls\`
 - Binary target: \`$HOST\`
-- Static-link decision: vendored OpenSSL is enabled for v1.0 release builds. Use
-  \`FLOWPLANE_RELEASE_TARGET=x86_64-unknown-linux-musl\` and verify with \`ldd\` or \`file\`.
+- Linkage: default release artifacts are native GNU/Linux builds for the release runner.
+  They may dynamically link glibc/OpenSSL from that environment. For a custom static/musl
+  build, set \`FLOWPLANE_RELEASE_TARGET=x86_64-unknown-linux-musl\` and verify with
+  \`ldd\` or \`file\`.
 - License: Apache-2.0 (Q-006 resolved); see \`LICENSE\`/\`NOTICE\`. Public distribution is not license-gated.
 - OCI image tag: \`$IMAGE_TAG\`
 - SBOM source artifact: \`flowplane-$VERSION.cargo-metadata.sbom.json\`

--- a/spec/17-split-node-release-readiness.md
+++ b/spec/17-split-node-release-readiness.md
@@ -1,0 +1,181 @@
+# 17 - Split-Node Release Readiness Verification
+
+> Status: verification report
+> Scope: current published release `v2.1.0`
+> Verdict rule: fail closed. Any `FAIL` or `UNVERIFIED` means the checked area is not ready.
+
+## v2.1.1-rc Branch Runtime Addendum
+
+The original report below verifies the **published `v2.1.0` surface** and correctly marks it
+`NOT READY` for no-clone split-node deployment. A follow-up runtime rehearsal on branch
+`feature/fpv2-0ym-adoption-evaluation-spine` at commit
+`aaeef638295d4b97d26a9daa542e20cd33cf9c7e` verifies the branch's packaged
+`2.1.1-rc` Linux amd64 artifacts:
+
+- Companion report: `spec/17-split-node-runtime-rehearsal-v2.1.1-rc.md`.
+- Packaged archive contained `flowplane`, `flowplane-agent`, `flowplane-rls`, and the deprecated
+  `fp-agent` compatibility symlink.
+- Runtime proof used separate Docker bridge identities for Postgres, local JWKS IdP, CP, Envoy,
+  `flowplane-agent`, and `flowplane-rls`.
+- CP listened on `0.0.0.0:8080` and `0.0.0.0:18000`.
+- The generated Envoy bootstrap used `flowplane-cp:18000` for `xds_cluster`, not localhost.
+- Envoy and `flowplane-agent` connected to CP xDS/diagnostics over mTLS with certificate-registry
+  binding.
+- CP `/healthz` and `/readyz`, agent `/healthz`, RLS `/healthz` and `/readyz`,
+  `flowplane stats overview`, and `flowplane ops xds status` all passed.
+
+Updated readiness interpretation:
+
+| Surface | Verdict | Reason |
+| --- | --- | --- |
+| Published `v2.1.0` | NOT READY | Release assets lack standalone operator/agent/RLS binaries and docs cannot be completed no-clone. |
+| Branch `2.1.1-rc` artifacts | READY for branch runtime evidence | Split-node artifact, mTLS, agent, RLS, health, and ops checks passed in a network-isolated rehearsal. |
+| Published `v2.1.1` | NOT READY until release | No `v2.1.1` GitHub Release/GHCR assets exist yet. Do not close issue #220 until real published assets are verified. |
+
+## Release Under Review
+
+Current published release:
+
+```text
+$ git rev-parse v2.1.0
+b35db069ef59df274b3710d5d6b3d36a3143656e
+
+$ git show -s --format='%H %D %s' v2.1.0
+73cc5f84f36f5b6e7adbf24faebbf95b526436cf tag: v2.1.0, origin/main, main chore(release): bump workspace version to 2.1.0 (#198)
+```
+
+`v2.1.0` is an annotated tag object (`b35db069...`) pointing at commit `73cc5f84...`.
+
+Published GitHub Release assets:
+
+```text
+$ gh release view v2.1.0 --json tagName,name,assets,url,targetCommitish,publishedAt,isDraft,isPrerelease
+{"assets":[{"name":"compose.eval.yml","size":6236,"url":"https://github.com/rajeevramani/flowplane/releases/download/v2.1.0/compose.eval.yml"}],"isDraft":false,"isPrerelease":false,"name":"v2.1.0","publishedAt":"2026-06-28T00:30:39Z","tagName":"v2.1.0","targetCommitish":"main","url":"https://github.com/rajeevramani/flowplane/releases/tag/v2.1.0"}
+```
+
+Binary-producing workspace members at `v2.1.0`:
+
+- `Cargo.toml:3-11` includes `crates/fp-agent`, `crates/flowplane`, and `crates/flowplane-rls`.
+- `Cargo.toml:15` sets workspace version `2.1.0`.
+- `Containerfile.release:4-12` builds and copies only `flowplane` and `fp-agent` into the hardened image.
+- `Containerfile.eval:11-19` builds and copies only `flowplane` and `fp-agent` into the evaluation image.
+- `crates/flowplane-rls/Cargo.toml:1-12` defines a separate `flowplane-rls` binary, but it is not built into either release image and is not attached as a GitHub Release asset.
+- `.github/workflows/release.yml:1-7` says the release workflow publishes GHCR images.
+- `.github/workflows/release.yml:249-254` attaches only `compose.eval.yml` as a release asset.
+
+Therefore, the published `v2.1.0` install surface is:
+
+- GHCR hardened image `ghcr.io/rajeevramani/flowplane:2.1.0`, containing `flowplane` and `fp-agent`.
+- GHCR eval image `ghcr.io/rajeevramani/flowplane:2.1.0-eval`, containing `flowplane` and `fp-agent`.
+- GitHub Release asset `compose.eval.yml`.
+- No standalone downloadable `flowplane`, `fp-agent`, or `flowplane-rls` binary tarball.
+
+## Verification Inputs And Method
+
+Artifacts under test are the published `v2.1.0` release artifacts above. Documentation evidence is read from the `v2.1.0` tag unless a row explicitly names a different ref. If a future check compares feature-branch docs against `v2.1.0` artifacts, that doc/runtime skew must be called out in the evidence instead of treated as a product failure.
+
+The binaries relevant to split-node readiness are explicit:
+
+- `flowplane`: control-plane server and operator/API-team CLI.
+- `fp-agent`: v2.1.0 dataplane diagnostics sidecar binary. The intended public name for future releases is `flowplane-agent`.
+- `flowplane-rls`: global rate-limit service binary.
+- Envoy: external dataplane process/image, not built by Flowplane.
+
+Cross-node runtime proof requires more than source inspection. A passing runtime proof must run CP and DP in separate network identities, for example separate VMs or containers on a user-defined bridge where the DP reaches CP through a non-loopback address. The proof must capture:
+
+- CP listening on non-loopback API and xDS addresses.
+- A generated Envoy bootstrap whose `xds_cluster` target is the remote CP host/port, not `127.0.0.1` or `localhost`.
+- Envoy and the dataplane agent connecting to CP over the documented mTLS path.
+- CP `/healthz` and `/readyz`, agent `/healthz`, xDS status, and RLS health/readiness where RLS is part of the deployment.
+
+The architecture-integrity constitution is a precondition for the final cross-check, not a product runtime dependency. If `flowplane-private-vault/constitution.md` is unavailable, the constitution cross-check is `UNVERIFIED` and must be reported separately; it should not be confused with a binary split-node failure. This run had the vault available.
+
+## Verdict Table
+
+| Check | A/B | Status | Evidence |
+| --- | --- | --- | --- |
+| 1. Published artifact availability | A | FAIL | Split-node requires an operator/CP CLI (`flowplane`), a DP agent (`fp-agent` in v2.1.0, intended future public name `flowplane-agent`), Envoy, and RLS when global rate limiting is enabled. `gh release view v2.1.0` shows only `compose.eval.yml` as a GitHub Release asset. `.github/workflows/release.yml:249-254` attaches only `compose.eval.yml`. The release images contain `flowplane` and `fp-agent` (`Containerfile.release:4-12`; `Containerfile.eval:11-19`), so the agent can be obtained by running the combined image, but no standalone binary tarballs/checksums are published for operator installation and `flowplane-rls` is not included in the images or release assets. |
+| 2. Network binding | A | PASS | CP API and xDS bind addresses are configurable and default non-loopback: `FLOWPLANE_API_ADDR` resolves from env/file/default `0.0.0.0:8080` in `crates/fp-core/src/config.rs:153,182-190`; `FLOWPLANE_XDS_ADDR` resolves from env/file/default `0.0.0.0:18000` in `crates/fp-core/src/config.rs:193-201`. API server binds the resolved address in `crates/flowplane/src/serve.rs:236-266`; xDS server passes resolved `xds_addr` to `serve_mtls` or dev plaintext in `crates/flowplane/src/serve.rs:140-181`. RLS listen defaults are non-loopback in `docs/reference/configuration.md:59-60`. Hardcoded loopback remains intentional for Envoy admin inside the DP unit: `crates/fp-api/src/dataplanes_api.rs:644-648` and `crates/fp-agent/src/main.rs:32-37`. |
+| 3. DP bootstrap remote CP address | A | UNVERIFIED | Source inspection shows the intended mechanism: the CLI accepts `--xds-host` and `--xds-port`, defaulting to `127.0.0.1` / `18000`, in `crates/flowplane/src/cli/commands.rs:966-974`; CLI forwards those query params in `crates/flowplane/src/cli/mod.rs:1861-1865`; REST bootstrap query names `xds_host` as the host/DNS Envoy uses to reach CP in `crates/fp-api/src/dataplanes_api.rs:188-198`; rendering places `{xds_host}` / `{xds_port}` into the `xds_cluster` socket address in `crates/fp-api/src/dataplanes_api.rs:673-681`. However, no captured command output in this verification generated bootstrap from a running CP with a remote, non-loopback `--xds-host`, so the release behavior remains unverified. Localhost default is still a documented hazard for split-node use if the operator omits `--xds-host`. |
+| 4. Transport security | A | PASS | Production xDS is mTLS-or-disabled: when `config.xds_tls` exists, xDS starts with `serve_mtls` and cert/key/client-CA paths in `crates/flowplane/src/serve.rs:140-163`; without xDS TLS and outside dev mode the listener is disabled with a warning in `crates/flowplane/src/serve.rs:186-190`. Config validates the xDS TLS triad all-or-none in `crates/fp-core/src/config.rs:248-270`, with tests for partial rejection in `crates/fp-core/src/config.rs:617-642`. Envoy bootstrap requires cert/key/CA in `mtls` mode in `crates/flowplane/src/cli/mod.rs:1853-1859` and `crates/fp-api/src/dataplanes_api.rs:568-587`. Agent diagnostics supports mTLS materials and TLS server verification in `crates/fp-agent/src/main.rs:51-65,106-121,241-258`. |
+| 5. DP AuthN/AuthZ and secret handling | A | PASS | `spec/04-xds.md:33-48` specifies DP identity as SPIFFE URI plus database certificate binding, and explicitly says `node.metadata.team` is never authorization. The API issues certificates at `POST /api/v1/teams/{team}/proxy-certificates/issue` and the returned view includes `certificate_pem`, `private_key_pem`, and `ca_certificate_pem` once in `crates/fp-api/src/dataplanes_api.rs:116-130`; v2.1.0 docs state Flowplane never stores the private key in `docs/how-to/register-dataplane-mtls.md:39-70`. Agent TLS client identity is loaded from cert/key files in `crates/fp-agent/src/main.rs:245-256`. |
+| 6. Health/readiness with CP and DP on different hosts | A | UNVERIFIED | CP `/healthz` and `/readyz` exist (`crates/fp-api/src/routes.rs` found via grep at routes `238-239` and handlers `344-366`); agent `/healthz` exists and requires recent Envoy admin poll plus diagnostics ack in `crates/fp-agent/src/main.rs:340-382`; RLS `/healthz` and `/readyz` exist in `crates/flowplane-rls/src/admin.rs` per grep output. However, no command output in this verification proves these endpoints working with CP and DP on separate hosts. |
+| 7. Split-node mode documented | B | PASS | `docs/how-to/production-readiness.md:10-13` says to deploy control plane and dataplane bundle separately. `docs/how-to/register-dataplane-mtls.md:91-103` documents an agent dialing `https://cp.example.com:18000`. |
+| 8. Documentation completeness | B | FAIL | Docs cover some pieces but not all. They cover CP xDS/API config in `docs/how-to/production-readiness.md:16-28,51-68`, DP cert issuance in `docs/how-to/register-dataplane-mtls.md:39-89`, and agent startup in `docs/how-to/register-dataplane-mtls.md:91-116`. Missing or incomplete: no no-clone install path for `fp-agent`/future `flowplane-agent`; no no-clone install path for `flowplane-rls`; no DP-only image or binary artifact path; no complete two-host example with ports/firewall; no release asset download commands for operator binaries; no cert rotation runbook for the DP agent; no fully self-contained RLS production deployment path. |
+| 9. Documentation accuracy | B | FAIL | Drift/gaps: v2.1.0 docs use `fp-agent` (`docs/how-to/register-dataplane-mtls.md:5,91-103`), while the preferred public name is `flowplane-agent`; `docs/how-to/global-rate-limit.md:19` says `flowplane-rls` can be built with `cargo build` or a release artifact, but no release artifact exists; `docs/how-to/production-readiness.md:32-44` tells operators to run repo-local `scripts/release/package-release.sh`, which violates no-clone operator documentation. The GitHub Release asset output above proves only `compose.eval.yml` is published. |
+| 10. Runnable by reader on two hosts using only docs | B | FAIL | Not runnable. A reader cannot obtain standalone `fp-agent`/`flowplane-agent` or `flowplane-rls` from `v2.1.0` GitHub Release assets; release workflow only attaches `compose.eval.yml` (`.github/workflows/release.yml:249-254`). The combined GHCR image contains `fp-agent`, but the docs do not present a no-clone split-node path that uses that image as the DP agent artifact. The docs also require a repo-local packaging script (`docs/how-to/production-readiness.md:32-44`) and source build fallback for RLS (`docs/how-to/global-rate-limit.md:19`). |
+| 11. Operations: upgrade/rollback/version-skew/troubleshooting | B | FAIL | `docs/how-to/production-readiness.md:47-49` briefly says CP/DP upgrade order is independent and existing DPs keep serving last-applied config during CP restart. Troubleshooting table covers generic connectivity/TLS signals in `docs/how-to/production-readiness.md:97-109`. Missing: explicit version-skew policy between CP, Envoy bootstrap, agent, and RLS; rollback steps; agent/RLS binary compatibility matrix; cross-node TLS/SNI/firewall troubleshooting examples; no-clone artifact validation for all required binaries. |
+| 12. Location/discoverability | B | PASS | `docs/README.md:54-61` says implementation truth is code/tests, user/operator truth is canonical docs pages, deployment examples link to canonical pages, and design rationale is `spec/` plus issues. `docs/README.md:20-30` says public docs must be completable without `spec/` or `internal/`. This report belongs in `spec/` as behavioral/release-readiness analysis; public operator fixes belong in `docs/how-to` / `docs/reference`; release evidence is canonical in the vault per constitution boundary `flowplane-private-vault/constitution.md:81-82` and docs policy `docs/README.md:7`. |
+
+## Binary / Runtime Sub-Verdict
+
+**BINARY READY? NO.**
+
+Runtime code has strong split-node primitives:
+
+- API and xDS bind addresses are configurable and default to non-loopback.
+- Envoy bootstrap can point to a remote CP host/port.
+- xDS production path is mTLS-or-disabled.
+- DP identity is certificate/SPIFFE plus registry binding.
+- Agent diagnostics can connect outbound to a remote CP over TLS/mTLS.
+
+Blocking binary/runtime items:
+
+1. `v2.1.0` publishes no standalone operator binary artifacts. The release workflow attaches only `compose.eval.yml`, and the release page contains no tarballs for `flowplane`, `fp-agent`/`flowplane-agent`, or `flowplane-rls`.
+2. The release images include `fp-agent`, not the intended public binary name `flowplane-agent`.
+3. `flowplane-rls` is a separate binary crate, but it is neither in the release images nor attached as a release asset.
+4. No captured split-node runtime command output proves CP health, DP agent health, xDS status, and RLS health with CP and DP on separate hosts.
+
+## Documentation Sub-Verdict
+
+**DOCS READY? NO.**
+
+The docs describe the architecture direction, but they do not make the split-node deployment completable by an outside operator using only published artifacts.
+
+Blocking documentation items:
+
+1. The docs require or imply binaries that are not downloadable from the current release.
+2. The docs still rely on repo-local/source-oriented paths (`scripts/release/package-release.sh`, `cargo build --bin flowplane-rls`) for operator flows.
+3. The dataplane agent is documented as `fp-agent`; the desired public/operator name is `flowplane-agent`.
+4. The RLS path is under-documented for no-clone production-shaped evaluation.
+5. Operations coverage lacks explicit version-skew, rollback, and split-node troubleshooting details.
+
+## Overall Verdict
+
+**OVERALL: NOT READY.**
+
+Both sub-verdicts must pass for split-node deployment readiness. Binary/runtime is not ready because the current release does not publish all required operator binaries and lacks split-node runtime proof. Documentation is not ready because a reader cannot stand up CP and DP on separate hosts using only public docs and published artifacts.
+
+## Constitution Cross-Check
+
+The fail-closed verdict is required by the architecture-integrity constitution:
+
+- The constitution requires CP and dataplane to be separate deployment units and says localhost/loopback is dev-only, with dataplane units connecting outbound to CP and generated bootstrap carrying resolved addresses/ports/cert paths explicitly (`flowplane-private-vault/constitution.md:43`).
+- It requires tenant isolation by mTLS certificate-registry binding, not self-reported node metadata (`flowplane-private-vault/constitution.md:45`).
+- It requires fail-closed security boundaries: production xDS is mTLS-or-off, partial TLS config fails boot, dev plaintext is explicit/gated (`flowplane-private-vault/constitution.md:49`).
+- It requires deployment packaging to preserve security boundaries, with runtime secrets/certs from deployment secret mechanisms and dataplane control traffic over CP-terminated mTLS (`flowplane-private-vault/constitution.md:50`).
+- It forbids Envoy admin as an operator/product API and requires diagnostics through the agent/CP path (`flowplane-private-vault/constitution.md:51`).
+
+The code mostly aligns with these invariants. The release packaging and public docs do not yet provide a no-clone, split-node-completable operator path, so readiness cannot be declared.
+
+## Required Blocking Fixes Before READY
+
+1. Publish standalone release tarballs/assets for supported platforms containing:
+   - `flowplane`
+   - `flowplane-agent`
+   - `flowplane-rls`
+   - checksums and install/verify instructions
+2. Rename the public dataplane agent binary and docs from `fp-agent` to `flowplane-agent`; keep any internal crate name as implementation detail only.
+3. Include `flowplane-rls` in release packaging or publish a documented container/artifact for it.
+4. Replace public docs that require `scripts/release/package-release.sh` or `cargo build` for operator evaluation.
+5. Add a complete split-node runbook covering:
+   - CP bind/listen config
+   - remote DP bootstrap with `--xds-host`
+   - xDS mTLS server/client CA roles
+   - dataplane cert issue/register/rotation/revocation
+   - agent and RLS install/run commands from release artifacts
+   - ports and firewall matrix
+   - health/readiness/xDS/RLS checks
+   - upgrade/rollback/version-skew policy
+   - troubleshooting for DNS, TCP, TLS, SPIFFE/cert binding, NACKs, and diagnostics acks
+6. Capture and attach runtime evidence from a real two-node or network-isolated rehearsal.

--- a/spec/17-split-node-runtime-rehearsal-v2.1.1-rc.md
+++ b/spec/17-split-node-runtime-rehearsal-v2.1.1-rc.md
@@ -1,0 +1,177 @@
+# 17 — Split-Node Runtime Rehearsal (v2.1.1-rc branch evidence)
+
+> Status: runtime verification report (companion to `spec/17-split-node-release-readiness.md`)
+> Scope: branch `feature/fpv2-0ym-adoption-evaluation-spine`, packaged `2.1.1-rc` Linux artifacts
+> Verdict rule: fail closed. Any `FAIL` or `UNVERIFIED` means the checked area is NOT READY.
+> Canonicality note: per the architecture-integrity constitution, release evidence is canonical
+> in `../flowplane-private-vault`. This file is the in-repo delivery copy of that evidence for the
+> branch work; the vault remains the canonical home.
+
+This report supersedes the *source-inspection-only* `UNVERIFIED` rows in
+`spec/17-split-node-release-readiness.md` (checks 3 and 6) with **captured runtime evidence** from a
+real, network-isolated split-node rehearsal, and re-checks the prior `FAIL` rows (published binary
+artifacts, `fp-agent` naming, missing `flowplane-rls`) against the branch.
+
+## Runtime Environment Under Test
+
+| Field | Value |
+| --- | --- |
+| Branch | `feature/fpv2-0ym-adoption-evaluation-spine` |
+| Branch HEAD SHA | `aaeef638295d4b97d26a9daa542e20cd33cf9c7e` |
+| Relevant branch commits | `ef857ac fpv2-snr.1 publish split-node artifacts`, `aaeef63 fpv2-snr.2 document split-node release path` |
+| Artifact under test | `flowplane-2.1.1-rc-linux-amd64.tar.gz` (built from this branch) |
+| Compiled-in version | `2.1.0` (workspace `Cargo.toml` version; `-rc` affects packaging/naming only — see Observations) |
+| OS / arch | Ubuntu 24.04.4 LTS (Noble), `x86_64`, kernel `6.18.5` |
+| Container runtime | Docker `29.3.1` (build c2be9cc); Podman: not installed |
+| Rust | `rustc 1.94.1 (e408947bf 2026-03-25)`, `cargo 1.94.1` |
+| Envoy | `envoyproxy/envoy:v1.37-latest` (the image pinned by `compose.eval.yml`) |
+| Build command | `FLOWPLANE_RELEASE_VERSION=2.1.1-rc FLOWPLANE_RELEASE_HOST=linux-amd64 scripts/release/package-release.sh` |
+
+All binaries exercised in the proof path are the **packaged release-style binaries** from the
+unpacked archive; `target/debug` and source-tree-only binaries were not used.
+
+## Verdict Table
+
+| Check | Area | Status | Evidence |
+| --- | --- | --- | --- |
+| 1. Release artifact build | Binary | PASS | `package-release.sh` produced `flowplane-2.1.1-rc-linux-amd64.tar.gz` (16 MB), `*.cargo-metadata.sbom.json`, `SHA256SUMS`. `sha256sum -c SHA256SUMS` → both `OK`. |
+| 2. Archive contents | Binary | PASS | Tarball contains `bin/flowplane`, `bin/flowplane-agent`, `bin/flowplane-rls`, `bin/fp-agent` (symlink → `flowplane-agent`), `release-manifest.md`. `SHA256SUMS` is published alongside the tarball (it checksums it), per standard release layout. |
+| 3. Binary smoke checks | Binary | PASS | `flowplane --help`, `flowplane-agent --help`, `fp-agent --help` (alias usage prints `fp-agent`) all emit usage. `timeout 5s flowplane-rls` → exit `124` (ran until killed; startup log `flowplane-rls starting grpc=0.0.0.0:50051 admin=0.0.0.0:8081`). |
+| 4. CP non-loopback bind | Runtime | PASS | `FLOWPLANE_API_ADDR=0.0.0.0:8080`, `FLOWPLANE_XDS_ADDR=0.0.0.0:18000`. In-namespace `/proc/net/tcp` shows `LISTEN 0.0.0.0:8080` (`00000000:1F90`) and `LISTEN 0.0.0.0:18000` (`00000000:4650`) — both `0.0.0.0`, not `127.0.0.1`. CP log: `xDS ADS server starting (mTLS, certificate-registry binding) addr 0.0.0.0:18000`. |
+| 5. Envoy bootstrap → remote CP | Runtime | PASS | CLI-generated bootstrap. `grep` over `envoy.yaml`: only `127.0.0.1` is the Envoy **admin** (`:9901`, loopback by design); `xds_cluster` endpoint is `flowplane-cp:18000`. mTLS `UpstreamTlsContext` references client cert/key + `server-ca.crt`. |
+| 6. xDS mTLS cross-node | Runtime | PASS | Envoy admin: `control_plane.connected_state: 1`, `cluster.xds_cluster.ssl.handshake: 1`, `upstream_cx_connect_fail: 0`, `xds_cluster::172.18.0.4:18000::health_flags::healthy`. CP log: `dataplane authenticated via certificate registry … dataplane connected`. No TLS/auth failures in CP or Envoy logs. |
+| 7. Agent cross-node | Runtime | PASS | `flowplane-agent` (separate container) → `--cp-endpoint https://flowplane-cp:18000` mTLS, `--envoy-admin-url http://flowplane-envoy:9901`. Agent `/healthz` → `ok`. CP log: `dataplane authenticated via certificate registry … node: diagnostics`. `dataplane get` shows `last_heartbeat_at` advancing. |
+| 8. CP health/readiness | Runtime | PASS | `/healthz` → `{"status":"ok","version":"2.1.0"}`; `/readyz` → `{"status":"ready","checks":[{database,ok},{xds_outbox_consumer,ok},{xds_outbox_lag,ok}]}`. |
+| 9. RLS health/readiness | Runtime | PASS | `flowplane-rls` (separate container) `/healthz` → HTTP `200`, `/readyz` → HTTP `200`. |
+| 10. CLI operational checks | Runtime | PASS | `flowplane stats overview --team payments` → `live_dataplanes: 1`. `flowplane ops xds status --team payments` → `health: healthy`, `recent_nack_count: 0`, dataplane `live: true`. |
+| 11. DP identity = cert-registry binding | Runtime | PASS | Issued client cert SAN `URI:spiffe://flowplane.local/org/<org>/team/<team>/proxy/<dp-id>`, issuer `flowplane-dp-issuer-ca` (from `FLOWPLANE_CERT_ISSUER_CA_*`). CP authenticated the stream "via certificate registry", not node metadata. |
+| 12. Split-node network identities | Runtime | PASS | 6 containers with distinct bridge IPs on `flowplane-net` (CP `172.18.0.4`, Envoy `172.18.0.5`, agent `172.18.0.6`). DP reaches CP by bridge IP, never `127.0.0.1`. All host port publications bound to `127.0.0.1` only. |
+| 13. Published v2.1.1 release assets | Binary/Docs | **FAIL** | `gh`/Releases API: latest published release is **`v2.1.0`** (assets: `compose.eval.yml` + source archives only). **No `v2.1.1` or `v2.1.1-rc` release exists.** The branch wires `release.yml` to attach binary tarballs/SBOM/`SHA256SUMS` and smoke-test all three binaries, but it is **unmerged and unpublished**. |
+
+## Topology Used
+
+```
+                     Docker bridge: flowplane-net (172.18.0.0/16)
+  flowplane-postgres(.2)  flowplane-idp(.3)  flowplane-cp(.4)
+  flowplane-envoy(.5)     flowplane-agent(.6)  flowplane-rls(.7)
+```
+
+- CP↔DP traffic crosses the bridge by DNS name / bridge IP — never localhost.
+- Throwaway local CA material: a `flowplane-xds-server-ca` (signs the CP xDS **server** cert, SAN
+  `flowplane-cp`) and a separate `flowplane-dp-issuer-ca` (`FLOWPLANE_CERT_ISSUER_CA_*`; the CP mints
+  DP **client** certs from it and trusts it as `FLOWPLANE_XDS_TLS_CLIENT_CA`).
+- Throwaway local IdP: an nginx container (`flowplane-idp`) serving a static JWKS; CP configured with
+  `FLOWPLANE_OIDC_ISSUER`/`FLOWPLANE_OIDC_AUDIENCE`/`FLOWPLANE_OIDC_JWKS_URI`. Platform admin
+  bootstrapped with test OIDC subject `oidc-rehearsal-admin`; a locally-minted RS256 JWT validated
+  against the JWKS (`whoami` → `platform_admin: true`). No real credentials or external IdP.
+
+## Exact Commands (abridged, secrets redacted)
+
+```bash
+# Build
+FLOWPLANE_RELEASE_VERSION=2.1.1-rc FLOWPLANE_RELEASE_HOST=linux-amd64 scripts/release/package-release.sh
+sha256sum -c SHA256SUMS
+tar xzf flowplane-2.1.1-rc-linux-amd64.tar.gz -C <staging>
+
+# Smoke
+bin/flowplane --help; bin/flowplane-agent --help; bin/fp-agent --help; timeout 5s bin/flowplane-rls
+
+# CP xDS mTLS + cert issuer + OIDC (env-file, key/token redacted)
+FLOWPLANE_API_ADDR=0.0.0.0:8080  FLOWPLANE_XDS_ADDR=0.0.0.0:18000  FLOWPLANE_API_INSECURE=true
+FLOWPLANE_XDS_TLS_CERT=/etc/flowplane/tls/xds-server.crt  FLOWPLANE_XDS_TLS_KEY=…  FLOWPLANE_XDS_TLS_CLIENT_CA=/etc/flowplane/ca/issuer-ca.crt
+FLOWPLANE_CERT_ISSUER_CA_CERT_PATH=/etc/flowplane/ca/issuer-ca.crt  FLOWPLANE_CERT_ISSUER_CA_KEY_PATH=…  FLOWPLANE_CERT_ISSUER_TRUST_DOMAIN=flowplane.local
+FLOWPLANE_OIDC_ISSUER=https://idp.flowplane.local  FLOWPLANE_OIDC_AUDIENCE=flowplane  FLOWPLANE_OIDC_JWKS_URI=http://flowplane-idp/jwks.json
+flowplane db migrate && flowplane serve
+
+# Bootstrap + provision (admin JWT)
+curl -X POST .../api/v1/bootstrap/initialize -H "Authorization: Bearer <bootstrap-token>" -d '{"org_name":"platform",…,"admin_subject":"oidc-rehearsal-admin",…}'
+flowplane org create rehearsal-org;  flowplane org member add rehearsal-org --role owner --subject oidc-rehearsal-admin
+flowplane --org rehearsal-org team create payments
+flowplane --org rehearsal-org dataplane create edge-gateway-1 --team payments
+flowplane --org rehearsal-org dataplane cert issue edge-gateway-1 --team payments --ttl-hours 24
+
+# Bootstrap pointing at remote CP DNS
+flowplane --org rehearsal-org --out envoy.yaml dataplane bootstrap edge-gateway-1 --team payments --mode mtls \
+  --xds-host flowplane-cp --xds-port 18000 --cert-path … --key-path … --ca-path /etc/flowplane/dp/server-ca.crt
+grep -n "flowplane-cp\|127.0.0.1\|localhost" envoy.yaml
+
+# Envoy + agent + RLS (separate containers on flowplane-net)
+docker run … envoyproxy/envoy:v1.37-latest -c /etc/envoy/envoy.yaml
+flowplane-agent --envoy-admin-url http://flowplane-envoy:9901 --cp-endpoint https://flowplane-cp:18000 \
+  --dataplane-id <uuid> --tls-cert-path … --tls-key-path … --tls-ca-path … --tls-server-name flowplane-cp --health-bind-addr 0.0.0.0:19902
+flowplane-rls   # FLOWPLANE_RLS_GRPC_LISTEN=0.0.0.0:50051 FLOWPLANE_RLS_ADMIN_LISTEN=0.0.0.0:8081
+
+# Checks
+curl .../healthz .../readyz   # CP and RLS
+curl http://127.0.0.1:<agent>/healthz
+flowplane stats overview --team payments;  flowplane ops xds status --team payments
+```
+
+## Rehearsal Accommodations (documented, non-product)
+
+1. **API plaintext** (`FLOWPLANE_API_INSECURE=true`): the operator/API hop ran plaintext behind the
+   loopback-only host mapping to avoid standing up a second TLS endpoint. The **xDS** path — the hop
+   that matters for split-node security — was full mTLS. The CP logged the expected plaintext-API
+   warning.
+2. **Envoy admin rebind for a two-container split:** the *generated* bootstrap correctly defaults
+   admin to `127.0.0.1` (Check 5 evidence — the loopback-only invariant holds by default). For this
+   rehearsal the admin address was rebound to `0.0.0.0` **only** so the separate `flowplane-agent`
+   container could reach `flowplane-envoy:9901` (the task topology) and so the host could capture
+   `/clusters`/`/config_dump`. Admin was published to `127.0.0.1` on the host only, never to a public
+   interface. In a real deployment the agent is a dataplane-local sidecar sharing Envoy's namespace
+   and reaches admin over loopback.
+
+## Sub-Verdicts
+
+- **BINARY READY (branch artifacts + runtime)? PASS.** The packaged `2.1.1-rc` artifacts contain all
+  three operator binaries plus the `fp-agent` compatibility alias, pass smoke checks, and run a full
+  cross-node split-node topology: CP binds non-loopback, Envoy bootstrap targets the remote CP DNS,
+  xDS connects over mTLS with certificate-registry binding, the agent connects cross-node, and CP/RLS
+  health/readiness and CLI ops all succeed with zero TLS/auth failures and zero NACKs.
+- **DOCS READY (branch content)? PASS.** `docs/how-to/production-readiness.md` now provides a no-clone
+  install path (download tarball + `SHA256SUMS` verify + `install`), uses `flowplane-agent` (with
+  `fp-agent` called out as a deprecated alias), documents `flowplane-rls`, ports/firewall matrix,
+  upgrade/rollback, version-skew, and split-node TLS/bootstrap troubleshooting.
+  `register-dataplane-mtls.md` and `global-rate-limit.md` now point at published artifacts. Caveat:
+  these docs reference `2.1.1` download URLs that **do not yet resolve** until v2.1.1 is published.
+- **PUBLISHED-ARTIFACT READY (v2.1.1 release)? FAIL.** No `v2.1.1` GitHub Release or GHCR tag exists;
+  `v2.1.0` still publishes only `compose.eval.yml`. The fix is present in branch code but unmerged.
+
+## Overall Verdict
+
+- **BRANCH split-node readiness: READY.** Every runtime and artifact-build check passed against the
+  packaged `2.1.1-rc` binaries from this branch. The prior report's `UNVERIFIED` runtime rows (xDS
+  mTLS, cross-host health) are now `PASS` with captured evidence, and its `FAIL` rows for binary
+  packaging (`flowplane-rls` absent, `fp-agent` naming, no standalone tarballs) are resolved in branch
+  artifacts and the release workflow.
+- **PUBLISHED v2.1.1 release readiness: NOT READY.** Until the branch merges and a `v2.1.1` tag runs
+  the updated `release.yml` and attaches the tarballs/SBOM/`SHA256SUMS` (and the docs' `2.1.1` URLs
+  resolve), the published surface is unchanged from `v2.1.0`.
+
+## Blocking Items (most severe first)
+
+1. **No published v2.1.1 artifacts (issue #220 blocker).** Latest release is `v2.1.0` with only
+   `compose.eval.yml`. **Do not close issue #220** on this evidence — local `2.1.1-rc` artifacts prove
+   branch readiness but are not published assets. Closing requires a real `v2.1.1` GitHub Release/GHCR
+   build verified to contain `flowplane`, `flowplane-agent`, `flowplane-rls`, checksums, and SBOM.
+2. **Docs reference unpublished `2.1.1` download URLs.** `production-readiness.md` install commands
+   resolve only after v2.1.1 is published; this is doc/runtime skew until the release ships, not a
+   code defect.
+
+## Observations (non-blocking)
+
+- **Compiled version vs artifact label.** `flowplane --version` / `flowplane-agent --version` and CP
+  `/healthz` report `2.1.0` (the workspace `Cargo.toml` version on this branch).
+  `FLOWPLANE_RELEASE_VERSION=2.1.1-rc` only renames/labels the artifact; it does not bump the
+  compiled-in version. The real v2.1.1 release path bumps the workspace version (the `resolve-version`
+  job + version-bump commit), so published binaries will self-report `2.1.1`. Worth confirming at tag
+  time.
+- `flowplane-rls` has no `--version` flag (it is a long-running service binary); `--help`/smoke run is
+  the appropriate liveness check.
+
+## Teardown
+
+All rehearsal containers (`flowplane-postgres`, `flowplane-idp`, `flowplane-cp`, `flowplane-envoy`,
+`flowplane-agent`, `flowplane-rls`), the `flowplane-net` bridge network, and the ephemeral Postgres
+volume were removed; `docker ps -a`/`network ls`/`volume ls` confirm none remain. All tokens,
+bootstrap tokens, and private keys were redacted from this report.


### PR DESCRIPTION
## Summary

This PR adds the adoption/evaluation documentation spine and the split-node release-readiness work for Flowplane 2.1.1.

Key changes:
- Adds no-clone developer and platform evaluation paths.
- Adds OIDC, bootstrap, tenant/team/user/grant, API-team onboarding, and REST body guidance.
- Updates production readiness, dataplane mTLS, RLS, AWS, CLI, and observability docs.
- Publishes release packaging support for `flowplane`, `flowplane-agent`, and `flowplane-rls` Linux tarballs plus checksums/SBOMs.
- Updates release images to include `flowplane-agent`, `flowplane-rls`, and the deprecated `fp-agent` compatibility alias.
- Adds split-node readiness specs and runtime rehearsal evidence for `2.1.1-rc` branch artifacts.

## Notes

The branch-level split-node runtime rehearsal passed against packaged `2.1.1-rc` artifacts. Published release readiness remains blocked until an actual `v2.1.1` release exists and its assets are verified; issue `#220` should stay open until then.

## Validation

- `cargo build --locked -p fp-agent --bin flowplane-agent -p flowplane-rls --bin flowplane-rls`
- `cargo fmt --check`
- `cargo clippy --locked -p fp-agent --bin flowplane-agent -p flowplane-rls --bin flowplane-rls -- -D warnings`
- `scripts/release/package-release.sh` with test release version/host
- Hardened and eval image smoke tests for `flowplane`, `flowplane-agent`, `fp-agent`, and `flowplane-rls`
- `python3 scripts/ci/check-docs-boundary.py`
- `python3 scripts/ci/check-docs-jargon.py`
- Split-node runtime rehearsal evidence imported from Claude's verification report
