### PR TITLE
Update docs for v2.1.1 release references

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ published **evaluation** image and stands up the whole stack — Postgres, the d
 demo upstream, and Envoy — then routes a real request through the gateway. No repo checkout, no
 `cargo build`.
 
-> Set `VER` to a published release. The example below uses `2.1.0`, whose evaluator bundle and
+> Set `VER` to a published release. The example below uses `2.1.1`, whose evaluator bundle and
 > `:${VER}-eval` image are published for `linux/amd64` and `linux/arm64`. For newer releases,
 > use the version shown on the GitHub Releases page. The image is **multi-arch**: a plain
 > `docker pull` resolves the native variant — no `--platform` flag, no emulation.
 
 ```bash
-VER=2.1.0
+VER=2.1.1
 
 # 1. Fetch the evaluator bundle at the matching release tag (the only file you need)
 curl -fsSLO https://raw.githubusercontent.com/rajeevramani/flowplane/v${VER}/compose.eval.yml

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,7 +6,7 @@ Exhaustive reference for the `flowplane` binary: global options, every top-level
 
 To drive the CLI from a script or agent, see the how-to [Script Flowplane from a shell or agent](../how-to/script-the-cli.md); for the reasoning behind the output envelope, exit codes, and `schema`, see [The CLI as a typed contract](../concepts/cli-contract.md).
 
-`flowplane --help` is self-sufficient: as of 2.1.0 every command and subcommand shows a one-line summary, every flag and positional shows help text, and the workflow ("spine") commands — resource `create`/`update`, `route generate`, `api create`, `expose`/`unexpose`/`apply`, the capture/discovery starters, `dataplane bootstrap`/`cert register`/`issue`/`revoke`, `secret create`/`rotate` — carry a copy-pasteable example in their `--help`. This page is the exhaustive reference; `--help` is the in-terminal quick path.
+`flowplane --help` is self-sufficient: as of 2.1.1 every command and subcommand shows a one-line summary, every flag and positional shows help text, and the workflow ("spine") commands — resource `create`/`update`, `route generate`, `api create`, `expose`/`unexpose`/`apply`, the capture/discovery starters, `dataplane bootstrap`/`cert register`/`issue`/`revoke`, `secret create`/`rotate` — carry a copy-pasteable example in their `--help`. This page is the exhaustive reference; `--help` is the in-terminal quick path.
 
 ## Global options
 

--- a/docs/tutorials/evaluate-no-clone.md
+++ b/docs/tutorials/evaluate-no-clone.md
@@ -10,10 +10,10 @@ The evaluation bundle runs dev mode: an in-process identity issuer, seeded `dev-
 
 ## 1. Start the published evaluator bundle
 
-Use a published release. This example uses `2.1.0`, whose eval compose file and multi-arch eval image are published:
+Use a published release. This example uses `2.1.1`, whose eval compose file and multi-arch eval image are published:
 
 ```bash
-VER=2.1.0
+VER=2.1.1
 
 curl -fsSLO https://raw.githubusercontent.com/rajeevramani/flowplane/v${VER}/compose.eval.yml
 

--- a/spec/17-split-node-release-readiness.md
+++ b/spec/17-split-node-release-readiness.md
@@ -1,8 +1,24 @@
 # 17 - Split-Node Release Readiness Verification
 
-> Status: verification report
-> Scope: current published release `v2.1.0`
+> Status: historical verification report with post-release update
+> Scope: historical published release `v2.1.0`, plus current `v2.1.1` release update
 > Verdict rule: fail closed. Any `FAIL` or `UNVERIFIED` means the checked area is not ready.
+
+## v2.1.1 Post-Release Update
+
+`v2.1.1` is now published from tag commit `cbb40e4b3ed75fa6275b8594e89abc01ae956fed`.
+The GitHub Release contains the no-clone split-node artifacts introduced by this work:
+
+- `compose.eval.yml`
+- `flowplane-2.1.1-linux-amd64.tar.gz`
+- `flowplane-2.1.1-linux-arm64.tar.gz`
+- `flowplane-2.1.1-linux-amd64.cargo-metadata.sbom.json`
+- `flowplane-2.1.1-linux-arm64.cargo-metadata.sbom.json`
+- `SHA256SUMS`
+
+The user-facing docs now use `2.1.1` in no-clone examples. The historical `v2.1.0` evidence below
+is retained to document the blocker that caused the split-node release-readiness work; it is no
+longer the current published surface.
 
 ## v2.1.1-rc Branch Runtime Addendum
 
@@ -30,7 +46,7 @@ Updated readiness interpretation:
 | --- | --- | --- |
 | Published `v2.1.0` | NOT READY | Release assets lack standalone operator/agent/RLS binaries and docs cannot be completed no-clone. |
 | Branch `2.1.1-rc` artifacts | READY for branch runtime evidence | Split-node artifact, mTLS, agent, RLS, health, and ops checks passed in a network-isolated rehearsal. |
-| Published `v2.1.1` | NOT READY until release | No `v2.1.1` GitHub Release/GHCR assets exist yet. Do not close issue #220 until real published assets are verified. |
+| Published `v2.1.1` | READY for artifact availability | GitHub Release assets now include Linux amd64/arm64 tarballs, SBOMs, checksums, and the eval compose file. |
 
 ## Release Under Review
 

--- a/spec/17-split-node-runtime-rehearsal-v2.1.1-rc.md
+++ b/spec/17-split-node-runtime-rehearsal-v2.1.1-rc.md
@@ -7,6 +7,14 @@
 > in `../flowplane-private-vault`. This file is the in-repo delivery copy of that evidence for the
 > branch work; the vault remains the canonical home.
 
+## Post-Release Update
+
+`v2.1.1` is now published from tag commit `cbb40e4b3ed75fa6275b8594e89abc01ae956fed`. The GitHub
+Release contains `flowplane-2.1.1-linux-amd64.tar.gz`, `flowplane-2.1.1-linux-arm64.tar.gz`, the
+per-arch cargo metadata SBOMs, `SHA256SUMS`, and `compose.eval.yml`. The pre-release row below that
+marked published assets as `FAIL` is retained as historical evidence for the branch rehearsal; it is
+superseded by the published `v2.1.1` release assets.
+
 This report supersedes the *source-inspection-only* `UNVERIFIED` rows in
 `spec/17-split-node-release-readiness.md` (checks 3 and 6) with **captured runtime evidence** from a
 real, network-isolated split-node rehearsal, and re-checks the prior `FAIL` rows (published binary


### PR DESCRIPTION
## Summary

Update current release documentation references after publishing `v2.1.1`.

Changes:
- README no-clone Quick Start now uses `VER=2.1.1`.
- `docs/tutorials/evaluate-no-clone.md` now uses `VER=2.1.1`.
- CLI reference now says the self-sufficient help baseline is `2.1.1`.
- Split-node specs now include post-release notes that `v2.1.1` assets are published and that the older `v2.1.0` rows are historical evidence.

## Verification

- `rg -n "2\\.1\\.0|v2\\.1\\.0" README.md docs deploy internal` returns no matches.
- Remaining `2.1.0` references are in `CHANGELOG.md` and historical `spec/17` evidence only.
- `python3 scripts/ci/check-docs-boundary.py`
- `python3 scripts/ci/check-docs-jargon.py`
- `git diff --check`
