### PR TITLE
Prepare v2.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ upgrade of an earlier Flowplane line — there is no in-place migration path fro
 version. `1.0.0` is its first stable release and the point at which the public REST API,
 CLI surface, and configuration contract become subject to semantic versioning.
 
+## [2.1.1] - 2026-06-30
+
+Patch release. Documentation and release-packaging update for no-clone evaluation and
+split-node deployment readiness.
+
+### Added
+
+- No-clone developer and platform evaluation docs, including OIDC/bootstrap, tenant/team/user
+  lifecycle, API-team onboarding, REST body examples, and operator verification paths.
+- Release packaging for Linux `flowplane`, `flowplane-agent`, and `flowplane-rls` tarballs with
+  checksums and SBOMs.
+- Split-node runtime readiness evidence for packaged `2.1.1` branch artifacts.
+
+### Changed
+
+- Release images now include `flowplane-agent` and `flowplane-rls`; `fp-agent` remains as a
+  deprecated compatibility alias.
+- Production readiness, dataplane mTLS, RLS, AWS, CLI, and observability docs now point readers
+  toward public release artifacts instead of source checkout paths.
+
+### Fixed
+
+- Updated `anyhow` to `1.0.103` in `Cargo.lock` to clear `RUSTSEC-2026-0190` in `cargo deny`.
+
 ## [2.1.0] - 2026-06-27
 
 Minor release. **CLI Tier-2 help quality: `flowplane --help` is now self-sufficient.** Every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,7 +762,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flowplane"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "flowplane-rls"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "axum",
  "envoy-types",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "fp-agent"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "fp-api"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "axum",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "fp-core"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "fp-domain"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "base64",
  "chrono",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "fp-storage"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "fp-domain",
  "metrics",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "fp-xds"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 rust-version = "1.92"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Prepare Flowplane `v2.1.1` for release.

Changes:
- Bump workspace version from `2.1.0` to `2.1.1` in `Cargo.toml`.
- Refresh local workspace package versions in `Cargo.lock`.
- Add the `2.1.1` changelog entry.

## Validation

- `cargo check --workspace --locked`
- `cargo deny check` (`advisories ok, bans ok, licenses ok, sources ok`; existing warnings only)
- `cargo build --locked -p flowplane --bin flowplane --no-default-features -p fp-agent --bin flowplane-agent -p flowplane-rls --bin flowplane-rls`
- `target/debug/flowplane --version` -> `flowplane 2.1.1`
- `target/debug/flowplane-agent --version` -> `flowplane-agent 2.1.1`

## Release note

After this PR is merged, create and push annotated tag `v2.1.1` from the merge commit so the Release workflow publishes the Linux tarballs, SBOMs, checksums, and GHCR images from the tagged commit.
