### PR TITLE
AI request tracing + trace-issue fixes (#226–#231)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ internal/.env.auth0.example
 # ai-dev-framework local config
 .aidf.yml
 
+
+
 # local
 .local/
 .pi/
@@ -18,6 +20,7 @@ scripts/flowplane-dev
 scripts/flowplane-dev.py
 .beads/
 scratchpad/
+.ramu-kaka/
 
 # internal build-journey scaffolding (agent prompts / automation notes)
 internal/dev-workflow-automation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,145 @@
+# Project Instructions for AI Agents
+
+This file provides instructions and context for AI coding agents working on this project.
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:full hash:f65d5d33 -->
+## Issue Tracking with bd (beads)
+
+**IMPORTANT**: This project uses **bd (beads)** for ALL issue tracking. Do NOT use markdown TODOs, task lists, or other tracking methods.
+
+### Why bd?
+
+- Dependency-aware: Track blockers and relationships between issues
+- Git-friendly: Dolt-powered version control with native sync
+- Agent-optimized: JSON output, ready work detection, discovered-from links
+- Prevents duplicate tracking systems and confusion
+
+### Quick Start
+
+**Check for ready work:**
+
+```bash
+bd ready --json
+```
+
+**Create new issues:**
+
+```bash
+bd create "Issue title" --description="Detailed context" -t bug|feature|task -p 0-4 --json
+bd create "Issue title" --description="What this issue is about" -p 1 --deps discovered-from:bd-123 --json
+```
+
+**Claim and update:**
+
+```bash
+bd update <id> --claim --json
+bd update bd-42 --priority 1 --json
+```
+
+**Complete work:**
+
+```bash
+bd close bd-42 --reason "Completed" --json
+```
+
+### Issue Types
+
+- `bug` - Something broken
+- `feature` - New functionality
+- `task` - Work item (tests, docs, refactoring)
+- `epic` - Large feature with subtasks
+- `chore` - Maintenance (dependencies, tooling)
+
+### Priorities
+
+- `0` - Critical (security, data loss, broken builds)
+- `1` - High (major features, important bugs)
+- `2` - Medium (default, nice-to-have)
+- `3` - Low (polish, optimization)
+- `4` - Backlog (future ideas)
+
+### Workflow for AI Agents
+
+1. **Check ready work**: `bd ready` shows unblocked issues
+2. **Claim your task atomically**: `bd update <id> --claim`
+3. **Work on it**: Implement, test, document
+4. **Discover new work?** Create linked issue:
+   - `bd create "Found bug" --description="Details about what was found" -p 1 --deps discovered-from:<parent-id>`
+5. **Complete**: `bd close <id> --reason "Done"`
+
+### Quality
+- Use `--acceptance` and `--design` fields when creating issues
+- Use `--validate` to check description completeness
+
+### Lifecycle
+- `bd defer <id>` / `bd supersede <id>` for issue management
+- `bd stale` / `bd orphans` / `bd lint` for hygiene
+- `bd human <id>` to flag for human decisions
+- `bd formula list` / `bd mol pour <name>` for structured workflows
+
+### Auto-Sync
+
+bd automatically syncs via Dolt:
+
+- Each write auto-commits to Dolt history
+- Use `bd dolt push`/`bd dolt pull` for remote sync
+- No manual export/import needed!
+
+### Important Rules
+
+- ✅ Use bd for ALL task tracking
+- ✅ Always use `--json` flag for programmatic use
+- ✅ Link discovered work with `discovered-from` dependencies
+- ✅ Check `bd ready` before asking "what should I work on?"
+- ❌ Do NOT create markdown TODO lists
+- ❌ Do NOT use external issue trackers
+- ❌ Do NOT duplicate tracking systems
+
+For more details, see README.md and docs/QUICKSTART.md.
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd dolt push
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+
+<!-- END BEADS INTEGRATION -->
+
+
+## Build & Test
+
+_Add your build and test commands here_
+
+```bash
+# Example:
+# npm install
+# npm test
+```
+
+## Architecture Overview
+
+_Add a brief overview of your project architecture_
+
+## Conventions & Patterns
+
+_Add your project-specific conventions here_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ upgrade of an earlier Flowplane line — there is no in-place migration path fro
 version. `1.0.0` is its first stable release and the point at which the public REST API,
 CLI surface, and configuration contract become subject to semantic versioning.
 
+## [Unreleased]
+
+### Added
+
+- **AI request tracing.** Every request through an AI gateway listener records a per-hop
+  trace row (route match, auth, budget, credential injection, upstream, usage) with
+  outcomes, per-hop timings, HTTP status, and token counts. Retrieve it with
+  `flowplane ai trace --request-id <id>`; a W3C `traceparent` is propagated to the provider
+  and its `trace_id` stored for APM correlation. Trace rows never contain prompt/response
+  bodies or credential values.
+- **AI trace retention.** Per-team trace TTL via `flowplane ai retention get|set`
+  (`GET`/`PUT /api/v1/teams/{team}/ai/retention`), default 30 days; rows are stamped with
+  their expiry at capture time.
+- **AI budget shadow previews.** The budget hop's `detail.shadow[]` reports would-be
+  rejections for shadow-mode budgets on otherwise-successful requests.
+
+### Fixed
+
+- AI gateway listeners now own `x-request-id`: a client-supplied id is ignored and the
+  server generates its own (returned in the response), so a caller cannot choose or collide
+  another request's trace key. (#227)
+- AI budget-exceeded (429) and credential-failure (500) rejections now return the JSON error
+  envelope `{"code","message"}` with `content-type: application/json`, matching the
+  `route_match` error style. (#230)
+- Listener-side AI rejections (budget, credential injection) now record the client-facing
+  HTTP status in the trace row's `status_code` instead of leaving it null. (#231)
+- `PUT /api/v1/teams/{team}/ai/retention` enforces optimistic concurrency: a stale or
+  malformed `If-Match` is rejected (409 / 400) instead of silently last-writer-winning. (#226)
+- Docs — AI trace hop timeline (a merged multi-stream view, not an execution-order waterfall;
+  corrected `latency_ms` scope) and the budget hop's `detail.shadow[]` shape now match the
+  runtime. (#228, #229)
+
 ## [2.1.1] - 2026-06-30
 
 Patch release. Documentation and release-packaging update for no-clone evaluation and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,6 +962,7 @@ dependencies = [
 name = "fp-storage"
 version = "2.1.1"
 dependencies = [
+ "chrono",
  "fp-domain",
  "metrics",
  "rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,6 +996,7 @@ dependencies = [
  "tonic",
  "tonic-prost",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "x509-parser",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,9 +473,9 @@ checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/flowplane/src/cli/commands.rs
+++ b/crates/flowplane/src/cli/commands.rs
@@ -382,6 +382,24 @@ pub enum AiCommand {
         #[command(subcommand)]
         command: ResourceCommand,
     },
+    /// Show the correlated hop timeline for AI data-plane requests.
+    #[command(
+        after_help = "Example:\n  flowplane ai trace --team payments --request-id 018ff2ef-bfc6-7000-8000-000000000001"
+    )]
+    Trace {
+        /// Team scope; defaults to the active context's team.
+        #[arg(long)]
+        team: Option<String>,
+        /// Server-generated x-request-id from the AI data-plane response.
+        #[arg(long)]
+        request_id: Option<String>,
+        /// W3C trace id from an inbound traceparent header.
+        #[arg(long)]
+        trace_id: Option<String>,
+        /// Maximum number of traces to return.
+        #[arg(long, default_value_t = 50)]
+        limit: i64,
+    },
     /// Show AI token-usage records.
     Usage {
         /// Team scope; defaults to the active context's team.

--- a/crates/flowplane/src/cli/commands.rs
+++ b/crates/flowplane/src/cli/commands.rs
@@ -400,6 +400,11 @@ pub enum AiCommand {
         #[arg(long, default_value_t = 50)]
         limit: i64,
     },
+    /// Manage the AI trace retention policy.
+    Retention {
+        #[command(subcommand)]
+        command: AiRetentionCommand,
+    },
     /// Show AI token-usage records.
     Usage {
         /// Team scope; defaults to the active context's team.
@@ -417,6 +422,26 @@ pub enum AiCommand {
         /// Number of records to skip for pagination.
         #[arg(long, default_value_t = 0)]
         offset: i64,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum AiRetentionCommand {
+    /// Show the retention policy in force (team policy or the built-in 30-day default).
+    Get {
+        /// Team scope; defaults to the active context's team.
+        #[arg(long)]
+        team: Option<String>,
+    },
+    /// Set the team's trace TTL (create-or-replace; affects only newly captured traces).
+    #[command(after_help = "Example:\n  flowplane ai retention set --team payments --days 14")]
+    Set {
+        /// Team scope; defaults to the active context's team.
+        #[arg(long)]
+        team: Option<String>,
+        /// Days a new trace row lives before the expiry sweep removes it (1-365).
+        #[arg(long)]
+        days: i32,
     },
 }
 

--- a/crates/flowplane/src/cli/mod.rs
+++ b/crates/flowplane/src/cli/mod.rs
@@ -17,11 +17,12 @@ use std::time::{Duration, Instant};
 
 use client::RestClient;
 pub use commands::{
-    AiCommand, ApiCommand, ApplyCommand, AuthCommand, CertCommand, ConfigCommand,
-    DataplaneBootstrapMode, DataplaneCommand, ExposeCommand, GrantCommand, LearnCommand,
-    LearnDiscoverCommand, McpCommand, OpsCommand, OrgCommand, OrgMemberCommand, RateLimitCommand,
-    RateLimitOverrideCommand, RateLimitPolicyCommand, ResourceCommand, RouteCommand, SecretCommand,
-    StatsCommand, TeamCommand, TeamMemberCommand, UnexposeCommand, XdsCommand,
+    AiCommand, AiRetentionCommand, ApiCommand, ApplyCommand, AuthCommand, CertCommand,
+    ConfigCommand, DataplaneBootstrapMode, DataplaneCommand, ExposeCommand, GrantCommand,
+    LearnCommand, LearnDiscoverCommand, McpCommand, OpsCommand, OrgCommand, OrgMemberCommand,
+    RateLimitCommand, RateLimitOverrideCommand, RateLimitPolicyCommand, ResourceCommand,
+    RouteCommand, SecretCommand, StatsCommand, TeamCommand, TeamMemberCommand, UnexposeCommand,
+    XdsCommand,
 };
 pub use config::GlobalOptions;
 use config::{
@@ -1053,6 +1054,32 @@ pub async fn run_ai(global: GlobalOptions, command: AiCommand) -> Result<()> {
                 .await?;
             Ok(())
         }
+        AiCommand::Retention { command } => match command {
+            AiRetentionCommand::Get { team } => {
+                let client = RestClient::new(global)?;
+                let team = client.team(team)?;
+                client
+                    .request(
+                        reqwest::Method::GET,
+                        &format!("/api/v1/teams/{team}/ai/retention"),
+                        None,
+                    )
+                    .await?;
+                Ok(())
+            }
+            AiRetentionCommand::Set { team, days } => {
+                let client = RestClient::new(global)?;
+                let team = client.team(team)?;
+                client
+                    .request(
+                        reqwest::Method::PUT,
+                        &format!("/api/v1/teams/{team}/ai/retention"),
+                        Some(json!({ "trace_ttl_days": days })),
+                    )
+                    .await?;
+                Ok(())
+            }
+        },
         AiCommand::Usage {
             team,
             provider_id,
@@ -2616,6 +2643,7 @@ fn cli_endpoint_templates() -> BTreeSet<&'static str> {
         "/api/v1/teams/{team}/ai/budgets/{name}",
         "/api/v1/teams/{team}/ai/usage",
         "/api/v1/teams/{team}/ai/trace",
+        "/api/v1/teams/{team}/ai/retention",
         "/api/v1/teams/{team}/rate-limit-domains",
         "/api/v1/teams/{team}/rate-limit-domains/{domain}",
         "/api/v1/teams/{team}/rate-limit-domains/{domain}/policies",

--- a/crates/flowplane/src/cli/mod.rs
+++ b/crates/flowplane/src/cli/mod.rs
@@ -1023,6 +1023,36 @@ pub async fn run_ai(global: GlobalOptions, command: AiCommand) -> Result<()> {
         AiCommand::Providers { command } => run_resource(global, "ai/providers", command).await,
         AiCommand::Routes { command } => run_resource(global, "ai/routes", command).await,
         AiCommand::Budgets { command } => run_resource(global, "ai/budgets", command).await,
+        AiCommand::Trace {
+            team,
+            request_id,
+            trace_id,
+            limit,
+        } => {
+            let client = RestClient::new(global)?;
+            let team = client.team(team)?;
+            let mut query = Vec::new();
+            if let Some(request_id) = request_id {
+                query.push(("request_id", request_id));
+            }
+            if let Some(trace_id) = trace_id {
+                query.push(("trace_id", trace_id));
+            }
+            query.push(("limit", limit.to_string()));
+            let query = query
+                .into_iter()
+                .map(|(key, value)| format!("{key}={}", query_component(&value)))
+                .collect::<Vec<_>>()
+                .join("&");
+            client
+                .request(
+                    reqwest::Method::GET,
+                    &format!("/api/v1/teams/{team}/ai/trace?{query}"),
+                    None,
+                )
+                .await?;
+            Ok(())
+        }
         AiCommand::Usage {
             team,
             provider_id,
@@ -2585,6 +2615,7 @@ fn cli_endpoint_templates() -> BTreeSet<&'static str> {
         "/api/v1/teams/{team}/ai/budgets",
         "/api/v1/teams/{team}/ai/budgets/{name}",
         "/api/v1/teams/{team}/ai/usage",
+        "/api/v1/teams/{team}/ai/trace",
         "/api/v1/teams/{team}/rate-limit-domains",
         "/api/v1/teams/{team}/rate-limit-domains/{domain}",
         "/api/v1/teams/{team}/rate-limit-domains/{domain}/policies",

--- a/crates/flowplane/src/cli/output.rs
+++ b/crates/flowplane/src/cli/output.rs
@@ -345,6 +345,9 @@ fn kind_override(path: &str) -> Option<&'static str> {
     if path.ends_with("/ai/trace") {
         return Some("aiTrace");
     }
+    if path.ends_with("/ai/retention") {
+        return Some("aiRetention");
+    }
     if path.ends_with("/envoy-config") {
         return Some("envoyConfig");
     }
@@ -1222,6 +1225,7 @@ mod tests {
             ("/api/v1/teams/p/stats/overview", "statsOverview"),
             ("/api/v1/teams/p/ops/trace", "trace"),
             ("/api/v1/teams/p/ai/trace", "aiTrace"),
+            ("/api/v1/teams/p/ai/retention", "aiRetention"),
             ("/api/v1/teams/p/ai/usage", "usage"),
             ("/api/v1/teams/p/dataplanes/d1/envoy-config", "envoyConfig"),
             (

--- a/crates/flowplane/src/cli/output.rs
+++ b/crates/flowplane/src/cli/output.rs
@@ -342,6 +342,9 @@ fn kind_override(path: &str) -> Option<&'static str> {
     if path.ends_with("/ops/trace") {
         return Some("trace");
     }
+    if path.ends_with("/ai/trace") {
+        return Some("aiTrace");
+    }
     if path.ends_with("/envoy-config") {
         return Some("envoyConfig");
     }
@@ -1218,6 +1221,7 @@ mod tests {
             ),
             ("/api/v1/teams/p/stats/overview", "statsOverview"),
             ("/api/v1/teams/p/ops/trace", "trace"),
+            ("/api/v1/teams/p/ai/trace", "aiTrace"),
             ("/api/v1/teams/p/ai/usage", "usage"),
             ("/api/v1/teams/p/dataplanes/d1/envoy-config", "envoyConfig"),
             (

--- a/crates/flowplane/src/main.rs
+++ b/crates/flowplane/src/main.rs
@@ -588,7 +588,7 @@ mod tests {
         // from `--help`. The union guard forces every FUTURE leaf to be classified one way or the
         // other. Pure in-process (no temp dir / network) so it is inherently parallel-safe.
 
-        // 44 SPINE leaves (space-joined paths) — each must expose a parseable example.
+        // 45 SPINE leaves (space-joined paths) — each must expose a parseable example.
         const SPINE: &[&str] = &[
             "auth login",
             "config set-context",
@@ -615,6 +615,7 @@ mod tests {
             "ai routes update",
             "ai budgets create",
             "ai budgets update",
+            "ai trace",
             "rate-limit domain create",
             "rate-limit domain update",
             "rate-limit policy create",

--- a/crates/flowplane/src/main.rs
+++ b/crates/flowplane/src/main.rs
@@ -588,7 +588,7 @@ mod tests {
         // from `--help`. The union guard forces every FUTURE leaf to be classified one way or the
         // other. Pure in-process (no temp dir / network) so it is inherently parallel-safe.
 
-        // 45 SPINE leaves (space-joined paths) — each must expose a parseable example.
+        // 46 SPINE leaves (space-joined paths) — each must expose a parseable example.
         const SPINE: &[&str] = &[
             "auth login",
             "config set-context",
@@ -615,6 +615,7 @@ mod tests {
             "ai routes update",
             "ai budgets create",
             "ai budgets update",
+            "ai retention set",
             "ai trace",
             "rate-limit domain create",
             "rate-limit domain update",
@@ -637,7 +638,7 @@ mod tests {
             "apply",
         ];
 
-        // 77 EXEMPT leaves (space-joined paths) — no example required.
+        // 78 EXEMPT leaves (space-joined paths) — no example required.
         const EXEMPT: &[&str] = &[
             "ai budgets delete",
             "ai budgets get",
@@ -645,6 +646,7 @@ mod tests {
             "ai providers delete",
             "ai providers get",
             "ai providers list",
+            "ai retention get",
             "ai routes delete",
             "ai routes get",
             "ai routes list",

--- a/crates/flowplane/src/serve.rs
+++ b/crates/flowplane/src/serve.rs
@@ -214,6 +214,18 @@ pub async fn run() -> anyhow::Result<()> {
         None
     };
 
+    // AI trace retention sweep (ai-gateway-e2e-trace s5): fixed-interval deletion of trace
+    // rows whose insert-stamped expires_at has passed. Owned by the CP; no dataplane involved.
+    {
+        let sweep_pool = pool.clone();
+        let sweep_shutdown = xds_shutdown_tx.subscribe();
+        tokio::spawn(run_ai_trace_sweep(sweep_pool, sweep_shutdown));
+        tracing::info!(
+            interval_secs = AI_TRACE_SWEEP_INTERVAL_SECS,
+            "ai trace retention sweep started"
+        );
+    }
+
     let state = fp_api::AppState {
         pool,
         prometheus,
@@ -374,6 +386,40 @@ async fn run_rls_sync(
         match fp_core::services::rls_sync::reconcile_once(&pool, &admin_url, &client).await {
             Ok(count) => tracing::debug!(policies = count, "rls policy reconcile pushed"),
             Err(e) => tracing::warn!("rls policy reconcile failed: {e}"),
+        }
+    }
+}
+
+/// Fixed sweep cadence for expired AI trace rows. Hourly is deliberately coarse: expiry
+/// precision only needs to be within the sweep interval of a row's `expires_at`, and one
+/// bulk DELETE per hour keeps the sweep invisible next to the per-request insert load.
+const AI_TRACE_SWEEP_INTERVAL_SECS: u64 = 3600;
+
+/// Expired-trace sweep loop: on every tick, delete all `ai_trace_events` rows whose
+/// `expires_at` has passed. The first tick fires immediately at startup so a restarted CP
+/// clears backlog without waiting a full interval. Errors are logged and the loop keeps
+/// running — retention is eventually consistent, never a boot or request failure.
+async fn run_ai_trace_sweep(pool: sqlx::PgPool, mut shutdown: tokio::sync::watch::Receiver<bool>) {
+    let mut interval =
+        tokio::time::interval(std::time::Duration::from_secs(AI_TRACE_SWEEP_INTERVAL_SECS));
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {}
+            changed = shutdown.changed() => {
+                if changed.is_err() || *shutdown.borrow() {
+                    return;
+                }
+                continue;
+            }
+        }
+        let as_of = sqlx::types::chrono::Utc::now();
+        match fp_storage::repos::ai_trace::delete_expired_trace_events(&pool, as_of).await {
+            Ok(deleted) if deleted > 0 => {
+                tracing::info!(deleted, "ai trace retention sweep removed expired rows");
+            }
+            Ok(_) => tracing::debug!("ai trace retention sweep found nothing expired"),
+            Err(e) => tracing::warn!("ai trace retention sweep failed: {e}"),
         }
     }
 }

--- a/crates/flowplane/tests/cli_ai_retention.rs
+++ b/crates/flowplane/tests/cli_ai_retention.rs
@@ -1,0 +1,185 @@
+//! Slice s5 (ai-gateway-e2e-trace): CLI parity for `flowplane ai retention get/set` against
+//! a REAL control plane — the actual fp-api router over a loopback TCP listener backed by
+//! the shared test PostgreSQL. The commands are pure REST clients (the CLI process receives
+//! only FLOWPLANE_SERVER/FLOWPLANE_TOKEN, no DB URL), and the rendered envelope `data` must
+//! equal the REST response body for both the built-in default and a stored policy.
+//!
+//! Parallel-safety (invariant 18): the CP binds 127.0.0.1:0, all org/team/agent names are
+//! unique per run, and the child process gets an isolated HOME.
+
+#![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use fp_domain::AgentKind;
+use fp_storage::repos::identity;
+use serde_json::Value;
+
+fn unique(prefix: &str) -> String {
+    format!(
+        "{prefix}-{}",
+        &uuid::Uuid::now_v7().simple().to_string()[20..]
+    )
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ai_retention_cli_get_and_set_work_as_rest_only_clients() {
+    let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+        eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+        return;
+    };
+    let pool = fp_storage::connect(&url, 4).await.expect("connect");
+    fp_storage::migrate(&pool).await.expect("migrate");
+
+    // Tenancy fixture: one org, one team, one agent whose bearer token authenticates via
+    // the fpat_ path and holds (ai-usage, read) + (ai-usage, update) — the two grants the
+    // retention surface enforces.
+    let org = identity::create_org(&pool, &unique("org"), "")
+        .await
+        .expect("org");
+    let team = identity::create_team(&pool, org.id, &unique("team"), "")
+        .await
+        .expect("team");
+    let token = format!(
+        "fpat_{}{}",
+        uuid::Uuid::new_v4().simple(),
+        uuid::Uuid::new_v4().simple()
+    );
+    let mut tx = pool.begin().await.expect("begin");
+    let agent = identity::create_agent_tx(
+        &mut tx,
+        org.id,
+        &unique("agent"),
+        AgentKind::CpTool,
+        &identity::hash_agent_token(&token),
+        None,
+    )
+    .await
+    .expect("agent");
+    for action in [
+        fp_domain::authz::Action::Read,
+        fp_domain::authz::Action::Update,
+    ] {
+        identity::add_agent_grant_in_tx(
+            &mut tx,
+            agent.id,
+            org.id,
+            team.id,
+            fp_domain::authz::Resource::AiUsage,
+            action,
+            None,
+        )
+        .await
+        .expect("agent grant");
+    }
+    tx.commit().await.expect("commit");
+
+    // A real CP: the production router served over loopback on an ephemeral port.
+    let app = fp_api::build_router(fp_api::AppState {
+        pool,
+        prometheus: metrics_exporter_prometheus::PrometheusBuilder::new()
+            .build_recorder()
+            .handle(),
+        version: "test",
+        validator: None,
+        write_throttle: std::sync::Arc::new(fp_api::throttle::WriteThrottle::new(1000)),
+        xds_readiness: None,
+        discovery_forwarding_policy: Default::default(),
+        rls_repush: None,
+        rls_grpc_configured: false,
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind CP to an ephemeral port");
+    let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    let http = reqwest::Client::new();
+    let retention_url = format!("{base_url}/api/v1/teams/{}/ai/retention", team.name);
+    let home = common::unique_tempdir();
+    let cli = |args: &[&str]| {
+        common::flowplane_cmd(&home)
+            .env("FLOWPLANE_SERVER", &base_url)
+            .env("FLOWPLANE_TOKEN", &token)
+            .args(args)
+            .output()
+            .expect("run flowplane")
+    };
+
+    // GET before any policy: the CLI renders the same built-in-default body as REST.
+    let rest_default: Value = http
+        .get(&retention_url)
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("rest get")
+        .json()
+        .await
+        .expect("rest json");
+    assert_eq!(rest_default["trace_ttl_days"], 30);
+    assert_eq!(rest_default["is_default"], true);
+    let out = cli(&["ai", "retention", "get", "--team", &team.name, "-o", "json"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "ai retention get must exit 0; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let envelope: Value = serde_json::from_slice(&out.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout is not a JSON envelope ({e}): {}",
+            String::from_utf8_lossy(&out.stdout)
+        )
+    });
+    assert_eq!(envelope["kind"], "aiRetention");
+    assert_eq!(
+        envelope["data"], rest_default,
+        "CLI must render the same payload as REST"
+    );
+
+    // SET through the CLI (a pure REST PUT): the stored policy is what REST then returns.
+    let out = cli(&[
+        "ai",
+        "retention",
+        "set",
+        "--team",
+        &team.name,
+        "--days",
+        "14",
+        "-o",
+        "json",
+    ]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "ai retention set must exit 0; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let envelope: Value = serde_json::from_slice(&out.stdout).expect("set envelope");
+    assert_eq!(envelope["kind"], "aiRetention");
+    assert_eq!(envelope["data"]["trace_ttl_days"], 14);
+    assert_eq!(envelope["data"]["is_default"], false);
+    assert_eq!(envelope["data"]["revision"], 1);
+
+    // GET parity after the set: CLI and REST agree on the stored policy.
+    let rest_stored: Value = http
+        .get(&retention_url)
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("rest get stored")
+        .json()
+        .await
+        .expect("rest stored json");
+    assert_eq!(rest_stored["trace_ttl_days"], 14);
+    let out = cli(&["ai", "retention", "get", "--team", &team.name, "-o", "json"]);
+    assert_eq!(out.status.code(), Some(0));
+    let envelope: Value = serde_json::from_slice(&out.stdout).expect("get envelope");
+    assert_eq!(
+        envelope["data"], rest_stored,
+        "stored-policy payload must match REST"
+    );
+
+    server.abort();
+}

--- a/crates/flowplane/tests/cli_ai_trace.rs
+++ b/crates/flowplane/tests/cli_ai_trace.rs
@@ -1,0 +1,223 @@
+//! Slice s4 (ai-gateway-e2e-trace): CLI parity for `flowplane ai trace` against a REAL
+//! control plane — the actual fp-api router over a loopback TCP listener backed by the
+//! shared test PostgreSQL. The command is a pure REST client (no direct DB access from the
+//! CLI process: it receives only FLOWPLANE_SERVER/FLOWPLANE_TOKEN), and its rendered
+//! envelope `data` must equal the REST response body — same hops, same miss payload.
+//!
+//! Parallel-safety (invariant 18): the CP binds 127.0.0.1:0, all org/team/agent names are
+//! unique per run, and the child process gets an isolated HOME.
+
+#![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+use fp_domain::AgentKind;
+use fp_storage::repos::identity;
+use serde_json::Value;
+
+fn unique(prefix: &str) -> String {
+    format!(
+        "{prefix}-{}",
+        &uuid::Uuid::now_v7().simple().to_string()[20..]
+    )
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ai_trace_cli_renders_the_same_hops_as_rest() {
+    let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+        eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+        return;
+    };
+    let pool = fp_storage::connect(&url, 4).await.expect("connect");
+    fp_storage::migrate(&pool).await.expect("migrate");
+
+    // Tenancy fixture: one org, one team, one agent whose bearer token authenticates via
+    // the fpat_ path (no OIDC validator needed) and holds exactly (ai-usage, read).
+    let org = identity::create_org(&pool, &unique("org"), "")
+        .await
+        .expect("org");
+    let team = identity::create_team(&pool, org.id, &unique("team"), "")
+        .await
+        .expect("team");
+    let token = format!(
+        "fpat_{}{}",
+        uuid::Uuid::new_v4().simple(),
+        uuid::Uuid::new_v4().simple()
+    );
+    let mut tx = pool.begin().await.expect("begin");
+    let agent = identity::create_agent_tx(
+        &mut tx,
+        org.id,
+        &unique("agent"),
+        AgentKind::CpTool,
+        &identity::hash_agent_token(&token),
+        None,
+    )
+    .await
+    .expect("agent");
+    identity::add_agent_grant_in_tx(
+        &mut tx,
+        agent.id,
+        org.id,
+        team.id,
+        fp_domain::authz::Resource::AiUsage,
+        fp_domain::authz::Action::Read,
+        None,
+    )
+    .await
+    .expect("agent grant");
+    tx.commit().await.expect("commit");
+
+    // Seed one trace row (the write path is slice s2's; this test owns retrieval parity).
+    let request_id = uuid::Uuid::now_v7().to_string();
+    fp_storage::repos::ai_trace::upsert_trace_event(
+        &pool,
+        &fp_storage::repos::ai_trace::AiTraceEventUpsert {
+            team_id: team.id,
+            request_id: request_id.clone(),
+            trace_id: None,
+            route_config_id: fp_domain::RouteConfigId::from(uuid::Uuid::now_v7()),
+            listener_id: None,
+            provider_id: None,
+            model: Some("gpt-5".into()),
+            status_code: Some(200),
+            hops: serde_json::json!([
+                {"hop": "route_match", "started_at": "2026-07-04T00:00:00.100Z",
+                 "ended_at": "2026-07-04T00:00:00.200Z", "outcome": "matched",
+                 "origin": "listener", "failed": false, "detail": {}},
+                {"hop": "budget", "started_at": "2026-07-04T00:00:00.210Z",
+                 "ended_at": "2026-07-04T00:00:00.230Z", "outcome": "allowed",
+                 "origin": "listener", "failed": false, "detail": {}},
+                {"hop": "upstream", "started_at": "2026-07-04T00:00:00.300Z",
+                 "ended_at": "2026-07-04T00:00:00.900Z", "outcome": "ok",
+                 "origin": "upstream", "failed": false, "detail": {"status": 200}}
+            ]),
+        },
+    )
+    .await
+    .expect("seed trace row");
+
+    // A real CP: the production router served over loopback on an ephemeral port.
+    let app = fp_api::build_router(fp_api::AppState {
+        pool,
+        prometheus: metrics_exporter_prometheus::PrometheusBuilder::new()
+            .build_recorder()
+            .handle(),
+        version: "test",
+        validator: None,
+        write_throttle: std::sync::Arc::new(fp_api::throttle::WriteThrottle::new(1000)),
+        xds_readiness: None,
+        discovery_forwarding_policy: Default::default(),
+        rls_repush: None,
+        rls_grpc_configured: false,
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind CP to an ephemeral port");
+    let base_url = format!("http://{}", listener.local_addr().expect("local addr"));
+    let server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    // REST reference response, fetched directly.
+    let http = reqwest::Client::new();
+    let rest: Value = http
+        .get(format!(
+            "{base_url}/api/v1/teams/{}/ai/trace?request_id={request_id}&limit=50",
+            team.name
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("rest call")
+        .json()
+        .await
+        .expect("rest json");
+    assert_eq!(
+        rest["traces"].as_array().map(Vec::len),
+        Some(1),
+        "seeded row must be visible over REST: {rest}"
+    );
+
+    // The CLI, black-box: REST-only client (only server URL + token are provided).
+    let home = common::unique_tempdir();
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", &base_url)
+        .env("FLOWPLANE_TOKEN", &token)
+        .args([
+            "ai",
+            "trace",
+            "--team",
+            &team.name,
+            "--request-id",
+            &request_id,
+            "-o",
+            "json",
+        ])
+        .output()
+        .expect("run flowplane ai trace");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "ai trace must exit 0; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let envelope: Value = serde_json::from_slice(&out.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout is not a JSON envelope ({e}): {}",
+            String::from_utf8_lossy(&out.stdout)
+        )
+    });
+    assert_eq!(envelope["kind"], "aiTrace");
+
+    // Parity: the CLI envelope's data IS the REST body — identical hop timeline included.
+    assert_eq!(
+        envelope["data"], rest,
+        "CLI must render the same payload as REST"
+    );
+    assert_eq!(
+        envelope["data"]["traces"][0]["hops"], rest["traces"][0]["hops"],
+        "hop timelines must match"
+    );
+
+    // Miss parity: an unknown id renders the same distinguishable miss payload as REST.
+    let missing_id = uuid::Uuid::now_v7().to_string();
+    let rest_miss: Value = http
+        .get(format!(
+            "{base_url}/api/v1/teams/{}/ai/trace?request_id={missing_id}&limit=50",
+            team.name
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .expect("rest miss call")
+        .json()
+        .await
+        .expect("rest miss json");
+    assert_eq!(rest_miss["miss"]["message"], "no trace row found");
+    let out = common::flowplane_cmd(&home)
+        .env("FLOWPLANE_SERVER", &base_url)
+        .env("FLOWPLANE_TOKEN", &token)
+        .args([
+            "ai",
+            "trace",
+            "--team",
+            &team.name,
+            "--request-id",
+            &missing_id,
+            "-o",
+            "json",
+        ])
+        .output()
+        .expect("run flowplane ai trace (miss)");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "a miss is a 200 and must exit 0; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let envelope: Value = serde_json::from_slice(&out.stdout).expect("miss envelope");
+    assert_eq!(envelope["data"], rest_miss, "miss payload must match REST");
+
+    server.abort();
+}

--- a/crates/flowplane/tests/cli_s7_coverage.rs
+++ b/crates/flowplane/tests/cli_s7_coverage.rs
@@ -142,6 +142,9 @@ const SHARED_LAYER_COVERED: &[&str] = &[
     "ai budgets create",
     "ai budgets update",
     "ai budgets delete",
+    // ai retention
+    "ai retention get",
+    "ai retention set",
     // ai usage
     "ai usage",
     // ai trace

--- a/crates/flowplane/tests/cli_s7_coverage.rs
+++ b/crates/flowplane/tests/cli_s7_coverage.rs
@@ -144,6 +144,8 @@ const SHARED_LAYER_COVERED: &[&str] = &[
     "ai budgets delete",
     // ai usage
     "ai usage",
+    // ai trace
+    "ai trace",
     // rate-limit domain
     "rate-limit domain list",
     "rate-limit domain get",

--- a/crates/fp-api/src/ai_api.rs
+++ b/crates/fp-api/src/ai_api.rs
@@ -2,7 +2,7 @@
 
 use crate::error::ApiError;
 use crate::extract::ApiJson;
-use crate::resources::{resolve_team, revision_from, ListQuery, Page};
+use crate::resources::{optional_revision_from, resolve_team, revision_from, ListQuery, Page};
 use crate::state::AppState;
 use axum::extract::{Extension, Path, Query, State};
 use axum::http::HeaderMap;
@@ -698,7 +698,10 @@ pub async fn get_ai_retention(
 /// Existing rows keep the expiry they were stamped with; only new rows use the new TTL.
 #[utoipa::path(put, path = "/api/v1/teams/{team}/ai/retention",
     tag = "AI",
-    params(("team" = String, Path, description = "Team name or UUID")),
+    params(
+        ("team" = String, Path, description = "Team name or UUID"),
+        ("If-Match" = Option<i64>, Header, description = "Current retention revision; omit to create or replace, supply to guard against a concurrent change"),
+    ),
     request_body = SetAiRetentionBody,
     responses((status = 200, body = AiRetentionView)))]
 pub async fn put_ai_retention(
@@ -706,11 +709,21 @@ pub async fn put_ai_retention(
     Path(team): Path<String>,
     Extension(ctx): Extension<PrincipalCtx>,
     Extension(rid): Extension<RequestId>,
+    headers: HeaderMap,
     ApiJson(body): ApiJson<SetAiRetentionBody>,
 ) -> Result<Json<AiRetentionView>, ApiError> {
     let run = async {
+        let expected_version = optional_revision_from(&headers)?;
         let team = resolve_team(&state, &ctx, &team).await?;
-        ai_svc::set_retention_policy(&state.pool, &ctx, team, body.trace_ttl_days, None, rid).await
+        ai_svc::set_retention_policy(
+            &state.pool,
+            &ctx,
+            team,
+            body.trace_ttl_days,
+            expected_version,
+            rid,
+        )
+        .await
     };
     run.await
         .map(|policy| Json(shape_retention_view(Some(policy))))

--- a/crates/fp-api/src/ai_api.rs
+++ b/crates/fp-api/src/ai_api.rs
@@ -710,7 +710,7 @@ pub async fn put_ai_retention(
 ) -> Result<Json<AiRetentionView>, ApiError> {
     let run = async {
         let team = resolve_team(&state, &ctx, &team).await?;
-        ai_svc::set_retention_policy(&state.pool, &ctx, team, body.trace_ttl_days, rid).await
+        ai_svc::set_retention_policy(&state.pool, &ctx, team, body.trace_ttl_days, None, rid).await
     };
     run.await
         .map(|policy| Json(shape_retention_view(Some(policy))))

--- a/crates/fp-api/src/ai_api.rs
+++ b/crates/fp-api/src/ai_api.rs
@@ -636,6 +636,87 @@ pub async fn get_ai_trace(
     Ok(Json(shape_trace_response(events, id_filtered)))
 }
 
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SetAiRetentionBody {
+    /// Days a new trace row lives before the expiry sweep removes it (1–365).
+    pub trace_ttl_days: i32,
+}
+
+/// The retention policy in force for the team's AI trace rows. `is_default: true` means no
+/// team policy row exists and the built-in 30-day default applies (`revision`/`updated_at`
+/// absent); a stored policy carries its revision and update time.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AiRetentionView {
+    pub trace_ttl_days: i32,
+    pub is_default: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revision: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// The effective policy: the team's row when present, the built-in default otherwise.
+fn shape_retention_view(policy: Option<fp_domain::AiRetentionPolicy>) -> AiRetentionView {
+    match policy {
+        Some(policy) => AiRetentionView {
+            trace_ttl_days: policy.trace_ttl_days,
+            is_default: false,
+            revision: Some(policy.version),
+            updated_at: Some(policy.updated_at),
+        },
+        None => AiRetentionView {
+            trace_ttl_days: fp_storage::repos::ai_trace::DEFAULT_AI_TRACE_TTL_DAYS,
+            is_default: true,
+            revision: None,
+            updated_at: None,
+        },
+    }
+}
+
+/// Effective AI trace retention policy for the team.
+#[utoipa::path(get, path = "/api/v1/teams/{team}/ai/retention",
+    tag = "AI",
+    params(("team" = String, Path, description = "Team name or UUID")),
+    responses((status = 200, body = AiRetentionView)))]
+pub async fn get_ai_retention(
+    State(state): State<AppState>,
+    Path(team): Path<String>,
+    Extension(ctx): Extension<PrincipalCtx>,
+    Extension(rid): Extension<RequestId>,
+) -> Result<Json<AiRetentionView>, ApiError> {
+    let run = async {
+        let team = resolve_team(&state, &ctx, &team).await?;
+        ai_svc::get_retention_policy(&state.pool, &ctx, team, rid).await
+    };
+    run.await
+        .map(|policy| Json(shape_retention_view(policy)))
+        .map_err(|e| ApiError::new(e, rid))
+}
+
+/// Set the team's AI trace retention policy (create-or-replace; one policy per team).
+/// Existing rows keep the expiry they were stamped with; only new rows use the new TTL.
+#[utoipa::path(put, path = "/api/v1/teams/{team}/ai/retention",
+    tag = "AI",
+    params(("team" = String, Path, description = "Team name or UUID")),
+    request_body = SetAiRetentionBody,
+    responses((status = 200, body = AiRetentionView)))]
+pub async fn put_ai_retention(
+    State(state): State<AppState>,
+    Path(team): Path<String>,
+    Extension(ctx): Extension<PrincipalCtx>,
+    Extension(rid): Extension<RequestId>,
+    ApiJson(body): ApiJson<SetAiRetentionBody>,
+) -> Result<Json<AiRetentionView>, ApiError> {
+    let run = async {
+        let team = resolve_team(&state, &ctx, &team).await?;
+        ai_svc::set_retention_policy(&state.pool, &ctx, team, body.trace_ttl_days, rid).await
+    };
+    run.await
+        .map(|policy| Json(shape_retention_view(Some(policy))))
+        .map_err(|e| ApiError::new(e, rid))
+}
+
 #[utoipa::path(get, path = "/api/v1/teams/{team}/ai/usage",
     tag = "AI",
     params(("team" = String, Path, description = "Team name or UUID"), AiUsageQuery),
@@ -740,5 +821,34 @@ mod tests {
         assert_eq!(trace_limit(-5), 1);
         assert_eq!(trace_limit(25), 25);
         assert_eq!(trace_limit(10_000), 500);
+    }
+
+    #[test]
+    fn retention_view_distinguishes_stored_policy_from_builtin_default() {
+        // No policy row: the 30-day default, flagged as such, with no revision/updated_at
+        // keys on the wire at all.
+        let default_view = shape_retention_view(None);
+        assert_eq!(default_view.trace_ttl_days, 30);
+        assert!(default_view.is_default);
+        let json = serde_json::to_value(&default_view).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({ "trace_ttl_days": 30, "is_default": true })
+        );
+
+        // Stored policy: its TTL, revision, and update time; is_default false.
+        let updated_at = chrono::Utc::now();
+        let stored = shape_retention_view(Some(fp_domain::AiRetentionPolicy {
+            id: uuid::Uuid::now_v7(),
+            team_id: fp_domain::TeamId::from(uuid::Uuid::now_v7()),
+            trace_ttl_days: 7,
+            version: 3,
+            created_at: updated_at,
+            updated_at,
+        }));
+        assert_eq!(stored.trace_ttl_days, 7);
+        assert!(!stored.is_default);
+        assert_eq!(stored.revision, Some(3));
+        assert_eq!(stored.updated_at, Some(updated_at));
     }
 }

--- a/crates/fp-api/src/ai_api.rs
+++ b/crates/fp-api/src/ai_api.rs
@@ -10,8 +10,8 @@ use axum::Json;
 use fp_core::services::ai as ai_svc;
 use fp_core::PrincipalCtx;
 use fp_domain::{
-    AiBudget, AiBudgetSpec, AiProvider, AiProviderSpec, AiRoute, AiRouteSpec, AiUsageSummary,
-    RequestId,
+    AiBudget, AiBudgetSpec, AiProvider, AiProviderSpec, AiRoute, AiRouteSpec, AiTraceEvent,
+    AiUsageSummary, RequestId,
 };
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
@@ -508,6 +508,134 @@ pub async fn delete_ai_budget(
         .map_err(|e| ApiError::new(e, rid))
 }
 
+#[derive(Debug, Deserialize, IntoParams, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AiTraceParams {
+    /// The server-generated `x-request-id` returned on the AI data-plane response.
+    #[serde(default)]
+    pub request_id: Option<String>,
+    /// W3C trace id from an inbound `traceparent` (non-unique, list-queryable).
+    #[serde(default)]
+    pub trace_id: Option<String>,
+    #[serde(default = "default_trace_limit")]
+    pub limit: i64,
+}
+
+fn default_trace_limit() -> i64 {
+    50
+}
+
+/// One correlated trace row: the per-request hop timeline plus its top-level correlation ids.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AiTraceEventView {
+    pub id: uuid::Uuid,
+    pub request_id: String,
+    pub trace_id: Option<String>,
+    pub route_config_id: uuid::Uuid,
+    pub listener_id: Option<uuid::Uuid>,
+    pub provider_id: Option<uuid::Uuid>,
+    pub model: Option<String>,
+    pub status_code: Option<i32>,
+    /// The first hop (in timeline order) whose outcome is a failure, if any.
+    pub failure_hop: Option<String>,
+    /// Timeline of `{hop, started_at, ended_at, outcome, origin, failed, detail}` entries.
+    #[schema(value_type = Object)]
+    pub hops: serde_json::Value,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub expires_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl From<AiTraceEvent> for AiTraceEventView {
+    fn from(value: AiTraceEvent) -> Self {
+        Self {
+            id: value.id,
+            request_id: value.request_id,
+            trace_id: value.trace_id,
+            route_config_id: value.route_config_id.as_uuid(),
+            listener_id: value.listener_id.map(|id| id.as_uuid()),
+            provider_id: value.provider_id.map(|id| id.as_uuid()),
+            model: value.model,
+            status_code: value.status_code,
+            failure_hop: value.failure_hop,
+            hops: value.hops,
+            created_at: value.created_at,
+            expires_at: value.expires_at,
+        }
+    }
+}
+
+/// Present exactly when an id-filtered query matched no row: distinguishes "no trace row
+/// found" (and names the request classes that are never traced) from an empty list.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AiTraceMiss {
+    pub message: String,
+    pub hint: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AiTraceResponse {
+    pub traces: Vec<AiTraceEventView>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub miss: Option<AiTraceMiss>,
+}
+
+/// The request classes that never produce a trace row (design Risk 5): the hint a miss
+/// carries so an operator can tell "never traced" from "wrong id".
+const NEVER_TRACED_HINT: &str =
+    "no trace row exists for this id; requests that never complete HTTP processing at the AI \
+     listener are never traced: TCP/TLS-level failures, client disconnect before request \
+     headers, and pre-ExtProc declared-filter denials";
+
+/// Clamp the caller's limit to the repo's supported window (1..=500), defaulting to 50.
+fn trace_limit(limit: i64) -> i64 {
+    limit.clamp(1, 500)
+}
+
+/// A miss (id filter given, nothing matched) is distinguishable from an empty unfiltered
+/// list: only the miss carries the `miss` payload naming the never-traced classes.
+fn shape_trace_response(events: Vec<AiTraceEvent>, id_filtered: bool) -> AiTraceResponse {
+    let miss = (id_filtered && events.is_empty()).then(|| AiTraceMiss {
+        message: "no trace row found".into(),
+        hint: NEVER_TRACED_HINT.into(),
+    });
+    AiTraceResponse {
+        traces: events.into_iter().map(AiTraceEventView::from).collect(),
+        miss,
+    }
+}
+
+/// Correlated hop timeline for AI data-plane requests, newest first.
+#[utoipa::path(get, path = "/api/v1/teams/{team}/ai/trace",
+    tag = "AI",
+    params(("team" = String, Path, description = "Team name or UUID"), AiTraceParams),
+    responses((status = 200, body = AiTraceResponse)))]
+pub async fn get_ai_trace(
+    State(state): State<AppState>,
+    Path(team): Path<String>,
+    Query(params): Query<AiTraceParams>,
+    Extension(ctx): Extension<PrincipalCtx>,
+    Extension(rid): Extension<RequestId>,
+) -> Result<Json<AiTraceResponse>, ApiError> {
+    let run = async {
+        let team = resolve_team(&state, &ctx, &team).await?;
+        ai_svc::trace_events(
+            &state.pool,
+            &ctx,
+            team,
+            fp_storage::repos::ai_trace::AiTraceQuery {
+                request_id: params.request_id.as_deref(),
+                trace_id: params.trace_id.as_deref(),
+                limit: trace_limit(params.limit),
+            },
+            rid,
+        )
+        .await
+    };
+    let events = run.await.map_err(|e| ApiError::new(e, rid))?;
+    let id_filtered = params.request_id.is_some() || params.trace_id.is_some();
+    Ok(Json(shape_trace_response(events, id_filtered)))
+}
+
 #[utoipa::path(get, path = "/api/v1/teams/{team}/ai/usage",
     tag = "AI",
     params(("team" = String, Path, description = "Team name or UUID"), AiUsageQuery),
@@ -536,4 +664,81 @@ pub async fn get_ai_usage(
         .await
     };
     run.await.map(Json).map_err(|e| ApiError::new(e, rid))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn trace_event(request_id: &str) -> AiTraceEvent {
+        AiTraceEvent {
+            id: uuid::Uuid::now_v7(),
+            team_id: fp_domain::TeamId::from(uuid::Uuid::now_v7()),
+            request_id: request_id.to_string(),
+            trace_id: None,
+            route_config_id: fp_domain::RouteConfigId::from(uuid::Uuid::now_v7()),
+            listener_id: None,
+            provider_id: None,
+            model: Some("gpt-5".into()),
+            status_code: Some(200),
+            failure_hop: None,
+            hops: serde_json::json!([
+                {"hop": "route_match", "outcome": "matched", "origin": "listener", "failed": false}
+            ]),
+            created_at: chrono::Utc::now(),
+            expires_at: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn id_filtered_miss_carries_the_never_traced_hint() {
+        let shaped = shape_trace_response(Vec::new(), true);
+        assert!(shaped.traces.is_empty());
+        let miss = shaped
+            .miss
+            .expect("miss payload on an id-filtered empty result");
+        assert_eq!(miss.message, "no trace row found");
+        // The hint must name every never-traced class from design Risk 5.
+        for class in [
+            "TCP/TLS-level failures",
+            "client disconnect before request headers",
+            "pre-ExtProc declared-filter denials",
+        ] {
+            assert!(
+                miss.hint.contains(class),
+                "hint must name the never-traced class {class:?}, got: {}",
+                miss.hint
+            );
+        }
+    }
+
+    #[test]
+    fn unfiltered_empty_list_is_a_plain_empty_success_without_miss() {
+        let shaped = shape_trace_response(Vec::new(), false);
+        assert!(shaped.traces.is_empty());
+        assert!(shaped.miss.is_none());
+        // Distinguishable on the wire: no `miss` key at all for the empty success.
+        let json = serde_json::to_value(&shaped).unwrap();
+        assert_eq!(json, serde_json::json!({ "traces": [] }));
+    }
+
+    #[test]
+    fn hits_render_the_hop_timeline_and_never_a_miss() {
+        let shaped = shape_trace_response(vec![trace_event("req-1")], true);
+        assert!(shaped.miss.is_none());
+        assert_eq!(shaped.traces.len(), 1);
+        assert_eq!(shaped.traces[0].request_id, "req-1");
+        assert_eq!(shaped.traces[0].hops[0]["hop"], "route_match");
+    }
+
+    #[test]
+    fn trace_limit_clamps_to_the_repo_window() {
+        assert_eq!(default_trace_limit(), 50);
+        assert_eq!(trace_limit(default_trace_limit()), 50);
+        assert_eq!(trace_limit(0), 1);
+        assert_eq!(trace_limit(-5), 1);
+        assert_eq!(trace_limit(25), 25);
+        assert_eq!(trace_limit(10_000), 500);
+    }
 }

--- a/crates/fp-api/src/resources.rs
+++ b/crates/fp-api/src/resources.rs
@@ -68,6 +68,33 @@ pub fn revision_from(headers: &HeaderMap) -> DomainResult<i64> {
         })
 }
 
+/// Optional revision from `If-Match`, for create-or-replace endpoints where the header is
+/// optional: absent → `None` (create or replace); present → `Some(n)` (must match the current
+/// revision). A present-but-malformed header is an error rather than being silently ignored, so
+/// a client that meant to guard a write never falls through to a last-writer-wins replace.
+pub fn optional_revision_from(headers: &HeaderMap) -> DomainResult<Option<i64>> {
+    let Some(value) = headers.get(axum::http::header::IF_MATCH) else {
+        return Ok(None);
+    };
+    // The header IS present: it must be a valid integer revision. Anything unparseable —
+    // non-UTF-8, empty (`If-Match: ""`), or non-numeric — is an error, never a silent
+    // fall-through to a last-writer-wins replace (that is what an *omitted* header means).
+    value
+        .to_str()
+        .ok()
+        .map(|v| v.trim().trim_matches('"'))
+        .filter(|v| !v.is_empty())
+        .and_then(|v| v.parse::<i64>().ok())
+        .map(Some)
+        .ok_or_else(|| {
+            DomainError::new(
+                ErrorCode::ValidationFailed,
+                "If-Match must be an integer revision",
+            )
+            .with_hint("send If-Match: <revision>, or omit it to create or replace")
+        })
+}
+
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ListQuery {
     /// Max items (default 50, cap 500).

--- a/crates/fp-api/src/routes.rs
+++ b/crates/fp-api/src/routes.rs
@@ -189,6 +189,7 @@ fn secured_api() -> (Router<AppState>, utoipa::openapi::OpenApi) {
         ))
         .routes(routes!(ai_api::get_ai_usage))
         .routes(routes!(ai_api::get_ai_trace))
+        .routes(routes!(ai_api::get_ai_retention, ai_api::put_ai_retention))
         .routes(routes!(
             dataplanes_api::list_dataplanes,
             dataplanes_api::create_dataplane

--- a/crates/fp-api/src/routes.rs
+++ b/crates/fp-api/src/routes.rs
@@ -188,6 +188,7 @@ fn secured_api() -> (Router<AppState>, utoipa::openapi::OpenApi) {
             ai_api::delete_ai_budget
         ))
         .routes(routes!(ai_api::get_ai_usage))
+        .routes(routes!(ai_api::get_ai_trace))
         .routes(routes!(
             dataplanes_api::list_dataplanes,
             dataplanes_api::create_dataplane

--- a/crates/fp-api/tests/api_crud.rs
+++ b/crates/fp-api/tests/api_crud.rs
@@ -108,13 +108,14 @@ fn openapi_document_covers_every_registered_operation() {
     // + 2 route-generation plan operations.
     // + 5 AI provider operations + 5 AI route operations.
     // + 5 AI budget operations + 1 AI usage operation + 1 AI trace operation.
+    // + 2 AI retention operations (GET/PUT).
     // + 1 RLS force-repush admin operation.
     // + 14 rate-limit CRUD operations (5 domain + 5 policy + 4 override).
     // Updating this pin is a deliberate speed bump when the surface changes: the doc IS
     // the contract.
     assert_eq!(
-        operations, 111,
-        "expected 111 documented operations, got {operations}"
+        operations, 113,
+        "expected 113 documented operations, got {operations}"
     );
     assert!(json["components"]["securitySchemes"]["bearerAuth"].is_object());
     let schemas = json["components"]["schemas"].as_object().expect("schemas");
@@ -149,6 +150,7 @@ fn openapi_document_covers_every_registered_operation() {
         "/api/v1/teams/{team}/ai/providers",
         "/api/v1/teams/{team}/ai/routes",
         "/api/v1/teams/{team}/ai/trace",
+        "/api/v1/teams/{team}/ai/retention",
         "/api/v1/teams/{team}/xds/status",
         "/api/v1/teams/{team}/ops/trace",
     ] {
@@ -2017,4 +2019,278 @@ async fn ai_trace_retrieval_over_http() {
             .contains("ai-usage:read"),
         "403 must name the missing grant: {body}"
     );
+}
+
+// Slice s5 (ai-gateway-e2e-trace): retention policy surface over HTTP through the real
+// middleware stack — GET enforces (ai-usage, read), PUT enforces (ai-usage, update) with the
+// budget-CRUD mutation shape (authorize, validate, tx, audit row), cross-org 404, and the
+// default-vs-stored policy view.
+#[tokio::test]
+async fn ai_retention_crud_authz_and_audit_over_http() {
+    let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+        eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+        return;
+    };
+    let pool = fp_storage::connect(&url, 4).await.expect("connect");
+    fp_storage::migrate(&pool).await.expect("migrate");
+
+    let issuer = DevIssuer::generate().expect("issuer");
+    let validator = fp_core::OidcValidator::new(issuer.oidc_config());
+    validator
+        .load_jwks_json(issuer.jwks_json())
+        .await
+        .expect("jwks");
+
+    // Org A: an admin, a reader holding only (ai-usage, read), and a member holding only an
+    // unrelated grant.
+    let org_a = identity::create_org(&pool, &unique("org-a"), "")
+        .await
+        .expect("org a");
+    let team = identity::create_team(&pool, org_a.id, &unique("team"), "")
+        .await
+        .expect("team");
+    let admin_sub = unique("sub-admin");
+    let admin_token = issuer
+        .mint(&admin_sub, "ret-admin@test", "Retention Admin", 600)
+        .expect("mint admin");
+    let admin = identity::upsert_user_by_subject(&pool, &admin_sub, "ret-admin@test", "A")
+        .await
+        .expect("admin");
+    identity::add_org_membership(&pool, admin, org_a.id, OrgRole::Admin)
+        .await
+        .expect("admin member");
+
+    let reader_sub = unique("sub-reader");
+    let reader_token = issuer
+        .mint(&reader_sub, "ret-reader@test", "Retention Reader", 600)
+        .expect("mint reader");
+    let reader = identity::upsert_user_by_subject(&pool, &reader_sub, "ret-reader@test", "R")
+        .await
+        .expect("reader");
+    identity::add_org_membership(&pool, reader, org_a.id, OrgRole::Member)
+        .await
+        .expect("reader membership");
+    identity::add_grant(
+        &pool,
+        reader,
+        org_a.id,
+        team.id,
+        fp_domain::authz::Resource::AiUsage,
+        fp_domain::authz::Action::Read,
+        None,
+    )
+    .await
+    .expect("reader grant");
+
+    let member_sub = unique("sub-member");
+    let member_token = issuer
+        .mint(&member_sub, "ret-member@test", "Retention Member", 600)
+        .expect("mint member");
+    let member = identity::upsert_user_by_subject(&pool, &member_sub, "ret-member@test", "M")
+        .await
+        .expect("member");
+    identity::add_org_membership(&pool, member, org_a.id, OrgRole::Member)
+        .await
+        .expect("member membership");
+    identity::add_grant(
+        &pool,
+        member,
+        org_a.id,
+        team.id,
+        fp_domain::authz::Resource::AiProviders,
+        fp_domain::authz::Action::Read,
+        None,
+    )
+    .await
+    .expect("unrelated grant");
+
+    // Org B: an admin of a different org (cross-org caller).
+    let org_b = identity::create_org(&pool, &unique("org-b"), "")
+        .await
+        .expect("org b");
+    let outsider_sub = unique("sub-outsider");
+    let outsider_token = issuer
+        .mint(&outsider_sub, "ret-outsider@test", "Outsider", 600)
+        .expect("mint outsider");
+    let outsider = identity::upsert_user_by_subject(&pool, &outsider_sub, "ret-outsider@test", "O")
+        .await
+        .expect("outsider");
+    identity::add_org_membership(&pool, outsider, org_b.id, OrgRole::Admin)
+        .await
+        .expect("outsider member");
+
+    let app = fp_api::build_router(fp_api::AppState {
+        pool: pool.clone(),
+        prometheus: PrometheusBuilder::new().build_recorder().handle(),
+        version: "test",
+        validator: Some(std::sync::Arc::new(validator)),
+        write_throttle: std::sync::Arc::new(fp_api::throttle::WriteThrottle::new(1000)),
+        xds_readiness: None,
+        discovery_forwarding_policy: Default::default(),
+        rls_repush: None,
+        rls_grpc_configured: false,
+    });
+    let path = format!("/api/v1/teams/{}/ai/retention", team.name);
+    let get = |token: &str| {
+        Request::builder()
+            .method("GET")
+            .uri(&path)
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::empty())
+            .expect("get request")
+    };
+    let put = |token: &str, body: serde_json::Value| {
+        Request::builder()
+            .method("PUT")
+            .uri(&path)
+            .header("authorization", format!("Bearer {token}"))
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .expect("put request")
+    };
+    let audit_rows = || async {
+        sqlx::query_scalar::<_, i64>(
+            "SELECT count(*) FROM audit_log \
+             WHERE team_id = $1 AND action = 'ai_retention.set' AND outcome = 'success'",
+        )
+        .bind(team.id.as_uuid())
+        .fetch_one(&pool)
+        .await
+        .expect("audit count")
+    };
+
+    // No policy row yet: GET reports the built-in 30-day default.
+    let response = app
+        .clone()
+        .oneshot(get(&admin_token))
+        .await
+        .expect("get default");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    assert_eq!(body["trace_ttl_days"], 30);
+    assert_eq!(body["is_default"], true);
+    assert!(body.get("revision").is_none(), "default has no revision");
+
+    // PUT creates the policy (mutation shape: authorize, validate, tx, audit row).
+    let response = app
+        .clone()
+        .oneshot(put(&admin_token, serde_json::json!({"trace_ttl_days": 7})))
+        .await
+        .expect("put create");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    assert_eq!(body["trace_ttl_days"], 7);
+    assert_eq!(body["is_default"], false);
+    assert_eq!(body["revision"], 1);
+    assert_eq!(
+        audit_rows().await,
+        1,
+        "PUT must commit exactly one audit row"
+    );
+
+    // GET now reads the stored policy.
+    let response = app
+        .clone()
+        .oneshot(get(&admin_token))
+        .await
+        .expect("get stored");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    assert_eq!(body["trace_ttl_days"], 7);
+    assert_eq!(body["is_default"], false);
+
+    // PUT replaces (one policy per team) and bumps the revision; second audit row.
+    let response = app
+        .clone()
+        .oneshot(put(&admin_token, serde_json::json!({"trace_ttl_days": 14})))
+        .await
+        .expect("put replace");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    assert_eq!(body["trace_ttl_days"], 14);
+    assert_eq!(body["revision"], 2);
+    assert_eq!(audit_rows().await, 2);
+
+    // Validation fails closed BEFORE any write: out-of-bounds TTLs are rejected and leave
+    // no audit row behind.
+    for bad_ttl in [0, -1, 366] {
+        let response = app
+            .clone()
+            .oneshot(put(
+                &admin_token,
+                serde_json::json!({"trace_ttl_days": bad_ttl}),
+            ))
+            .await
+            .expect("put invalid");
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "trace_ttl_days {bad_ttl} must be rejected"
+        );
+    }
+    assert_eq!(audit_rows().await, 2, "rejected PUTs must not audit");
+
+    // (ai-usage, read) alone: GET allowed, PUT denied naming the update grant.
+    let response = app
+        .clone()
+        .oneshot(get(&reader_token))
+        .await
+        .expect("reader get");
+    assert_eq!(response.status(), StatusCode::OK);
+    let response = app
+        .clone()
+        .oneshot(put(&reader_token, serde_json::json!({"trace_ttl_days": 5})))
+        .await
+        .expect("reader put");
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body = json_of(response).await;
+    assert!(
+        body["message"]
+            .as_str()
+            .expect("message")
+            .contains("ai-usage:update"),
+        "403 must name the missing update grant: {body}"
+    );
+
+    // Unrelated grant only: GET denied naming the read grant.
+    let response = app
+        .clone()
+        .oneshot(get(&member_token))
+        .await
+        .expect("member get");
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body = json_of(response).await;
+    assert!(
+        body["message"]
+            .as_str()
+            .expect("message")
+            .contains("ai-usage:read"),
+        "403 must name the missing read grant: {body}"
+    );
+
+    // Cross-org: 404 per the org-boundary mapping, for both verbs.
+    let response = app
+        .clone()
+        .oneshot(get(&outsider_token))
+        .await
+        .expect("outsider get");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let response = app
+        .clone()
+        .oneshot(put(
+            &outsider_token,
+            serde_json::json!({"trace_ttl_days": 5}),
+        ))
+        .await
+        .expect("outsider put");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    // The stored policy is untouched by every denied/rejected attempt above.
+    let ttl: i32 =
+        sqlx::query_scalar("SELECT trace_ttl_days FROM ai_retention_policies WHERE team_id = $1")
+            .bind(team.id.as_uuid())
+            .fetch_one(&pool)
+            .await
+            .expect("policy row");
+    assert_eq!(ttl, 14);
 }

--- a/crates/fp-api/tests/api_crud.rs
+++ b/crates/fp-api/tests/api_crud.rs
@@ -107,14 +107,14 @@ fn openapi_document_covers_every_registered_operation() {
     // + 2 expose shortcut operations.
     // + 2 route-generation plan operations.
     // + 5 AI provider operations + 5 AI route operations.
-    // + 5 AI budget operations + 1 AI usage operation.
+    // + 5 AI budget operations + 1 AI usage operation + 1 AI trace operation.
     // + 1 RLS force-repush admin operation.
     // + 14 rate-limit CRUD operations (5 domain + 5 policy + 4 override).
     // Updating this pin is a deliberate speed bump when the surface changes: the doc IS
     // the contract.
     assert_eq!(
-        operations, 110,
-        "expected 110 documented operations, got {operations}"
+        operations, 111,
+        "expected 111 documented operations, got {operations}"
     );
     assert!(json["components"]["securitySchemes"]["bearerAuth"].is_object());
     let schemas = json["components"]["schemas"].as_object().expect("schemas");
@@ -148,6 +148,7 @@ fn openapi_document_covers_every_registered_operation() {
         "/api/v1/teams/{team}/learning-discovery-sessions/{session}/spec-versions",
         "/api/v1/teams/{team}/ai/providers",
         "/api/v1/teams/{team}/ai/routes",
+        "/api/v1/teams/{team}/ai/trace",
         "/api/v1/teams/{team}/xds/status",
         "/api/v1/teams/{team}/ops/trace",
     ] {
@@ -1776,5 +1777,244 @@ async fn malformed_json_body_returns_validation_envelope() {
     assert!(
         body.get("request_id").and_then(|v| v.as_str()).is_some(),
         "envelope must carry request_id, got: {body}"
+    );
+}
+
+// Slice s4 (ai-gateway-e2e-trace): team-scoped AI trace retrieval over HTTP through the
+// real middleware stack — correlated hop timeline on a hit, a distinguishable miss with
+// the never-traced-classes hint, cross-org 404, and missing-grant 403.
+#[tokio::test]
+async fn ai_trace_retrieval_over_http() {
+    let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+        eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+        return;
+    };
+    let pool = fp_storage::connect(&url, 4).await.expect("connect");
+    fp_storage::migrate(&pool).await.expect("migrate");
+
+    let issuer = DevIssuer::generate().expect("issuer");
+    let validator = fp_core::OidcValidator::new(issuer.oidc_config());
+    validator
+        .load_jwks_json(issuer.jwks_json())
+        .await
+        .expect("jwks");
+
+    // Org A: an admin (implicit team access) and a member holding only an unrelated grant.
+    let org_a = identity::create_org(&pool, &unique("org-a"), "")
+        .await
+        .expect("org a");
+    let team = identity::create_team(&pool, org_a.id, &unique("team"), "")
+        .await
+        .expect("team");
+    let admin_sub = unique("sub-admin");
+    let admin_token = issuer
+        .mint(&admin_sub, "trace-admin@test", "Trace Admin", 600)
+        .expect("mint admin");
+    let admin = identity::upsert_user_by_subject(&pool, &admin_sub, "trace-admin@test", "A")
+        .await
+        .expect("admin");
+    identity::add_org_membership(&pool, admin, org_a.id, OrgRole::Admin)
+        .await
+        .expect("admin member");
+
+    let member_sub = unique("sub-member");
+    let member_token = issuer
+        .mint(&member_sub, "trace-member@test", "Trace Member", 600)
+        .expect("mint member");
+    let member = identity::upsert_user_by_subject(&pool, &member_sub, "trace-member@test", "M")
+        .await
+        .expect("member");
+    identity::add_org_membership(&pool, member, org_a.id, OrgRole::Member)
+        .await
+        .expect("member membership");
+    identity::add_grant(
+        &pool,
+        member,
+        org_a.id,
+        team.id,
+        fp_domain::authz::Resource::AiProviders,
+        fp_domain::authz::Action::Read,
+        None,
+    )
+    .await
+    .expect("unrelated grant");
+
+    // Org B: an admin of a different org (cross-org caller).
+    let org_b = identity::create_org(&pool, &unique("org-b"), "")
+        .await
+        .expect("org b");
+    let outsider_sub = unique("sub-outsider");
+    let outsider_token = issuer
+        .mint(&outsider_sub, "trace-outsider@test", "Outsider", 600)
+        .expect("mint outsider");
+    let outsider =
+        identity::upsert_user_by_subject(&pool, &outsider_sub, "trace-outsider@test", "O")
+            .await
+            .expect("outsider");
+    identity::add_org_membership(&pool, outsider, org_b.id, OrgRole::Admin)
+        .await
+        .expect("outsider member");
+
+    // Seed one trace row for the team (the write path is slice s2's; here it is fixture data).
+    let request_id = uuid::Uuid::now_v7().to_string();
+    fp_storage::repos::ai_trace::upsert_trace_event(
+        &pool,
+        &fp_storage::repos::ai_trace::AiTraceEventUpsert {
+            team_id: team.id,
+            request_id: request_id.clone(),
+            trace_id: Some("0af7651916cd43dd8448eb211c80319c".into()),
+            route_config_id: fp_domain::RouteConfigId::from(uuid::Uuid::now_v7()),
+            listener_id: None,
+            provider_id: None,
+            model: Some("gpt-5".into()),
+            status_code: Some(200),
+            hops: serde_json::json!([
+                {"hop": "route_match", "started_at": "2026-07-04T00:00:00.100Z",
+                 "ended_at": "2026-07-04T00:00:00.200Z", "outcome": "matched",
+                 "origin": "listener", "failed": false, "detail": {}},
+                {"hop": "upstream", "started_at": "2026-07-04T00:00:00.300Z",
+                 "ended_at": "2026-07-04T00:00:00.900Z", "outcome": "ok",
+                 "origin": "upstream", "failed": false, "detail": {"status": 200}}
+            ]),
+        },
+    )
+    .await
+    .expect("seed trace row");
+
+    let app = fp_api::build_router(fp_api::AppState {
+        pool,
+        prometheus: PrometheusBuilder::new().build_recorder().handle(),
+        version: "test",
+        validator: Some(std::sync::Arc::new(validator)),
+        write_throttle: std::sync::Arc::new(fp_api::throttle::WriteThrottle::new(1000)),
+        xds_readiness: None,
+        discovery_forwarding_policy: Default::default(),
+        rls_repush: None,
+        rls_grpc_configured: false,
+    });
+    let request = |token: &str, path: &str| {
+        Request::builder()
+            .method("GET")
+            .uri(path)
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::empty())
+            .expect("request")
+    };
+
+    // Hit: correlated hop timeline, no miss payload.
+    let response = app
+        .clone()
+        .oneshot(request(
+            &admin_token,
+            &format!(
+                "/api/v1/teams/{}/ai/trace?request_id={request_id}",
+                team.name
+            ),
+        ))
+        .await
+        .expect("trace hit");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    let traces = body["traces"].as_array().expect("traces");
+    assert_eq!(traces.len(), 1);
+    assert_eq!(traces[0]["request_id"], request_id);
+    assert_eq!(traces[0]["trace_id"], "0af7651916cd43dd8448eb211c80319c");
+    let hops = traces[0]["hops"].as_array().expect("hops");
+    assert_eq!(hops[0]["hop"], "route_match");
+    assert_eq!(hops[1]["hop"], "upstream");
+    assert!(
+        body.get("miss").is_none(),
+        "hit must not carry a miss: {body}"
+    );
+
+    // trace_id filter returns the same row.
+    let response = app
+        .clone()
+        .oneshot(request(
+            &admin_token,
+            &format!(
+                "/api/v1/teams/{}/ai/trace?trace_id=0af7651916cd43dd8448eb211c80319c&limit=5",
+                team.name
+            ),
+        ))
+        .await
+        .expect("trace by trace_id");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    assert!(body["traces"]
+        .as_array()
+        .expect("traces")
+        .iter()
+        .any(|t| t["request_id"] == request_id.as_str()));
+
+    // Miss: unknown request_id → distinguishable "no trace row found" with the hint naming
+    // the never-traced classes (design Risk 5).
+    let response = app
+        .clone()
+        .oneshot(request(
+            &admin_token,
+            &format!(
+                "/api/v1/teams/{}/ai/trace?request_id={}",
+                team.name,
+                uuid::Uuid::now_v7()
+            ),
+        ))
+        .await
+        .expect("trace miss");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    assert!(body["traces"].as_array().expect("traces").is_empty());
+    assert_eq!(body["miss"]["message"], "no trace row found");
+    let hint = body["miss"]["hint"].as_str().expect("miss hint");
+    for class in [
+        "TCP/TLS-level failures",
+        "client disconnect before request headers",
+        "pre-ExtProc declared-filter denials",
+    ] {
+        assert!(hint.contains(class), "hint must name {class:?}: {hint}");
+    }
+
+    // Cross-org: an org-B token querying team A's request_id gets 404 (org-boundary
+    // mapping) and zero rows — denied in the service before any repo read.
+    let response = app
+        .clone()
+        .oneshot(request(
+            &outsider_token,
+            &format!(
+                "/api/v1/teams/{}/ai/trace?request_id={request_id}",
+                team.name
+            ),
+        ))
+        .await
+        .expect("cross-org trace");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let body = json_of(response).await;
+    assert!(
+        body.get("traces").is_none(),
+        "denial must return no rows: {body}"
+    );
+
+    // Missing grant: a same-org member with other team grants but without (ai-usage, read)
+    // gets 403 naming the missing grant.
+    let response = app
+        .clone()
+        .oneshot(request(
+            &member_token,
+            &format!(
+                "/api/v1/teams/{}/ai/trace?request_id={request_id}",
+                team.name
+            ),
+        ))
+        .await
+        .expect("missing-grant trace");
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let body = json_of(response).await;
+    assert_eq!(body["code"], "forbidden");
+    assert!(
+        body["message"]
+            .as_str()
+            .expect("message")
+            .contains("ai-usage:read"),
+        "403 must name the missing grant: {body}"
     );
 }

--- a/crates/fp-api/tests/api_crud.rs
+++ b/crates/fp-api/tests/api_crud.rs
@@ -2293,4 +2293,103 @@ async fn ai_retention_crud_authz_and_audit_over_http() {
             .await
             .expect("policy row");
     assert_eq!(ttl, 14);
+
+    // #226 optimistic concurrency (If-Match). The policy is at revision 2 / ttl 14 here,
+    // untouched by all the rejected attempts above.
+    let put_if_match = |token: &str, body: serde_json::Value, revision: i64| {
+        Request::builder()
+            .method("PUT")
+            .uri(&path)
+            .header("authorization", format!("Bearer {token}"))
+            .header("content-type", "application/json")
+            .header("if-match", revision.to_string())
+            .body(Body::from(body.to_string()))
+            .expect("put if-match request")
+    };
+    // A stale revision (1, current is 2) is rejected with 409 and writes nothing.
+    let response = app
+        .clone()
+        .oneshot(put_if_match(
+            &admin_token,
+            serde_json::json!({"trace_ttl_days": 21}),
+            1,
+        ))
+        .await
+        .expect("put stale");
+    assert_eq!(
+        response.status(),
+        StatusCode::CONFLICT,
+        "a stale If-Match must be rejected, not silently last-writer-win"
+    );
+    assert_eq!(
+        audit_rows().await,
+        2,
+        "a rejected stale write commits no audit row"
+    );
+    let response = app
+        .clone()
+        .oneshot(get(&admin_token))
+        .await
+        .expect("get after stale");
+    assert_eq!(
+        json_of(response).await["trace_ttl_days"],
+        14,
+        "the stale write left the stored policy untouched"
+    );
+    // The current revision (2) succeeds and bumps to 3.
+    let response = app
+        .clone()
+        .oneshot(put_if_match(
+            &admin_token,
+            serde_json::json!({"trace_ttl_days": 21}),
+            2,
+        ))
+        .await
+        .expect("put current revision");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = json_of(response).await;
+    assert_eq!(body["trace_ttl_days"], 21);
+    assert_eq!(body["revision"], 3);
+    assert_eq!(audit_rows().await, 3);
+    // Omitting If-Match still creates-or-replaces (the revision is optional), bumping to 4.
+    let response = app
+        .clone()
+        .oneshot(put(&admin_token, serde_json::json!({"trace_ttl_days": 28})))
+        .await
+        .expect("put without if-match");
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(json_of(response).await["revision"], 4);
+
+    // A present-but-malformed If-Match is a validation error, NOT treated as absent — it must
+    // never fall through to a silent create-or-replace. Policy stays at revision 4.
+    let malformed = Request::builder()
+        .method("PUT")
+        .uri(&path)
+        .header("authorization", format!("Bearer {admin_token}"))
+        .header("content-type", "application/json")
+        .header("if-match", "not-a-revision")
+        .body(Body::from(
+            serde_json::json!({"trace_ttl_days": 9}).to_string(),
+        ))
+        .expect("malformed if-match request");
+    let response = app
+        .clone()
+        .oneshot(malformed)
+        .await
+        .expect("put malformed if-match");
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "a present-but-malformed If-Match must be rejected, not treated as absent"
+    );
+    let response = app
+        .clone()
+        .oneshot(get(&admin_token))
+        .await
+        .expect("get after malformed");
+    assert_eq!(
+        json_of(response).await["revision"],
+        4,
+        "the malformed-If-Match write must not have changed the policy"
+    );
 }

--- a/crates/fp-core/src/services/ai.rs
+++ b/crates/fp-core/src/services/ai.rs
@@ -11,7 +11,7 @@ use fp_domain::gateway::route_config::{
     RouteConfigSpec, RouteRule, VirtualHost, WeightedClusterTarget,
 };
 use fp_domain::{
-    validate_ai_budget_name, validate_ai_provider_name, validate_ai_route_name,
+    ai_error_envelope, validate_ai_budget_name, validate_ai_provider_name, validate_ai_route_name,
     validate_trace_ttl_days, AiBudget, AiBudgetSpec, AiProvider, AiProviderSpec, AiRetentionPolicy,
     AiRoute, AiRouteMaterializedResources, AiRouteSpec, AiTraceEvent, AiUsageSummary, DomainError,
     DomainResult, RequestId, AI_MODEL_HEADER, DEFAULT_AI_ROUTE_TIMEOUT_SECS,
@@ -1267,10 +1267,10 @@ fn no_eligible_backend_route(path: &str) -> RouteRule {
             redirect: None,
             direct_response: Some(DirectResponseAction {
                 status: 400,
-                body: Some(
-                    r#"{"code":"no_eligible_ai_backend","message":"no eligible AI backend for requested model"}"#
-                        .into(),
-                ),
+                body: Some(ai_error_envelope(
+                    "no_eligible_ai_backend",
+                    "no eligible AI backend for requested model",
+                )),
             }),
             prefix_rewrite: None,
             template_rewrite: None,
@@ -1528,5 +1528,38 @@ mod tests {
         assert_eq!(weighted[1].cluster, names.cluster_names[1]);
         assert_eq!(weighted[1].weight, 7);
         assert!(default_route.action.retry_policy.is_none());
+    }
+
+    #[test]
+    fn no_eligible_backend_route_keeps_direct_response_body() {
+        let spec = route_spec(vec![AiRouteBackend {
+            provider_id: fp_domain::id::AiProviderId::generate(),
+            models: vec!["gpt-5".into()],
+            model_override: None,
+            weight: 1,
+            priority: 0,
+        }]);
+        let names = materialized_names("llm", &spec).expect("names");
+        let targets = ai_route_targets("llm", &spec).expect("targets");
+        let route_config = ai_route_config_spec(&spec, &targets, &names).expect("route config");
+
+        let route = route_config.virtual_hosts[0]
+            .routes
+            .iter()
+            .find(|route| route.name == "no-eligible-backend")
+            .expect("no eligible backend route");
+        let direct_response = route
+            .action
+            .direct_response
+            .as_ref()
+            .expect("direct response");
+
+        assert_eq!(direct_response.status, 400);
+        assert_eq!(
+            direct_response.body.as_deref(),
+            Some(
+                r#"{"code":"no_eligible_ai_backend","message":"no eligible AI backend for requested model"}"#
+            )
+        );
     }
 }

--- a/crates/fp-core/src/services/ai.rs
+++ b/crates/fp-core/src/services/ai.rs
@@ -13,10 +13,10 @@ use fp_domain::gateway::route_config::{
 use fp_domain::{
     validate_ai_budget_name, validate_ai_provider_name, validate_ai_route_name, AiBudget,
     AiBudgetSpec, AiProvider, AiProviderSpec, AiRoute, AiRouteMaterializedResources, AiRouteSpec,
-    AiUsageSummary, DomainError, DomainResult, RequestId, AI_MODEL_HEADER,
+    AiTraceEvent, AiUsageSummary, DomainError, DomainResult, RequestId, AI_MODEL_HEADER,
     DEFAULT_AI_ROUTE_TIMEOUT_SECS,
 };
-use fp_storage::repos::{ai, audit, clusters as cluster_repo, gateway as gateway_repo};
+use fp_storage::repos::{ai, ai_trace, audit, clusters as cluster_repo, gateway as gateway_repo};
 use reqwest::Url;
 use sqlx::PgPool;
 use std::collections::BTreeMap;
@@ -526,6 +526,19 @@ pub async fn usage_summary(
 ) -> DomainResult<Vec<AiUsageSummary>> {
     authorize(pool, ctx, Resource::AiUsage, Action::Read, team, request_id).await?;
     ai::usage_summary(pool, team.id, query).await
+}
+
+/// Team-scoped read of AI trace rows: authorization happens before any repo read, and the
+/// repo query is scoped by the resolved team id, so a foreign request_id can never match.
+pub async fn trace_events(
+    pool: &PgPool,
+    ctx: &PrincipalCtx,
+    team: TeamRef,
+    query: ai_trace::AiTraceQuery<'_>,
+    request_id: RequestId,
+) -> DomainResult<Vec<AiTraceEvent>> {
+    authorize(pool, ctx, Resource::AiUsage, Action::Read, team, request_id).await?;
+    ai_trace::list_trace_events(pool, team.id, query).await
 }
 
 pub async fn update_route(

--- a/crates/fp-core/src/services/ai.rs
+++ b/crates/fp-core/src/services/ai.rs
@@ -11,10 +11,10 @@ use fp_domain::gateway::route_config::{
     RouteConfigSpec, RouteRule, VirtualHost, WeightedClusterTarget,
 };
 use fp_domain::{
-    validate_ai_budget_name, validate_ai_provider_name, validate_ai_route_name, AiBudget,
-    AiBudgetSpec, AiProvider, AiProviderSpec, AiRoute, AiRouteMaterializedResources, AiRouteSpec,
-    AiTraceEvent, AiUsageSummary, DomainError, DomainResult, RequestId, AI_MODEL_HEADER,
-    DEFAULT_AI_ROUTE_TIMEOUT_SECS,
+    validate_ai_budget_name, validate_ai_provider_name, validate_ai_route_name,
+    validate_trace_ttl_days, AiBudget, AiBudgetSpec, AiProvider, AiProviderSpec, AiRetentionPolicy,
+    AiRoute, AiRouteMaterializedResources, AiRouteSpec, AiTraceEvent, AiUsageSummary, DomainError,
+    DomainResult, RequestId, AI_MODEL_HEADER, DEFAULT_AI_ROUTE_TIMEOUT_SECS,
 };
 use fp_storage::repos::{ai, ai_trace, audit, clusters as cluster_repo, gateway as gateway_repo};
 use reqwest::Url;
@@ -539,6 +539,61 @@ pub async fn trace_events(
 ) -> DomainResult<Vec<AiTraceEvent>> {
     authorize(pool, ctx, Resource::AiUsage, Action::Read, team, request_id).await?;
     ai_trace::list_trace_events(pool, team.id, query).await
+}
+
+/// The team's AI trace retention policy row; `None` means the built-in 30-day default is in
+/// force. Guarded by the same resource the trace read uses.
+pub async fn get_retention_policy(
+    pool: &PgPool,
+    ctx: &PrincipalCtx,
+    team: TeamRef,
+    request_id: RequestId,
+) -> DomainResult<Option<AiRetentionPolicy>> {
+    authorize(pool, ctx, Resource::AiUsage, Action::Read, team, request_id).await?;
+    ai_trace::get_retention_policy(pool, team.id).await
+}
+
+/// Create-or-replace the team's AI trace retention policy (PUT semantics: one row per team).
+/// Affects only rows inserted after the change — existing rows keep the expiry they were
+/// stamped with.
+pub async fn set_retention_policy(
+    pool: &PgPool,
+    ctx: &PrincipalCtx,
+    team: TeamRef,
+    trace_ttl_days: i32,
+    request_id: RequestId,
+) -> DomainResult<AiRetentionPolicy> {
+    authorize(
+        pool,
+        ctx,
+        Resource::AiUsage,
+        Action::Update,
+        team,
+        request_id,
+    )
+    .await?;
+    validate_trace_ttl_days(trace_ttl_days)?;
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(crate::services::db_err("set AI retention policy: begin"))?;
+    let policy = ai_trace::set_retention_policy(&mut tx, team, trace_ttl_days).await?;
+    audit::record_in_tx(
+        &mut tx,
+        &mutation_audit(
+            ctx,
+            request_id,
+            team,
+            "ai_retention.set",
+            "ai-retention",
+            "trace",
+        ),
+    )
+    .await?;
+    tx.commit()
+        .await
+        .map_err(crate::services::db_err("set AI retention policy: commit"))?;
+    Ok(policy)
 }
 
 pub async fn update_route(

--- a/crates/fp-core/src/services/ai.rs
+++ b/crates/fp-core/src/services/ai.rs
@@ -561,6 +561,7 @@ pub async fn set_retention_policy(
     ctx: &PrincipalCtx,
     team: TeamRef,
     trace_ttl_days: i32,
+    expected_version: Option<i64>,
     request_id: RequestId,
 ) -> DomainResult<AiRetentionPolicy> {
     authorize(
@@ -577,7 +578,8 @@ pub async fn set_retention_policy(
         .begin()
         .await
         .map_err(crate::services::db_err("set AI retention policy: begin"))?;
-    let policy = ai_trace::set_retention_policy(&mut tx, team, trace_ttl_days).await?;
+    let policy =
+        ai_trace::set_retention_policy(&mut tx, team, trace_ttl_days, expected_version).await?;
     audit::record_in_tx(
         &mut tx,
         &mutation_audit(

--- a/crates/fp-core/tests/ai_trace_service.rs
+++ b/crates/fp-core/tests/ai_trace_service.rs
@@ -1,0 +1,287 @@
+//! Slice s4 integration: team-scoped AI trace retrieval through the fp-core service.
+//! Authorization (`check_resource_access` on `(Resource::AiUsage, Action::Read)`) runs
+//! before any repo read; the repo query is scoped by team id so a foreign request_id can
+//! never match. Unique org/team/user names per run keep this parallel-safe against
+//! sibling tests sharing the database (invariant 18).
+
+#![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
+
+use fp_core::{GrantSet, PrincipalCtx};
+use fp_domain::authz::{Action, Resource};
+use fp_domain::{ErrorCode, OrgRole, RequestId};
+use fp_storage::repos::{ai_trace, identity};
+use sqlx::PgPool;
+
+fn unique(prefix: &str) -> String {
+    format!(
+        "{prefix}-{}",
+        &uuid::Uuid::now_v7().simple().to_string()[20..]
+    )
+}
+
+async fn test_pool() -> Option<PgPool> {
+    let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+        eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+        return None;
+    };
+    let pool = fp_storage::connect(&url, 4).await.expect("connect");
+    fp_storage::migrate(&pool).await.expect("migrate");
+    Some(pool)
+}
+
+/// Mirror the auth middleware's D-014 resolution for single-org test users.
+async fn principal_ctx(pool: &PgPool, subject: &str) -> PrincipalCtx {
+    let loaded = identity::load_principal(pool, subject)
+        .await
+        .expect("load principal")
+        .expect("principal exists");
+    let candidates: Vec<_> = loaded
+        .memberships
+        .iter()
+        .copied()
+        .filter(|(org_id, _)| Some(*org_id) != loaded.platform_org_id)
+        .collect();
+    let (org, org_selector_required) = match candidates.as_slice() {
+        [one] => (Some(*one), false),
+        [] => (None, false),
+        _ => (None, true),
+    };
+    PrincipalCtx::User {
+        user_id: loaded.user_id,
+        platform_admin: loaded.platform_admin,
+        org_selector_required,
+        org,
+        grants: GrantSet::new(loaded.grants),
+    }
+}
+
+/// Seed one trace row for `team_id` and return its request_id.
+async fn seed_trace_row(pool: &PgPool, team_id: fp_domain::TeamId) -> String {
+    let request_id = uuid::Uuid::now_v7().to_string();
+    ai_trace::upsert_trace_event(
+        pool,
+        &ai_trace::AiTraceEventUpsert {
+            team_id,
+            request_id: request_id.clone(),
+            trace_id: None,
+            route_config_id: fp_domain::RouteConfigId::from(uuid::Uuid::now_v7()),
+            listener_id: None,
+            provider_id: None,
+            model: Some("gpt-5".into()),
+            status_code: Some(200),
+            hops: serde_json::json!([
+                {"hop": "route_match", "started_at": "2026-07-04T00:00:00Z",
+                 "ended_at": "2026-07-04T00:00:00Z", "outcome": "matched",
+                 "origin": "listener", "failed": false, "detail": {}}
+            ]),
+        },
+    )
+    .await
+    .expect("seed trace row");
+    request_id
+}
+
+#[tokio::test]
+async fn trace_read_enforces_ai_usage_read_before_any_repo_read() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+
+    let org = identity::create_org(&pool, &unique("org"), "")
+        .await
+        .expect("org");
+    let team = identity::create_team(&pool, org.id, &unique("team"), "")
+        .await
+        .expect("team");
+    let team_ref = identity::resolve_team_ref(&pool, team.id)
+        .await
+        .expect("q")
+        .expect("team ref");
+    let request_id = seed_trace_row(&pool, team.id).await;
+
+    // A member holding (AiUsage, Read) on the team reads the trace.
+    let reader_sub = unique("sub-reader");
+    let reader = identity::upsert_user_by_subject(&pool, &reader_sub, "r@a.test", "Reader")
+        .await
+        .expect("reader");
+    identity::add_org_membership(&pool, reader, org.id, OrgRole::Member)
+        .await
+        .expect("member");
+    identity::add_grant(
+        &pool,
+        reader,
+        org.id,
+        team.id,
+        Resource::AiUsage,
+        Action::Read,
+        None,
+    )
+    .await
+    .expect("grant");
+    let reader_ctx = principal_ctx(&pool, &reader_sub).await;
+    let traces = fp_core::services::ai::trace_events(
+        &pool,
+        &reader_ctx,
+        team_ref,
+        ai_trace::AiTraceQuery {
+            request_id: Some(&request_id),
+            trace_id: None,
+            limit: 50,
+        },
+        RequestId::generate(),
+    )
+    .await
+    .expect("authorized trace read");
+    assert_eq!(traces.len(), 1);
+    assert_eq!(traces[0].request_id, request_id);
+    assert_eq!(traces[0].hops[0]["hop"], "route_match");
+
+    // A member with OTHER grants on the same team — but not (AiUsage, Read) — gets 403.
+    let other_sub = unique("sub-other");
+    let other = identity::upsert_user_by_subject(&pool, &other_sub, "o@a.test", "Other")
+        .await
+        .expect("other");
+    identity::add_org_membership(&pool, other, org.id, OrgRole::Member)
+        .await
+        .expect("member");
+    identity::add_grant(
+        &pool,
+        other,
+        org.id,
+        team.id,
+        Resource::AiProviders,
+        Action::Read,
+        None,
+    )
+    .await
+    .expect("unrelated grant");
+    let other_ctx = principal_ctx(&pool, &other_sub).await;
+    let err = fp_core::services::ai::trace_events(
+        &pool,
+        &other_ctx,
+        team_ref,
+        ai_trace::AiTraceQuery {
+            request_id: Some(&request_id),
+            trace_id: None,
+            limit: 50,
+        },
+        RequestId::generate(),
+    )
+    .await
+    .expect_err("missing (ai-usage, read) grant must deny");
+    assert_eq!(err.code, ErrorCode::Forbidden);
+    assert!(
+        err.message.contains("ai-usage:read"),
+        "denial names the missing grant, got: {}",
+        err.message
+    );
+}
+
+#[tokio::test]
+async fn cross_team_trace_reads_are_isolated_by_authz_and_by_scoping() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+
+    let org_a = identity::create_org(&pool, &unique("org-a"), "")
+        .await
+        .expect("org a");
+    let org_b = identity::create_org(&pool, &unique("org-b"), "")
+        .await
+        .expect("org b");
+    let team_a = identity::create_team(&pool, org_a.id, &unique("team-a"), "")
+        .await
+        .expect("team a");
+    let team_a2 = identity::create_team(&pool, org_a.id, &unique("team-a2"), "")
+        .await
+        .expect("team a2");
+    let ref_a = identity::resolve_team_ref(&pool, team_a.id)
+        .await
+        .expect("q")
+        .expect("ref a");
+    let ref_a2 = identity::resolve_team_ref(&pool, team_a2.id)
+        .await
+        .expect("q")
+        .expect("ref a2");
+    let request_id_a = seed_trace_row(&pool, team_a.id).await;
+
+    // Org-boundary mapping: an org-B admin querying team A's trace path gets not_found
+    // (anti-enumeration), never a row.
+    let mallory_sub = unique("sub-mallory");
+    let mallory = identity::upsert_user_by_subject(&pool, &mallory_sub, "m@b.test", "Mallory")
+        .await
+        .expect("mallory");
+    identity::add_org_membership(&pool, mallory, org_b.id, OrgRole::Admin)
+        .await
+        .expect("member");
+    let mallory_ctx = principal_ctx(&pool, &mallory_sub).await;
+    let err = fp_core::services::ai::trace_events(
+        &pool,
+        &mallory_ctx,
+        ref_a,
+        ai_trace::AiTraceQuery {
+            request_id: Some(&request_id_a),
+            trace_id: None,
+            limit: 50,
+        },
+        RequestId::generate(),
+    )
+    .await
+    .expect_err("cross-org trace read must deny");
+    assert_eq!(err.code, ErrorCode::NotFound);
+
+    // Scoped-by-construction: a reader authorized on team A2 querying team A's request_id
+    // through their OWN team scope gets zero rows — the repo query cannot match foreign rows.
+    let a2_sub = unique("sub-a2");
+    let a2_user = identity::upsert_user_by_subject(&pool, &a2_sub, "a2@a.test", "A2")
+        .await
+        .expect("a2 user");
+    identity::add_org_membership(&pool, a2_user, org_a.id, OrgRole::Member)
+        .await
+        .expect("member");
+    identity::add_grant(
+        &pool,
+        a2_user,
+        org_a.id,
+        team_a2.id,
+        Resource::AiUsage,
+        Action::Read,
+        None,
+    )
+    .await
+    .expect("grant");
+    let a2_ctx = principal_ctx(&pool, &a2_sub).await;
+    let traces = fp_core::services::ai::trace_events(
+        &pool,
+        &a2_ctx,
+        ref_a2,
+        ai_trace::AiTraceQuery {
+            request_id: Some(&request_id_a),
+            trace_id: None,
+            limit: 50,
+        },
+        RequestId::generate(),
+    )
+    .await
+    .expect("own-team read is authorized");
+    assert!(
+        traces.is_empty(),
+        "team A's request_id must not be visible through team A2's scope"
+    );
+
+    // And the same a2 principal aimed directly at team A is denied (no grant there).
+    let err = fp_core::services::ai::trace_events(
+        &pool,
+        &a2_ctx,
+        ref_a,
+        ai_trace::AiTraceQuery {
+            request_id: Some(&request_id_a),
+            trace_id: None,
+            limit: 50,
+        },
+        RequestId::generate(),
+    )
+    .await
+    .expect_err("no grant on team A");
+    assert_eq!(err.code, ErrorCode::Forbidden);
+}

--- a/crates/fp-core/tests/ai_trace_service.rs
+++ b/crates/fp-core/tests/ai_trace_service.rs
@@ -55,6 +55,49 @@ async fn principal_ctx(pool: &PgPool, subject: &str) -> PrincipalCtx {
     }
 }
 
+async fn ai_usage_writer_ctx(
+    pool: &PgPool,
+    org_id: fp_domain::OrgId,
+    team_id: fp_domain::TeamId,
+) -> PrincipalCtx {
+    let subject = unique("sub-ai-retention-writer");
+    let user = identity::upsert_user_by_subject(pool, &subject, "writer@a.test", "Writer")
+        .await
+        .expect("writer");
+    identity::add_org_membership(pool, user, org_id, OrgRole::Member)
+        .await
+        .expect("member");
+    identity::add_grant(
+        pool,
+        user,
+        org_id,
+        team_id,
+        Resource::AiUsage,
+        Action::Update,
+        None,
+    )
+    .await
+    .expect("grant ai usage update");
+    principal_ctx(pool, &subject).await
+}
+
+async fn ai_retention_success_audit_count(
+    pool: &PgPool,
+    team_id: fp_domain::TeamId,
+    request_id: RequestId,
+) -> i64 {
+    sqlx::query_scalar(
+        "SELECT count(*) FROM audit_log \
+         WHERE team_id = $1 AND request_id = $2 \
+           AND action = 'ai_retention.set' AND outcome = 'success'",
+    )
+    .bind(team_id.as_uuid())
+    .bind(request_id.as_uuid())
+    .fetch_one(pool)
+    .await
+    .expect("audit count")
+}
+
 /// Seed one trace row for `team_id` and return its request_id.
 async fn seed_trace_row(pool: &PgPool, team_id: fp_domain::TeamId) -> String {
     let request_id = uuid::Uuid::now_v7().to_string();
@@ -79,6 +122,203 @@ async fn seed_trace_row(pool: &PgPool, team_id: fp_domain::TeamId) -> String {
     .await
     .expect("seed trace row");
     request_id
+}
+
+#[tokio::test]
+async fn retention_set_writes_policy_and_success_audit_in_one_service_mutation() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+
+    let org = identity::create_org(&pool, &unique("org-retention"), "")
+        .await
+        .expect("org");
+    let team = identity::create_team(&pool, org.id, &unique("team-retention"), "")
+        .await
+        .expect("team");
+    let team_ref = identity::resolve_team_ref(&pool, team.id)
+        .await
+        .expect("q")
+        .expect("team ref");
+    let writer_ctx = ai_usage_writer_ctx(&pool, org.id, team.id).await;
+    let request_id = RequestId::generate();
+
+    let policy = fp_core::services::ai::set_retention_policy(
+        &pool,
+        &writer_ctx,
+        team_ref,
+        10,
+        None,
+        request_id,
+    )
+    .await
+    .expect("retention set");
+
+    assert_eq!(policy.trace_ttl_days, 10);
+    assert_eq!(policy.version, 1);
+    assert_eq!(
+        ai_retention_success_audit_count(&pool, team.id, request_id).await,
+        1,
+        "successful mutation records exactly one success audit row"
+    );
+    assert!(
+        ai_trace::get_retention_policy(&pool, team.id)
+            .await
+            .expect("get policy")
+            .is_some(),
+        "policy write is committed with the success audit"
+    );
+}
+
+#[tokio::test]
+async fn retention_set_requires_ai_usage_update_before_storage_mutation() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+
+    let org = identity::create_org(&pool, &unique("org-retention-authz"), "")
+        .await
+        .expect("org");
+    let team = identity::create_team(&pool, org.id, &unique("team-retention-authz"), "")
+        .await
+        .expect("team");
+    let team_ref = identity::resolve_team_ref(&pool, team.id)
+        .await
+        .expect("q")
+        .expect("team ref");
+    let subject = unique("sub-ai-retention-reader");
+    let user = identity::upsert_user_by_subject(&pool, &subject, "reader@a.test", "Reader")
+        .await
+        .expect("reader");
+    identity::add_org_membership(&pool, user, org.id, OrgRole::Member)
+        .await
+        .expect("member");
+    let ctx = principal_ctx(&pool, &subject).await;
+    let request_id = RequestId::generate();
+
+    let err =
+        fp_core::services::ai::set_retention_policy(&pool, &ctx, team_ref, 10, None, request_id)
+            .await
+            .expect_err("missing AiUsage Update grant denies");
+
+    assert_eq!(err.code, ErrorCode::Forbidden);
+    assert!(
+        ai_trace::get_retention_policy(&pool, team.id)
+            .await
+            .expect("get policy")
+            .is_none(),
+        "authorization denial must happen before storage mutation"
+    );
+}
+
+#[tokio::test]
+async fn retention_set_validates_ttl_before_storage_mutation_and_success_audit() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+
+    let org = identity::create_org(&pool, &unique("org-retention-ttl"), "")
+        .await
+        .expect("org");
+    let team = identity::create_team(&pool, org.id, &unique("team-retention-ttl"), "")
+        .await
+        .expect("team");
+    let team_ref = identity::resolve_team_ref(&pool, team.id)
+        .await
+        .expect("q")
+        .expect("team ref");
+    let writer_ctx = ai_usage_writer_ctx(&pool, org.id, team.id).await;
+    let request_id = RequestId::generate();
+
+    let err = fp_core::services::ai::set_retention_policy(
+        &pool,
+        &writer_ctx,
+        team_ref,
+        0,
+        None,
+        request_id,
+    )
+    .await
+    .expect_err("invalid TTL fails");
+
+    assert_eq!(err.code, ErrorCode::ValidationFailed);
+    assert!(
+        ai_trace::get_retention_policy(&pool, team.id)
+            .await
+            .expect("get policy")
+            .is_none(),
+        "TTL validation must happen before storage mutation"
+    );
+    assert_eq!(
+        ai_retention_success_audit_count(&pool, team.id, request_id).await,
+        0,
+        "validation failure must not record ai_retention.set success audit"
+    );
+}
+
+#[tokio::test]
+async fn retention_set_stale_revision_leaves_policy_and_records_no_success_audit() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+
+    let org = identity::create_org(&pool, &unique("org-retention-stale"), "")
+        .await
+        .expect("org");
+    let team = identity::create_team(&pool, org.id, &unique("team-retention-stale"), "")
+        .await
+        .expect("team");
+    let team_ref = identity::resolve_team_ref(&pool, team.id)
+        .await
+        .expect("q")
+        .expect("team ref");
+    let writer_ctx = ai_usage_writer_ctx(&pool, org.id, team.id).await;
+    let created = fp_core::services::ai::set_retention_policy(
+        &pool,
+        &writer_ctx,
+        team_ref,
+        10,
+        None,
+        RequestId::generate(),
+    )
+    .await
+    .expect("create");
+    let replaced = fp_core::services::ai::set_retention_policy(
+        &pool,
+        &writer_ctx,
+        team_ref,
+        20,
+        Some(created.version),
+        RequestId::generate(),
+    )
+    .await
+    .expect("matching replace");
+    let stale_request_id = RequestId::generate();
+
+    let err = fp_core::services::ai::set_retention_policy(
+        &pool,
+        &writer_ctx,
+        team_ref,
+        30,
+        Some(created.version),
+        stale_request_id,
+    )
+    .await
+    .expect_err("stale revision fails");
+
+    assert_eq!(err.code, ErrorCode::RevisionMismatch);
+    let fetched = ai_trace::get_retention_policy(&pool, team.id)
+        .await
+        .expect("get policy")
+        .expect("policy");
+    assert_eq!(fetched.id, created.id);
+    assert_eq!(fetched.trace_ttl_days, 20);
+    assert_eq!(fetched.version, replaced.version);
+    assert_eq!(
+        ai_retention_success_audit_count(&pool, team.id, stale_request_id).await,
+        0,
+        "stale revision must not record ai_retention.set success audit"
+    );
 }
 
 #[tokio::test]

--- a/crates/fp-domain/src/ai.rs
+++ b/crates/fp-domain/src/ai.rs
@@ -21,6 +21,14 @@ pub const AI_MODEL_HEADER: &str = "x-flowplane-ai-model";
 pub const DEFAULT_AI_ROUTE_TIMEOUT_SECS: u32 = 120;
 pub const MAX_AI_REQUEST_BODY_BYTES: usize = 1024 * 1024;
 
+pub fn ai_error_envelope(code: &str, message: &str) -> String {
+    serde_json::json!({
+        "code": code,
+        "message": message,
+    })
+    .to_string()
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AiRoute {
     pub id: AiRouteId,
@@ -589,6 +597,16 @@ mod tests {
         assert!(validate_trace_ttl_days(0).is_err());
         assert!(validate_trace_ttl_days(-7).is_err());
         assert!(validate_trace_ttl_days(MAX_AI_TRACE_TTL_DAYS + 1).is_err());
+    }
+
+    #[test]
+    fn ai_error_envelope_round_trips_embedded_quotes() {
+        let message = r#"AI budget "hard-stop" exceeded for model "gpt-5""#;
+        let envelope = ai_error_envelope("flowplane_ai_budget_exceeded", message);
+
+        let parsed: serde_json::Value = serde_json::from_str(&envelope).expect("json envelope");
+        assert_eq!(parsed["code"], "flowplane_ai_budget_exceeded");
+        assert_eq!(parsed["message"], message);
     }
 
     #[test]

--- a/crates/fp-domain/src/ai.rs
+++ b/crates/fp-domain/src/ai.rs
@@ -210,6 +210,31 @@ pub struct AiTraceEvent {
     pub expires_at: DateTime<Utc>,
 }
 
+/// Per-team AI trace retention policy: the TTL stamped onto new `ai_trace_events` rows at
+/// insert time. At most one row per team; absence means the built-in 30-day default applies.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AiRetentionPolicy {
+    pub id: uuid::Uuid,
+    pub team_id: TeamId,
+    pub trace_ttl_days: i32,
+    pub version: i64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+pub const MAX_AI_TRACE_TTL_DAYS: i32 = 365;
+
+/// Bounds mirror `raw_observation_ttl_days` (1..=365): a zero/negative TTL would expire rows
+/// at insert, and an unbounded one defeats retention entirely.
+pub fn validate_trace_ttl_days(days: i32) -> DomainResult<()> {
+    if !(1..=MAX_AI_TRACE_TTL_DAYS).contains(&days) {
+        return Err(DomainError::validation(format!(
+            "trace_ttl_days must be between 1 and {MAX_AI_TRACE_TTL_DAYS}, got {days}"
+        )));
+    }
+    Ok(())
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct AiProviderSpec {
@@ -555,6 +580,16 @@ fn usage_from_sse_event(event: &str) -> Option<OpenAiTokenUsage> {
 #[allow(clippy::expect_used)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn trace_ttl_days_bounds_are_explicit() {
+        assert!(validate_trace_ttl_days(1).is_ok());
+        assert!(validate_trace_ttl_days(30).is_ok());
+        assert!(validate_trace_ttl_days(MAX_AI_TRACE_TTL_DAYS).is_ok());
+        assert!(validate_trace_ttl_days(0).is_err());
+        assert!(validate_trace_ttl_days(-7).is_err());
+        assert!(validate_trace_ttl_days(MAX_AI_TRACE_TTL_DAYS + 1).is_err());
+    }
 
     #[test]
     fn provider_spec_rejects_unsupported_kind_and_bad_url() {

--- a/crates/fp-domain/src/ai.rs
+++ b/crates/fp-domain/src/ai.rs
@@ -1,7 +1,7 @@
 //! AI gateway provider resources (S10).
 
 use crate::error::{DomainError, DomainResult};
-use crate::id::{AiBudgetId, AiProviderId, AiRouteId, RouteConfigId, SecretId, TeamId};
+use crate::id::{AiBudgetId, AiProviderId, AiRouteId, ListenerId, RouteConfigId, SecretId, TeamId};
 use crate::validate_name;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -180,6 +180,34 @@ pub struct AiUsageSummary {
     pub completion_tokens: u64,
     pub total_tokens: u64,
     pub event_count: u64,
+}
+
+/// One end-to-end trace row per AI data-plane request, keyed by the server-owned
+/// `x-request-id`. Hop detail is carried only in `hops` (a JSON array of
+/// `{hop, started_at, ended_at, outcome, origin, detail}` entries) — there is no
+/// relational hop projection, and by construction no prompt/completion/credential
+/// payload field exists anywhere in the row.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct AiTraceEvent {
+    #[schema(value_type = uuid::Uuid)]
+    pub id: uuid::Uuid,
+    #[schema(value_type = uuid::Uuid)]
+    pub team_id: TeamId,
+    pub request_id: String,
+    pub trace_id: Option<String>,
+    #[schema(value_type = uuid::Uuid)]
+    pub route_config_id: RouteConfigId,
+    #[schema(value_type = Option<uuid::Uuid>)]
+    pub listener_id: Option<ListenerId>,
+    #[schema(value_type = Option<uuid::Uuid>)]
+    pub provider_id: Option<AiProviderId>,
+    pub model: Option<String>,
+    pub status_code: Option<i32>,
+    pub failure_hop: Option<String>,
+    #[schema(value_type = Object)]
+    pub hops: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]

--- a/crates/fp-domain/src/lib.rs
+++ b/crates/fp-domain/src/lib.rs
@@ -22,10 +22,11 @@ pub mod secret;
 pub use ai::{
     openai_usage_from_json, prepare_openai_chat_request, rewrite_openai_chat_request_model,
     strip_synthetic_openai_usage_sse, validate_ai_budget_name, validate_ai_provider_name,
-    validate_ai_route_name, AiBudget, AiBudgetMode, AiBudgetSpec, AiProvider, AiProviderKind,
-    AiProviderSpec, AiRoute, AiRouteBackend, AiRouteMaterializedResources, AiRouteSpec,
-    AiRouteStatus, AiTraceEvent, AiUsageSummary, OpenAiChatRequest, OpenAiTokenUsage,
-    AI_MODEL_HEADER, DEFAULT_AI_ROUTE_TIMEOUT_SECS, MAX_AI_REQUEST_BODY_BYTES,
+    validate_ai_route_name, validate_trace_ttl_days, AiBudget, AiBudgetMode, AiBudgetSpec,
+    AiProvider, AiProviderKind, AiProviderSpec, AiRetentionPolicy, AiRoute, AiRouteBackend,
+    AiRouteMaterializedResources, AiRouteSpec, AiRouteStatus, AiTraceEvent, AiUsageSummary,
+    OpenAiChatRequest, OpenAiTokenUsage, AI_MODEL_HEADER, DEFAULT_AI_ROUTE_TIMEOUT_SECS,
+    MAX_AI_REQUEST_BODY_BYTES, MAX_AI_TRACE_TTL_DAYS,
 };
 pub use dataplane::{validate_spiffe_uri, Dataplane, ProxyCertificate, TeamStatsOverview};
 pub use discovery::{

--- a/crates/fp-domain/src/lib.rs
+++ b/crates/fp-domain/src/lib.rs
@@ -20,13 +20,13 @@ pub mod route_generation;
 pub mod secret;
 
 pub use ai::{
-    openai_usage_from_json, prepare_openai_chat_request, rewrite_openai_chat_request_model,
-    strip_synthetic_openai_usage_sse, validate_ai_budget_name, validate_ai_provider_name,
-    validate_ai_route_name, validate_trace_ttl_days, AiBudget, AiBudgetMode, AiBudgetSpec,
-    AiProvider, AiProviderKind, AiProviderSpec, AiRetentionPolicy, AiRoute, AiRouteBackend,
-    AiRouteMaterializedResources, AiRouteSpec, AiRouteStatus, AiTraceEvent, AiUsageSummary,
-    OpenAiChatRequest, OpenAiTokenUsage, AI_MODEL_HEADER, DEFAULT_AI_ROUTE_TIMEOUT_SECS,
-    MAX_AI_REQUEST_BODY_BYTES, MAX_AI_TRACE_TTL_DAYS,
+    ai_error_envelope, openai_usage_from_json, prepare_openai_chat_request,
+    rewrite_openai_chat_request_model, strip_synthetic_openai_usage_sse, validate_ai_budget_name,
+    validate_ai_provider_name, validate_ai_route_name, validate_trace_ttl_days, AiBudget,
+    AiBudgetMode, AiBudgetSpec, AiProvider, AiProviderKind, AiProviderSpec, AiRetentionPolicy,
+    AiRoute, AiRouteBackend, AiRouteMaterializedResources, AiRouteSpec, AiRouteStatus,
+    AiTraceEvent, AiUsageSummary, OpenAiChatRequest, OpenAiTokenUsage, AI_MODEL_HEADER,
+    DEFAULT_AI_ROUTE_TIMEOUT_SECS, MAX_AI_REQUEST_BODY_BYTES, MAX_AI_TRACE_TTL_DAYS,
 };
 pub use dataplane::{validate_spiffe_uri, Dataplane, ProxyCertificate, TeamStatsOverview};
 pub use discovery::{

--- a/crates/fp-domain/src/lib.rs
+++ b/crates/fp-domain/src/lib.rs
@@ -24,8 +24,8 @@ pub use ai::{
     strip_synthetic_openai_usage_sse, validate_ai_budget_name, validate_ai_provider_name,
     validate_ai_route_name, AiBudget, AiBudgetMode, AiBudgetSpec, AiProvider, AiProviderKind,
     AiProviderSpec, AiRoute, AiRouteBackend, AiRouteMaterializedResources, AiRouteSpec,
-    AiRouteStatus, AiUsageSummary, OpenAiChatRequest, OpenAiTokenUsage, AI_MODEL_HEADER,
-    DEFAULT_AI_ROUTE_TIMEOUT_SECS, MAX_AI_REQUEST_BODY_BYTES,
+    AiRouteStatus, AiTraceEvent, AiUsageSummary, OpenAiChatRequest, OpenAiTokenUsage,
+    AI_MODEL_HEADER, DEFAULT_AI_ROUTE_TIMEOUT_SECS, MAX_AI_REQUEST_BODY_BYTES,
 };
 pub use dataplane::{validate_spiffe_uri, Dataplane, ProxyCertificate, TeamStatsOverview};
 pub use discovery::{

--- a/crates/fp-storage/Cargo.toml
+++ b/crates/fp-storage/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
+chrono = { workspace = true }
 fp-domain = { workspace = true }
 metrics = { workspace = true }
 rustls = { workspace = true }

--- a/crates/fp-storage/migrations/0031_ai_trace_events.sql
+++ b/crates/fp-storage/migrations/0031_ai_trace_events.sql
@@ -1,0 +1,45 @@
+-- 0031: AI gateway end-to-end trace rows (feature ai-gateway-e2e-trace, slice s2).
+--
+-- One observational row per AI data-plane request, keyed (team_id, request_id) — the
+-- server-owned x-request-id pinned by slice s1. Hop detail lives only in the `hops`
+-- JSONB array (sole store, no relational projection). `expires_at` is stamped at
+-- insert from the team's ai_retention_policies row (30-day default when absent), so
+-- every row is retention-correct from day one; the sweep task arrives in slice s5.
+--
+-- No prompt/completion/body columns exist by construction (design AC 6): the schema
+-- cannot carry request or response payloads, and the credential hop records the auth
+-- header *name* plus an outcome enum only.
+
+CREATE TABLE ai_retention_policies (
+    id             UUID PRIMARY KEY,
+    team_id        UUID NOT NULL,
+    org_id         UUID NOT NULL,
+    trace_ttl_days INT NOT NULL CHECK (trace_ttl_days > 0),
+    version        BIGINT NOT NULL DEFAULT 1,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (team_id),
+    FOREIGN KEY (team_id, org_id) REFERENCES teams(id, org_id) ON DELETE CASCADE
+);
+
+CREATE TABLE ai_trace_events (
+    id              UUID PRIMARY KEY,
+    team_id         UUID NOT NULL,
+    request_id      TEXT NOT NULL,
+    trace_id        TEXT,
+    route_config_id UUID NOT NULL,
+    listener_id     UUID,
+    provider_id     UUID,
+    model           TEXT,
+    status_code     INT,
+    failure_hop     TEXT,
+    hops            JSONB NOT NULL DEFAULT '[]'::jsonb,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at      TIMESTAMPTZ NOT NULL,
+    FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE CASCADE
+);
+
+-- The upsert key: both ExtProc streams of one HTTP request merge into one row.
+CREATE UNIQUE INDEX uq_ai_trace_events_team_request ON ai_trace_events(team_id, request_id);
+CREATE INDEX idx_ai_trace_events_team_created ON ai_trace_events(team_id, created_at DESC);
+CREATE INDEX idx_ai_trace_events_expires ON ai_trace_events(expires_at);

--- a/crates/fp-storage/src/repos/ai.rs
+++ b/crates/fp-storage/src/repos/ai.rs
@@ -175,6 +175,52 @@ pub async fn exhausted_enforcing_budget(
     .map_err(|e| DomainError::internal(format!("check AI budget capacity: {e}")))
 }
 
+/// One matching shadow budget's current standing, read for trace annotation only.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShadowBudgetEvaluation {
+    pub name: String,
+    pub used_units: i64,
+    pub limit_units: i64,
+}
+
+/// Read-only shadow-budget evaluation for the trace `budget` hop (design AC 3): returns
+/// every `mode='shadow'` budget matching this (team, route config, provider) scope with
+/// its current-window usage, so capture can record `would_reject` without ever gating the
+/// request. Never writes: counters are settled only by usage settlement.
+pub async fn evaluate_shadow_budgets(
+    pool: &PgPool,
+    team_id: TeamId,
+    route_config_id: RouteConfigId,
+    provider_id: AiProviderId,
+) -> DomainResult<Vec<ShadowBudgetEvaluation>> {
+    let rows = sqlx::query(
+        "SELECT b.name, COALESCE(c.used_units, 0) AS used_units, b.limit_units \
+         FROM ai_budgets b \
+         LEFT JOIN ai_budget_counters c \
+           ON c.budget_id = b.id \
+          AND c.window_start = to_timestamp(floor(extract(epoch FROM now()) / b.window_seconds) * b.window_seconds) \
+         WHERE b.team_id = $1 \
+           AND b.mode = 'shadow' \
+           AND (b.provider_id IS NULL OR b.provider_id = $2) \
+           AND (b.route_config_id IS NULL OR b.route_config_id = $3) \
+         ORDER BY b.name",
+    )
+    .bind(team_id.as_uuid())
+    .bind(provider_id.as_uuid())
+    .bind(route_config_id.as_uuid())
+    .fetch_all(pool)
+    .await
+    .map_err(|e| DomainError::internal(format!("evaluate AI shadow budgets: {e}")))?;
+    Ok(rows
+        .iter()
+        .map(|row| ShadowBudgetEvaluation {
+            name: row.get("name"),
+            used_units: row.get("used_units"),
+            limit_units: row.get("limit_units"),
+        })
+        .collect())
+}
+
 async fn insert_usage_event_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     event: &AiUsageEventInsert,

--- a/crates/fp-storage/src/repos/ai_trace.rs
+++ b/crates/fp-storage/src/repos/ai_trace.rs
@@ -12,13 +12,16 @@
 //! falling back to [`DEFAULT_AI_TRACE_TTL_DAYS`] — the same shape as
 //! `raw_observation_ttl_days` in `api_lifecycle.rs`.
 
+use chrono::Duration;
+use fp_domain::authz::TeamRef;
 use fp_domain::{
-    AiProviderId, AiTraceEvent, DomainError, DomainResult, ListenerId, RouteConfigId, TeamId,
+    AiProviderId, AiRetentionPolicy, AiTraceEvent, DomainError, DomainResult, ListenerId,
+    RouteConfigId, TeamId,
 };
 use serde_json::Value;
 use sqlx::postgres::PgRow;
 use sqlx::types::chrono::{DateTime, Utc};
-use sqlx::{PgPool, Row};
+use sqlx::{PgPool, Postgres, Row, Transaction};
 use uuid::Uuid;
 
 pub const DEFAULT_AI_TRACE_TTL_DAYS: i32 = 30;
@@ -88,18 +91,21 @@ pub async fn upsert_trace_event(pool: &PgPool, event: &AiTraceEventUpsert) -> Do
             .await
             .map_err(|e| DomainError::internal(format!("resolve AI trace ttl: {e}")))?;
     let ttl_days = resolve_ttl_days(ttl_days);
-    // created_at and expires_at come from the same now() so the TTL arithmetic is exact.
+    // created_at and expires_at derive from the same instant so the TTL arithmetic is exact.
+    let created_at = Utc::now();
+    let expires_at = trace_expires_at(created_at, ttl_days);
     sqlx::query(
         "INSERT INTO ai_trace_events \
          (id, team_id, request_id, route_config_id, hops, created_at, expires_at) \
-         VALUES ($1, $2, $3, $4, '[]'::jsonb, now(), now() + make_interval(days => $5)) \
+         VALUES ($1, $2, $3, $4, '[]'::jsonb, $5, $6) \
          ON CONFLICT (team_id, request_id) DO NOTHING",
     )
     .bind(Uuid::now_v7())
     .bind(event.team_id.as_uuid())
     .bind(&event.request_id)
     .bind(event.route_config_id.as_uuid())
-    .bind(ttl_days)
+    .bind(created_at)
+    .bind(expires_at)
     .execute(&mut *tx)
     .await
     .map_err(|e| DomainError::internal(format!("insert AI trace event: {e}")))?;
@@ -169,6 +175,83 @@ pub async fn list_trace_events(
 /// policy row exists, the 30-day built-in default otherwise.
 fn resolve_ttl_days(policy_ttl_days: Option<i32>) -> i32 {
     policy_ttl_days.unwrap_or(DEFAULT_AI_TRACE_TTL_DAYS)
+}
+
+/// The insert-time expiry stamp: exactly `created_at + ttl_days` whole days. This is the
+/// value [`upsert_trace_event`] binds, so a row's retention is fixed by the policy in force
+/// when it was written; a later policy change affects only new rows.
+fn trace_expires_at(created_at: DateTime<Utc>, ttl_days: i32) -> DateTime<Utc> {
+    created_at + Duration::days(i64::from(ttl_days))
+}
+
+const RETENTION_COLUMNS: &str = "id, team_id, trace_ttl_days, version, created_at, updated_at";
+
+fn retention_policy_from_row(row: &PgRow) -> AiRetentionPolicy {
+    AiRetentionPolicy {
+        id: row.get("id"),
+        team_id: TeamId::from(row.get::<Uuid, _>("team_id")),
+        trace_ttl_days: row.get("trace_ttl_days"),
+        version: row.get("version"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    }
+}
+
+/// The team's retention policy row, if one exists. `None` means the built-in
+/// [`DEFAULT_AI_TRACE_TTL_DAYS`] applies at insert time.
+pub async fn get_retention_policy(
+    pool: &PgPool,
+    team_id: TeamId,
+) -> DomainResult<Option<AiRetentionPolicy>> {
+    let row = sqlx::query(&format!(
+        "SELECT {RETENTION_COLUMNS} FROM ai_retention_policies WHERE team_id = $1"
+    ))
+    .bind(team_id.as_uuid())
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| DomainError::internal(format!("get AI retention policy: {e}")))?;
+    Ok(row.as_ref().map(retention_policy_from_row))
+}
+
+/// Create-or-replace the team's single retention policy row (the PUT semantics of the
+/// retention surface). Runs inside the caller's transaction so the audit row commits with it;
+/// the version bumps on every replace for change visibility.
+pub async fn set_retention_policy(
+    tx: &mut Transaction<'_, Postgres>,
+    team: TeamRef,
+    trace_ttl_days: i32,
+) -> DomainResult<AiRetentionPolicy> {
+    let row = sqlx::query(&format!(
+        "INSERT INTO ai_retention_policies (id, team_id, org_id, trace_ttl_days) \
+         VALUES ($1, $2, $3, $4) \
+         ON CONFLICT (team_id) DO UPDATE \
+           SET trace_ttl_days = EXCLUDED.trace_ttl_days, \
+               version = ai_retention_policies.version + 1, \
+               updated_at = now() \
+         RETURNING {RETENTION_COLUMNS}"
+    ))
+    .bind(Uuid::now_v7())
+    .bind(team.id.as_uuid())
+    .bind(team.org_id.as_uuid())
+    .bind(trace_ttl_days)
+    .fetch_one(&mut **tx)
+    .await
+    .map_err(|e| DomainError::internal(format!("set AI retention policy: {e}")))?;
+    Ok(retention_policy_from_row(&row))
+}
+
+/// The expiry sweep: delete every trace row whose `expires_at <= as_of`, across all teams,
+/// returning the deleted count. Team scoping is inherent, not filtered here: each row's
+/// `expires_at` was stamped at insert from its own team's policy (`trace_expires_at`), so
+/// the sweep can only remove a team's rows once *that team's* TTL has elapsed — unexpired
+/// rows and other teams' data are untouched (proven in `tests/ai_trace.rs`).
+pub async fn delete_expired_trace_events(pool: &PgPool, as_of: DateTime<Utc>) -> DomainResult<u64> {
+    let result = sqlx::query("DELETE FROM ai_trace_events WHERE expires_at <= $1")
+        .bind(as_of)
+        .execute(pool)
+        .await
+        .map_err(|e| DomainError::internal(format!("delete expired AI trace events: {e}")))?;
+    Ok(result.rows_affected())
 }
 
 /// Union two hop arrays by hop name. On a name conflict an `upstream`-origin entry beats a
@@ -293,6 +376,49 @@ mod tests {
         assert_eq!(resolve_ttl_days(None), DEFAULT_AI_TRACE_TTL_DAYS);
         assert_eq!(resolve_ttl_days(None), 30);
         assert_eq!(resolve_ttl_days(Some(7)), 7);
+    }
+
+    #[test]
+    fn expires_at_arithmetic_from_policy_vs_default_ttl() {
+        let created = DateTime::parse_from_rfc3339("2026-07-04T12:34:56.789Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        // Team policy of N days: expires_at is exactly created_at + N days.
+        let with_policy = trace_expires_at(created, resolve_ttl_days(Some(7)));
+        assert_eq!(with_policy - created, Duration::days(7));
+        // No policy row: the 30-day default applies.
+        let with_default = trace_expires_at(created, resolve_ttl_days(None));
+        assert_eq!(with_default - created, Duration::days(30));
+        assert_eq!(
+            with_default,
+            DateTime::parse_from_rfc3339("2026-08-03T12:34:56.789Z").unwrap()
+        );
+        // Sub-second precision of created_at is preserved, not truncated by the arithmetic.
+        assert_eq!(
+            with_policy.timestamp_subsec_micros(),
+            created.timestamp_subsec_micros()
+        );
+    }
+
+    #[test]
+    fn sweep_deletion_boundary_keeps_unexpired_rows() {
+        // The sweep SQL (`delete_expired_trace_events`) deletes rows with expires_at <= as_of.
+        // Boundary semantics of that predicate, over rows stamped by trace_expires_at: a row
+        // is kept strictly until its expiry instant has been reached. Team scoping (a sweep
+        // never touching another team's unexpired rows) is proven against real PostgreSQL in
+        // tests/ai_trace.rs.
+        let created = DateTime::parse_from_rfc3339("2026-07-04T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let expires = trace_expires_at(created, 7);
+        let swept = |as_of: DateTime<Utc>| expires <= as_of;
+        assert!(!swept(created), "fresh row is never swept");
+        assert!(
+            !swept(expires - Duration::microseconds(1)),
+            "row is kept until the last instant before expiry"
+        );
+        assert!(swept(expires), "expiry instant itself is inclusive (<=)");
+        assert!(swept(expires + Duration::days(1)));
     }
 
     #[test]

--- a/crates/fp-storage/src/repos/ai_trace.rs
+++ b/crates/fp-storage/src/repos/ai_trace.rs
@@ -304,5 +304,17 @@ mod tests {
         ]);
         let merged = merge_hops(&json!([]), &hops);
         assert_eq!(derive_failure_hop(&merged).as_deref(), Some("budget"));
+
+        // Failure classes from slice s3: the first failing hop in timeline order wins even
+        // when a later hop also failed (credential failure before a local-503 upstream gap).
+        let hops = json!([
+            {"hop": "route_match", "started_at": "2026-07-04T00:00:00Z", "ended_at": "2026-07-04T00:00:00Z", "outcome": "matched", "origin": "listener", "failed": false, "detail": {}},
+            {"hop": "credential_injection", "started_at": "2026-07-04T00:00:01Z", "ended_at": "2026-07-04T00:00:01Z", "outcome": "secret_missing", "origin": "listener", "failed": true, "detail": {}},
+            {"hop": "upstream", "started_at": "2026-07-04T00:00:02Z", "ended_at": "2026-07-04T00:00:02Z", "outcome": "no_upstream_connection", "origin": "listener", "failed": true, "detail": {}},
+        ]);
+        assert_eq!(
+            derive_failure_hop(&merge_hops(&json!([]), &hops)).as_deref(),
+            Some("credential_injection")
+        );
     }
 }

--- a/crates/fp-storage/src/repos/ai_trace.rs
+++ b/crates/fp-storage/src/repos/ai_trace.rs
@@ -15,8 +15,8 @@
 use chrono::Duration;
 use fp_domain::authz::TeamRef;
 use fp_domain::{
-    AiProviderId, AiRetentionPolicy, AiTraceEvent, DomainError, DomainResult, ListenerId,
-    RouteConfigId, TeamId,
+    AiProviderId, AiRetentionPolicy, AiTraceEvent, DomainError, DomainResult, ErrorCode,
+    ListenerId, RouteConfigId, TeamId,
 };
 use serde_json::Value;
 use sqlx::postgres::PgRow;
@@ -238,7 +238,29 @@ pub async fn set_retention_policy(
     tx: &mut Transaction<'_, Postgres>,
     team: TeamRef,
     trace_ttl_days: i32,
+    expected_version: Option<i64>,
 ) -> DomainResult<AiRetentionPolicy> {
+    if let Some(expected_version) = expected_version {
+        let row = sqlx::query(&format!(
+            "UPDATE ai_retention_policies \
+             SET trace_ttl_days = $3, \
+                 version = version + 1, \
+                 updated_at = now() \
+             WHERE team_id = $1 AND version = $2 \
+             RETURNING {RETENTION_COLUMNS}"
+        ))
+        .bind(team.id.as_uuid())
+        .bind(expected_version)
+        .bind(trace_ttl_days)
+        .fetch_optional(&mut **tx)
+        .await
+        .map_err(|e| DomainError::internal(format!("set AI retention policy: {e}")))?;
+        return match row {
+            Some(row) => Ok(retention_policy_from_row(&row)),
+            None => retention_revision_mismatch(tx, team.id, expected_version).await,
+        };
+    }
+
     let row = sqlx::query(&format!(
         "INSERT INTO ai_retention_policies (id, team_id, org_id, trace_ttl_days) \
          VALUES ($1, $2, $3, $4) \
@@ -256,6 +278,35 @@ pub async fn set_retention_policy(
     .await
     .map_err(|e| DomainError::internal(format!("set AI retention policy: {e}")))?;
     Ok(retention_policy_from_row(&row))
+}
+
+async fn retention_revision_mismatch<T>(
+    tx: &mut Transaction<'_, Postgres>,
+    team_id: TeamId,
+    expected_version: i64,
+) -> DomainResult<T> {
+    let current: Option<i64> =
+        sqlx::query_scalar("SELECT version FROM ai_retention_policies WHERE team_id = $1")
+            .bind(team_id.as_uuid())
+            .fetch_optional(&mut **tx)
+            .await
+            .map_err(|e| DomainError::internal(format!("set AI retention policy: recheck: {e}")))?;
+    Err(match current {
+        Some(version) => DomainError::new(
+            ErrorCode::RevisionMismatch,
+            format!(
+                "AI retention policy is at revision {version}, you supplied {expected_version}"
+            ),
+        )
+        .with_hint("re-read the retention policy and retry with the current revision"),
+        None => DomainError::new(
+            ErrorCode::RevisionMismatch,
+            format!(
+                "AI retention policy has no stored revision yet, you supplied {expected_version}"
+            ),
+        )
+        .with_hint("create the retention policy without a revision precondition"),
+    })
 }
 
 /// The expiry sweep: delete every trace row whose `expires_at <= as_of`, across all teams,

--- a/crates/fp-storage/src/repos/ai_trace.rs
+++ b/crates/fp-storage/src/repos/ai_trace.rs
@@ -47,6 +47,17 @@ pub struct AiTraceEventUpsert {
     pub hops: Value,
 }
 
+/// One stream's merge outcome: the row as it stands after this write, plus the hops that
+/// were already stored before it. The pair is captured atomically under the upsert's row
+/// lock, so the capture layer can detect the exact write that completed the per-request
+/// timeline — its span emission must fire exactly once per request, whichever stream's
+/// write lands last.
+#[derive(Debug, Clone)]
+pub struct AiTraceUpsertOutcome {
+    pub previous_hops: Value,
+    pub event: AiTraceEvent,
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 pub struct AiTraceQuery<'a> {
     pub request_id: Option<&'a str>,
@@ -79,7 +90,10 @@ fn trace_event_from_row(row: &PgRow) -> AiTraceEvent {
 /// Insert-or-merge one stream's trace contribution. The whole operation runs in one
 /// transaction with a row lock, so concurrent listener/upstream writes serialize and
 /// converge to the same row regardless of arrival order.
-pub async fn upsert_trace_event(pool: &PgPool, event: &AiTraceEventUpsert) -> DomainResult<()> {
+pub async fn upsert_trace_event(
+    pool: &PgPool,
+    event: &AiTraceEventUpsert,
+) -> DomainResult<AiTraceUpsertOutcome> {
     let mut tx = pool
         .begin()
         .await
@@ -119,7 +133,7 @@ pub async fn upsert_trace_event(pool: &PgPool, event: &AiTraceEventUpsert) -> Do
     .map_err(|e| DomainError::internal(format!("lock AI trace event: {e}")))?;
     let merged = merge_hops(&existing, &event.hops);
     let failure_hop = derive_failure_hop(&merged);
-    sqlx::query(
+    let row = sqlx::query(&format!(
         "UPDATE ai_trace_events SET \
            trace_id = COALESCE(trace_id, $3), \
            listener_id = COALESCE(listener_id, $4), \
@@ -128,8 +142,9 @@ pub async fn upsert_trace_event(pool: &PgPool, event: &AiTraceEventUpsert) -> Do
            status_code = COALESCE(status_code, $7), \
            hops = $8, \
            failure_hop = $9 \
-         WHERE team_id = $1 AND request_id = $2",
-    )
+         WHERE team_id = $1 AND request_id = $2 \
+         RETURNING {TRACE_COLUMNS}"
+    ))
     .bind(event.team_id.as_uuid())
     .bind(&event.request_id)
     .bind(&event.trace_id)
@@ -139,13 +154,16 @@ pub async fn upsert_trace_event(pool: &PgPool, event: &AiTraceEventUpsert) -> Do
     .bind(event.status_code)
     .bind(&merged)
     .bind(failure_hop)
-    .execute(&mut *tx)
+    .fetch_one(&mut *tx)
     .await
     .map_err(|e| DomainError::internal(format!("merge AI trace event: {e}")))?;
     tx.commit()
         .await
         .map_err(|e| DomainError::internal(format!("upsert AI trace event: commit: {e}")))?;
-    Ok(())
+    Ok(AiTraceUpsertOutcome {
+        previous_hops: existing,
+        event: trace_event_from_row(&row),
+    })
 }
 
 pub async fn list_trace_events(

--- a/crates/fp-storage/src/repos/ai_trace.rs
+++ b/crates/fp-storage/src/repos/ai_trace.rs
@@ -1,0 +1,308 @@
+//! AI gateway trace-event repository.
+//!
+//! Observation-write seam: rows are written by the xDS ExtProc capture path (the same
+//! exception class as `ai_usage_events`), best-effort, never on a product-mutation path.
+//! One row per AI data-plane request, keyed `(team_id, request_id)`; the listener-side
+//! and upstream-side ExtProc streams of one request each upsert their own hops and the
+//! merge is order-independent: hop entries are unioned by hop name (an `upstream`-origin
+//! entry wins over a `listener`-origin one for the same name), columns fill NULLs only,
+//! and `failure_hop` is re-derived from the merged timeline on every write.
+//!
+//! `expires_at` is resolved at insert from the team's `ai_retention_policies` row,
+//! falling back to [`DEFAULT_AI_TRACE_TTL_DAYS`] — the same shape as
+//! `raw_observation_ttl_days` in `api_lifecycle.rs`.
+
+use fp_domain::{
+    AiProviderId, AiTraceEvent, DomainError, DomainResult, ListenerId, RouteConfigId, TeamId,
+};
+use serde_json::Value;
+use sqlx::postgres::PgRow;
+use sqlx::types::chrono::{DateTime, Utc};
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+pub const DEFAULT_AI_TRACE_TTL_DAYS: i32 = 30;
+
+const TRACE_COLUMNS: &str = "id, team_id, request_id, trace_id, route_config_id, listener_id, \
+                             provider_id, model, status_code, failure_hop, hops, created_at, \
+                             expires_at";
+
+/// One ExtProc stream's contribution to a trace row. Column ownership is enforced by the
+/// capture layer (listener stream: `trace_id`, `listener_id`, `model`, `status_code`;
+/// upstream stream: `provider_id`) so the NULL-filling column merge is order-independent.
+#[derive(Debug, Clone)]
+pub struct AiTraceEventUpsert {
+    pub team_id: TeamId,
+    pub request_id: String,
+    pub trace_id: Option<String>,
+    pub route_config_id: RouteConfigId,
+    pub listener_id: Option<ListenerId>,
+    pub provider_id: Option<AiProviderId>,
+    pub model: Option<String>,
+    pub status_code: Option<i32>,
+    /// JSON array of `{hop, started_at, ended_at, outcome, origin, failed, detail}` entries.
+    pub hops: Value,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AiTraceQuery<'a> {
+    pub request_id: Option<&'a str>,
+    pub trace_id: Option<&'a str>,
+    pub limit: i64,
+}
+
+fn trace_event_from_row(row: &PgRow) -> AiTraceEvent {
+    AiTraceEvent {
+        id: row.get("id"),
+        team_id: TeamId::from(row.get::<Uuid, _>("team_id")),
+        request_id: row.get("request_id"),
+        trace_id: row.get("trace_id"),
+        route_config_id: RouteConfigId::from(row.get::<Uuid, _>("route_config_id")),
+        listener_id: row
+            .get::<Option<Uuid>, _>("listener_id")
+            .map(ListenerId::from),
+        provider_id: row
+            .get::<Option<Uuid>, _>("provider_id")
+            .map(AiProviderId::from),
+        model: row.get("model"),
+        status_code: row.get("status_code"),
+        failure_hop: row.get("failure_hop"),
+        hops: row.get("hops"),
+        created_at: row.get("created_at"),
+        expires_at: row.get("expires_at"),
+    }
+}
+
+/// Insert-or-merge one stream's trace contribution. The whole operation runs in one
+/// transaction with a row lock, so concurrent listener/upstream writes serialize and
+/// converge to the same row regardless of arrival order.
+pub async fn upsert_trace_event(pool: &PgPool, event: &AiTraceEventUpsert) -> DomainResult<()> {
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| DomainError::internal(format!("upsert AI trace event: begin: {e}")))?;
+    let ttl_days: Option<i32> =
+        sqlx::query_scalar("SELECT trace_ttl_days FROM ai_retention_policies WHERE team_id = $1")
+            .bind(event.team_id.as_uuid())
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| DomainError::internal(format!("resolve AI trace ttl: {e}")))?;
+    let ttl_days = resolve_ttl_days(ttl_days);
+    // created_at and expires_at come from the same now() so the TTL arithmetic is exact.
+    sqlx::query(
+        "INSERT INTO ai_trace_events \
+         (id, team_id, request_id, route_config_id, hops, created_at, expires_at) \
+         VALUES ($1, $2, $3, $4, '[]'::jsonb, now(), now() + make_interval(days => $5)) \
+         ON CONFLICT (team_id, request_id) DO NOTHING",
+    )
+    .bind(Uuid::now_v7())
+    .bind(event.team_id.as_uuid())
+    .bind(&event.request_id)
+    .bind(event.route_config_id.as_uuid())
+    .bind(ttl_days)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| DomainError::internal(format!("insert AI trace event: {e}")))?;
+    let existing: Value = sqlx::query_scalar(
+        "SELECT hops FROM ai_trace_events WHERE team_id = $1 AND request_id = $2 FOR UPDATE",
+    )
+    .bind(event.team_id.as_uuid())
+    .bind(&event.request_id)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| DomainError::internal(format!("lock AI trace event: {e}")))?;
+    let merged = merge_hops(&existing, &event.hops);
+    let failure_hop = derive_failure_hop(&merged);
+    sqlx::query(
+        "UPDATE ai_trace_events SET \
+           trace_id = COALESCE(trace_id, $3), \
+           listener_id = COALESCE(listener_id, $4), \
+           provider_id = COALESCE(provider_id, $5), \
+           model = COALESCE(model, $6), \
+           status_code = COALESCE(status_code, $7), \
+           hops = $8, \
+           failure_hop = $9 \
+         WHERE team_id = $1 AND request_id = $2",
+    )
+    .bind(event.team_id.as_uuid())
+    .bind(&event.request_id)
+    .bind(&event.trace_id)
+    .bind(event.listener_id.map(|id| id.as_uuid()))
+    .bind(event.provider_id.map(|id| id.as_uuid()))
+    .bind(&event.model)
+    .bind(event.status_code)
+    .bind(&merged)
+    .bind(failure_hop)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| DomainError::internal(format!("merge AI trace event: {e}")))?;
+    tx.commit()
+        .await
+        .map_err(|e| DomainError::internal(format!("upsert AI trace event: commit: {e}")))?;
+    Ok(())
+}
+
+pub async fn list_trace_events(
+    pool: &PgPool,
+    team_id: TeamId,
+    query: AiTraceQuery<'_>,
+) -> DomainResult<Vec<AiTraceEvent>> {
+    let rows = sqlx::query(&format!(
+        "SELECT {TRACE_COLUMNS} FROM ai_trace_events \
+         WHERE team_id = $1 \
+           AND ($2::TEXT IS NULL OR request_id = $2) \
+           AND ($3::TEXT IS NULL OR trace_id = $3) \
+         ORDER BY created_at DESC \
+         LIMIT $4"
+    ))
+    .bind(team_id.as_uuid())
+    .bind(query.request_id)
+    .bind(query.trace_id)
+    .bind(query.limit.clamp(1, 500))
+    .fetch_all(pool)
+    .await
+    .map_err(|e| DomainError::internal(format!("list AI trace events: {e}")))?;
+    Ok(rows.iter().map(trace_event_from_row).collect())
+}
+
+/// Insert-time TTL resolution: the team's `ai_retention_policies.trace_ttl_days` when a
+/// policy row exists, the 30-day built-in default otherwise.
+fn resolve_ttl_days(policy_ttl_days: Option<i32>) -> i32 {
+    policy_ttl_days.unwrap_or(DEFAULT_AI_TRACE_TTL_DAYS)
+}
+
+/// Union two hop arrays by hop name. On a name conflict an `upstream`-origin entry beats a
+/// `listener`-origin one; same-origin conflicts keep the already-stored entry. The result is
+/// sorted by (started_at, hop) so the merged array is identical whichever stream wrote first.
+fn merge_hops(existing: &Value, incoming: &Value) -> Value {
+    let empty = Vec::new();
+    let existing_hops = existing.as_array().unwrap_or(&empty);
+    let incoming_hops = incoming.as_array().unwrap_or(&empty);
+    let mut merged: Vec<Value> = existing_hops.clone();
+    for hop in incoming_hops {
+        let name = hop_name(hop);
+        match merged.iter_mut().find(|entry| hop_name(entry) == name) {
+            Some(entry) => {
+                if hop_origin(hop) == "upstream" && hop_origin(entry) != "upstream" {
+                    *entry = hop.clone();
+                }
+            }
+            None => merged.push(hop.clone()),
+        }
+    }
+    merged.sort_by(|a, b| {
+        hop_started_at(a)
+            .cmp(&hop_started_at(b))
+            .then_with(|| hop_name(a).cmp(hop_name(b)))
+    });
+    Value::Array(merged)
+}
+
+/// The first hop (in timeline order) flagged as failed, if any.
+fn derive_failure_hop(merged: &Value) -> Option<String> {
+    merged.as_array()?.iter().find_map(|hop| {
+        hop.get("failed")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+            .then(|| hop_name(hop).to_string())
+    })
+}
+
+fn hop_name(hop: &Value) -> &str {
+    hop.get("hop").and_then(Value::as_str).unwrap_or("")
+}
+
+fn hop_origin(hop: &Value) -> &str {
+    hop.get("origin").and_then(Value::as_str).unwrap_or("")
+}
+
+fn hop_started_at(hop: &Value) -> DateTime<Utc> {
+    hop.get("started_at")
+        .and_then(Value::as_str)
+        .and_then(|raw| DateTime::parse_from_rfc3339(raw).ok())
+        .map(|parsed| parsed.with_timezone(&Utc))
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn listener_hops() -> Value {
+        json!([
+            {"hop": "route_match", "started_at": "2026-07-04T00:00:00.100Z", "ended_at": "2026-07-04T00:00:00.200Z", "outcome": "matched", "origin": "listener", "failed": false, "detail": {}},
+            {"hop": "auth", "started_at": "2026-07-04T00:00:00.200Z", "ended_at": "2026-07-04T00:00:00.200Z", "outcome": "not_configured", "origin": "listener", "failed": false, "detail": {}},
+            {"hop": "budget", "started_at": "2026-07-04T00:00:00.210Z", "ended_at": "2026-07-04T00:00:00.230Z", "outcome": "allowed", "origin": "listener", "failed": false, "detail": {}},
+        ])
+    }
+
+    fn upstream_hops() -> Value {
+        json!([
+            {"hop": "budget", "started_at": "2026-07-04T00:00:00.300Z", "ended_at": "2026-07-04T00:00:00.320Z", "outcome": "allowed", "origin": "upstream", "failed": false, "detail": {}},
+            {"hop": "credential_injection", "started_at": "2026-07-04T00:00:00.320Z", "ended_at": "2026-07-04T00:00:00.340Z", "outcome": "injected", "origin": "upstream", "failed": false, "detail": {}},
+            {"hop": "upstream", "started_at": "2026-07-04T00:00:00.340Z", "ended_at": "2026-07-04T00:00:00.900Z", "outcome": "ok", "origin": "upstream", "failed": false, "detail": {"status": 200}},
+        ])
+    }
+
+    #[test]
+    fn merge_hops_is_order_independent() {
+        let listener_first =
+            merge_hops(&merge_hops(&json!([]), &listener_hops()), &upstream_hops());
+        let upstream_first =
+            merge_hops(&merge_hops(&json!([]), &upstream_hops()), &listener_hops());
+        assert_eq!(listener_first, upstream_first);
+        let names: Vec<&str> = listener_first
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(hop_name)
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                "route_match",
+                "auth",
+                "budget",
+                "credential_injection",
+                "upstream"
+            ]
+        );
+        // The duplicated budget hop resolved to the upstream-origin entry in both orders.
+        let budget = listener_first
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|hop| hop_name(hop) == "budget")
+            .unwrap();
+        assert_eq!(hop_origin(budget), "upstream");
+    }
+
+    #[test]
+    fn merge_hops_same_origin_keeps_existing_entry() {
+        let stored = json!([{"hop": "auth", "started_at": "2026-07-04T00:00:00Z", "ended_at": "2026-07-04T00:00:00Z", "outcome": "not_configured", "origin": "listener", "failed": false, "detail": {"first": true}}]);
+        let retry = json!([{"hop": "auth", "started_at": "2026-07-04T00:00:05Z", "ended_at": "2026-07-04T00:00:05Z", "outcome": "not_configured", "origin": "listener", "failed": false, "detail": {"first": false}}]);
+        let merged = merge_hops(&stored, &retry);
+        assert_eq!(merged.as_array().unwrap().len(), 1);
+        assert_eq!(merged[0]["detail"]["first"], json!(true));
+    }
+
+    #[test]
+    fn ttl_resolution_falls_back_to_thirty_day_default_without_policy() {
+        assert_eq!(resolve_ttl_days(None), DEFAULT_AI_TRACE_TTL_DAYS);
+        assert_eq!(resolve_ttl_days(None), 30);
+        assert_eq!(resolve_ttl_days(Some(7)), 7);
+    }
+
+    #[test]
+    fn derive_failure_hop_picks_first_failing_hop_in_timeline_order() {
+        assert_eq!(derive_failure_hop(&listener_hops()), None);
+        let hops = json!([
+            {"hop": "upstream", "started_at": "2026-07-04T00:00:02Z", "ended_at": "2026-07-04T00:00:03Z", "outcome": "error", "origin": "upstream", "failed": true, "detail": {}},
+            {"hop": "budget", "started_at": "2026-07-04T00:00:01Z", "ended_at": "2026-07-04T00:00:01Z", "outcome": "rejected", "origin": "listener", "failed": true, "detail": {}},
+        ]);
+        let merged = merge_hops(&json!([]), &hops);
+        assert_eq!(derive_failure_hop(&merged).as_deref(), Some("budget"));
+    }
+}

--- a/crates/fp-storage/src/repos/mod.rs
+++ b/crates/fp-storage/src/repos/mod.rs
@@ -2,6 +2,7 @@
 //! governance tables are org-keyed with the same explicitness.
 
 pub mod ai;
+pub mod ai_trace;
 pub mod api_lifecycle;
 pub mod audit;
 pub mod bootstrap;

--- a/crates/fp-storage/tests/ai_shadow_budget.rs
+++ b/crates/fp-storage/tests/ai_shadow_budget.rs
@@ -1,0 +1,315 @@
+//! Shadow-budget read-only evaluation query (feature ai-gateway-e2e-trace, slice s3).
+//!
+//! Parallel-safe: every test creates its own uniquely named org/team and its own budget
+//! rows; nothing assumes global row counts.
+
+#![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
+
+use fp_domain::{AiProviderId, RouteConfigId, TeamId};
+use fp_storage::repos::{ai, identity};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn unique(prefix: &str) -> String {
+    format!(
+        "{prefix}-{}",
+        &uuid::Uuid::now_v7().simple().to_string()[20..]
+    )
+}
+
+struct World {
+    pool: PgPool,
+    org_id: Uuid,
+    team_a: TeamId,
+    team_b: TeamId,
+}
+
+async fn world() -> Option<World> {
+    let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+        eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+        return None;
+    };
+    let pool = fp_storage::connect(&url, 8).await.expect("connect");
+    fp_storage::migrate(&pool).await.expect("migrate");
+    let org = identity::create_org(&pool, &unique("org-shadow"), "")
+        .await
+        .expect("org");
+    let team_a = identity::create_team(&pool, org.id, &unique("team-shadow-a"), "")
+        .await
+        .expect("team a");
+    let team_b = identity::create_team(&pool, org.id, &unique("team-shadow-b"), "")
+        .await
+        .expect("team b");
+    Some(World {
+        pool,
+        org_id: org.id.as_uuid(),
+        team_a: team_a.id,
+        team_b: team_b.id,
+    })
+}
+
+/// Insert a real ai_providers row (with its credential secret) so budgets can scope to it.
+async fn seed_provider(w: &World, team: TeamId) -> Uuid {
+    let secret_id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO secrets \
+         (id, team_id, org_id, name, description, secret_type, configuration_encrypted, nonce, encryption_key_id) \
+         VALUES ($1, $2, $3, $4, '', 'generic_secret', $5, $6, 'default')",
+    )
+    .bind(secret_id)
+    .bind(team.as_uuid())
+    .bind(w.org_id)
+    .bind(unique("ai-key"))
+    .bind(Vec::<u8>::from([1_u8]))
+    .bind(Vec::<u8>::from([2_u8; 12]))
+    .execute(&w.pool)
+    .await
+    .expect("secret");
+
+    let provider_id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO ai_providers \
+         (id, team_id, org_id, name, kind, base_url, credential_secret_id, auth_header) \
+         VALUES ($1, $2, $3, $4, 'openai', 'https://api.openai.example', $5, 'authorization')",
+    )
+    .bind(provider_id)
+    .bind(team.as_uuid())
+    .bind(w.org_id)
+    .bind(unique("provider"))
+    .bind(secret_id)
+    .execute(&w.pool)
+    .await
+    .expect("provider");
+    provider_id
+}
+
+/// Insert a real route_configs row so budgets can scope to it.
+async fn seed_route_config(w: &World, team: TeamId) -> Uuid {
+    let route_config_id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO route_configs (id, team_id, org_id, name, spec) \
+         VALUES ($1, $2, $3, $4, '{\"virtual_hosts\":[]}'::jsonb)",
+    )
+    .bind(route_config_id)
+    .bind(team.as_uuid())
+    .bind(w.org_id)
+    .bind(unique("route-config"))
+    .execute(&w.pool)
+    .await
+    .expect("route config");
+    route_config_id
+}
+
+/// Insert an ai_budgets row directly (NULL provider/route scope unless given) with an
+/// optional current-window counter.
+#[allow(clippy::too_many_arguments)]
+async fn seed_budget(
+    w: &World,
+    team: TeamId,
+    name: &str,
+    mode: &str,
+    limit_units: i64,
+    provider_id: Option<Uuid>,
+    route_config_id: Option<Uuid>,
+    used_units: Option<i64>,
+) {
+    let budget_id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO ai_budgets \
+         (id, team_id, org_id, name, mode, limit_units, window_seconds, provider_id, route_config_id, prompt_token_weight, completion_token_weight) \
+         VALUES ($1, $2, $3, $4, $5, $6, 3600, $7, $8, 1, 1)",
+    )
+    .bind(budget_id)
+    .bind(team.as_uuid())
+    .bind(w.org_id)
+    .bind(name)
+    .bind(mode)
+    .bind(limit_units)
+    .bind(provider_id)
+    .bind(route_config_id)
+    .execute(&w.pool)
+    .await
+    .expect("budget row");
+    if let Some(used) = used_units {
+        sqlx::query(
+            "INSERT INTO ai_budget_counters (budget_id, team_id, window_start, used_units) \
+             VALUES ($1, $2, to_timestamp(floor(extract(epoch FROM now()) / 3600) * 3600), $3)",
+        )
+        .bind(budget_id)
+        .bind(team.as_uuid())
+        .bind(used)
+        .execute(&w.pool)
+        .await
+        .expect("counter row");
+    }
+}
+
+#[tokio::test]
+async fn evaluate_shadow_budgets_reports_matching_shadow_standings_read_only() {
+    let Some(w) = world().await else { return };
+    let provider_id = seed_provider(&w, w.team_a).await;
+    let other_provider = seed_provider(&w, w.team_a).await;
+    let route_config_id = Uuid::now_v7();
+
+    // Exhausted team-wide shadow budget (NULL scope matches everything).
+    seed_budget(
+        &w,
+        w.team_a,
+        "shadow-over",
+        "shadow",
+        5,
+        None,
+        None,
+        Some(9),
+    )
+    .await;
+    // Shadow budget with headroom, provider-scoped to the queried provider.
+    seed_budget(
+        &w,
+        w.team_a,
+        "shadow-under",
+        "shadow",
+        100,
+        Some(provider_id),
+        None,
+        Some(3),
+    )
+    .await;
+    // Shadow budget with no counter yet: used_units must read as 0, not be dropped.
+    seed_budget(&w, w.team_a, "shadow-unused", "shadow", 7, None, None, None).await;
+    // Exhausted ENFORCING budget: never part of the shadow evaluation.
+    seed_budget(
+        &w,
+        w.team_a,
+        "enforcing-over",
+        "enforcing",
+        1,
+        None,
+        None,
+        Some(5),
+    )
+    .await;
+    // Shadow budget scoped to a different provider: filtered out.
+    seed_budget(
+        &w,
+        w.team_a,
+        "shadow-other-provider",
+        "shadow",
+        5,
+        Some(other_provider),
+        None,
+        Some(9),
+    )
+    .await;
+    // Another team's exhausted shadow budget: invisible.
+    seed_budget(
+        &w,
+        w.team_b,
+        "shadow-b-over",
+        "shadow",
+        1,
+        None,
+        None,
+        Some(5),
+    )
+    .await;
+
+    let evaluations = ai::evaluate_shadow_budgets(
+        &w.pool,
+        w.team_a,
+        RouteConfigId::from(route_config_id),
+        AiProviderId::from(provider_id),
+    )
+    .await
+    .expect("shadow evaluation");
+    assert_eq!(
+        evaluations,
+        vec![
+            ai::ShadowBudgetEvaluation {
+                name: "shadow-over".into(),
+                used_units: 9,
+                limit_units: 5,
+            },
+            ai::ShadowBudgetEvaluation {
+                name: "shadow-under".into(),
+                used_units: 3,
+                limit_units: 100,
+            },
+            ai::ShadowBudgetEvaluation {
+                name: "shadow-unused".into(),
+                used_units: 0,
+                limit_units: 7,
+            },
+        ],
+        "matching shadow budgets in name order, enforcing/foreign/other-scope excluded"
+    );
+
+    // Read-only: evaluation must not create or mutate any counter row.
+    let counters: Vec<(String, i64)> = sqlx::query_as(
+        "SELECT b.name, c.used_units FROM ai_budget_counters c \
+         JOIN ai_budgets b ON b.id = c.budget_id WHERE c.team_id = $1 ORDER BY b.name",
+    )
+    .bind(w.team_a.as_uuid())
+    .fetch_all(&w.pool)
+    .await
+    .expect("counters");
+    assert_eq!(
+        counters,
+        vec![
+            ("enforcing-over".to_string(), 5),
+            ("shadow-other-provider".to_string(), 9),
+            ("shadow-over".to_string(), 9),
+            ("shadow-under".to_string(), 3),
+        ],
+        "counters unchanged and none created by the read-only evaluation"
+    );
+}
+
+#[tokio::test]
+async fn evaluate_shadow_budgets_honors_route_config_scope() {
+    let Some(w) = world().await else { return };
+    let provider_id = Uuid::now_v7();
+    let route_config_id = seed_route_config(&w, w.team_a).await;
+    let other_route_config = seed_route_config(&w, w.team_a).await;
+
+    seed_budget(
+        &w,
+        w.team_a,
+        "shadow-this-route",
+        "shadow",
+        5,
+        None,
+        Some(route_config_id),
+        Some(6),
+    )
+    .await;
+    seed_budget(
+        &w,
+        w.team_a,
+        "shadow-other-route",
+        "shadow",
+        5,
+        None,
+        Some(other_route_config),
+        Some(6),
+    )
+    .await;
+
+    let evaluations = ai::evaluate_shadow_budgets(
+        &w.pool,
+        w.team_a,
+        RouteConfigId::from(route_config_id),
+        AiProviderId::from(provider_id),
+    )
+    .await
+    .expect("shadow evaluation");
+    assert_eq!(
+        evaluations,
+        vec![ai::ShadowBudgetEvaluation {
+            name: "shadow-this-route".into(),
+            used_units: 6,
+            limit_units: 5,
+        }],
+        "route-config-scoped shadow budgets match only their own route config"
+    );
+}

--- a/crates/fp-storage/tests/ai_trace.rs
+++ b/crates/fp-storage/tests/ai_trace.rs
@@ -1,0 +1,310 @@
+//! AI trace-event repository integration tests (feature ai-gateway-e2e-trace, slice s2).
+//!
+//! Parallel-safe: every test creates its own uniquely named org/team and keys rows by
+//! fresh UUID request ids; nothing assumes global row counts.
+
+#![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
+
+use fp_domain::{ListenerId, RouteConfigId, TeamId};
+use fp_storage::repos::{ai_trace, identity};
+use serde_json::{json, Value};
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+fn unique(prefix: &str) -> String {
+    format!(
+        "{prefix}-{}",
+        &uuid::Uuid::now_v7().simple().to_string()[20..]
+    )
+}
+
+struct World {
+    pool: PgPool,
+    team_a: TeamId,
+    team_b: TeamId,
+}
+
+async fn world() -> Option<World> {
+    let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+        eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+        return None;
+    };
+    let pool = fp_storage::connect(&url, 8).await.expect("connect");
+    fp_storage::migrate(&pool).await.expect("migrate");
+    let org = identity::create_org(&pool, &unique("org-trace"), "")
+        .await
+        .expect("org");
+    let team_a = identity::create_team(&pool, org.id, &unique("team-trace-a"), "")
+        .await
+        .expect("team a");
+    let team_b = identity::create_team(&pool, org.id, &unique("team-trace-b"), "")
+        .await
+        .expect("team b");
+    Some(World {
+        pool,
+        team_a: team_a.id,
+        team_b: team_b.id,
+    })
+}
+
+fn listener_event(
+    team_id: TeamId,
+    request_id: &str,
+    route_config_id: RouteConfigId,
+    listener_id: ListenerId,
+) -> ai_trace::AiTraceEventUpsert {
+    ai_trace::AiTraceEventUpsert {
+        team_id,
+        request_id: request_id.to_string(),
+        trace_id: Some("0af7651916cd43dd8448eb211c80319c".into()),
+        route_config_id,
+        listener_id: Some(listener_id),
+        provider_id: None,
+        model: Some("gpt-5".into()),
+        status_code: Some(200),
+        hops: json!([
+            {"hop": "route_match", "started_at": "2026-07-04T00:00:00.100000Z", "ended_at": "2026-07-04T00:00:00.150000Z", "outcome": "matched", "origin": "listener", "failed": false, "detail": {"model": "gpt-5"}},
+            {"hop": "auth", "started_at": "2026-07-04T00:00:00.150000Z", "ended_at": "2026-07-04T00:00:00.150000Z", "outcome": "not_configured", "origin": "listener", "failed": false, "detail": {}},
+            {"hop": "budget", "started_at": "2026-07-04T00:00:00.160000Z", "ended_at": "2026-07-04T00:00:00.170000Z", "outcome": "allowed", "origin": "listener", "failed": false, "detail": {"mode": "enforcing"}},
+        ]),
+    }
+}
+
+fn upstream_event(
+    team_id: TeamId,
+    request_id: &str,
+    route_config_id: RouteConfigId,
+) -> ai_trace::AiTraceEventUpsert {
+    ai_trace::AiTraceEventUpsert {
+        team_id,
+        request_id: request_id.to_string(),
+        trace_id: None,
+        route_config_id,
+        listener_id: None,
+        provider_id: Some(fp_domain::AiProviderId::from(Uuid::now_v7())),
+        model: None,
+        status_code: None,
+        hops: json!([
+            {"hop": "budget", "started_at": "2026-07-04T00:00:00.300000Z", "ended_at": "2026-07-04T00:00:00.310000Z", "outcome": "allowed", "origin": "upstream", "failed": false, "detail": {"mode": "enforcing"}},
+            {"hop": "credential_injection", "started_at": "2026-07-04T00:00:00.310000Z", "ended_at": "2026-07-04T00:00:00.320000Z", "outcome": "injected", "origin": "upstream", "failed": false, "detail": {"auth_header": "authorization"}},
+            {"hop": "upstream", "started_at": "2026-07-04T00:00:00.300000Z", "ended_at": "2026-07-04T00:00:00.900000Z", "outcome": "ok", "origin": "upstream", "failed": false, "detail": {"status": 200}},
+            {"hop": "usage", "started_at": "2026-07-04T00:00:00.900000Z", "ended_at": "2026-07-04T00:00:00.900000Z", "outcome": "settled", "origin": "upstream", "failed": false, "detail": {"total_tokens": 5}},
+        ]),
+    }
+}
+
+fn hop_names(hops: &Value) -> Vec<String> {
+    hops.as_array()
+        .unwrap()
+        .iter()
+        .map(|hop| hop["hop"].as_str().unwrap().to_string())
+        .collect()
+}
+
+#[tokio::test]
+async fn upsert_merges_listener_and_upstream_contributions_order_independently() {
+    let Some(w) = world().await else { return };
+    let route_config_id = RouteConfigId::from(Uuid::now_v7());
+    let listener_id = ListenerId::from(Uuid::now_v7());
+
+    let provider_id = fp_domain::AiProviderId::from(Uuid::now_v7());
+
+    // Request 1: listener stream writes first.
+    let req_1 = Uuid::now_v7().to_string();
+    let listener_1 = listener_event(w.team_a, &req_1, route_config_id, listener_id);
+    let mut upstream_1 = upstream_event(w.team_a, &req_1, route_config_id);
+    upstream_1.provider_id = Some(provider_id);
+    ai_trace::upsert_trace_event(&w.pool, &listener_1)
+        .await
+        .expect("listener upsert");
+    ai_trace::upsert_trace_event(&w.pool, &upstream_1)
+        .await
+        .expect("upstream upsert");
+
+    // Request 2: identical contributions, upstream stream writes first.
+    let req_2 = Uuid::now_v7().to_string();
+    let listener_2 = listener_event(w.team_a, &req_2, route_config_id, listener_id);
+    let mut upstream_2 = upstream_event(w.team_a, &req_2, route_config_id);
+    upstream_2.provider_id = Some(provider_id);
+    ai_trace::upsert_trace_event(&w.pool, &upstream_2)
+        .await
+        .expect("upstream-first upsert");
+    ai_trace::upsert_trace_event(&w.pool, &listener_2)
+        .await
+        .expect("listener-second upsert");
+
+    let rows = ai_trace::list_trace_events(
+        &w.pool,
+        w.team_a,
+        ai_trace::AiTraceQuery {
+            request_id: Some(&req_1),
+            trace_id: None,
+            limit: 10,
+        },
+    )
+    .await
+    .expect("list");
+    assert_eq!(rows.len(), 1, "both streams merged into one row");
+    let first = &rows[0];
+    let rows = ai_trace::list_trace_events(
+        &w.pool,
+        w.team_a,
+        ai_trace::AiTraceQuery {
+            request_id: Some(&req_2),
+            trace_id: None,
+            limit: 10,
+        },
+    )
+    .await
+    .expect("list second");
+    assert_eq!(rows.len(), 1);
+    let second = &rows[0];
+
+    // Semantic content converges regardless of which stream wrote first.
+    assert_eq!(first.hops, second.hops);
+    assert_eq!(first.trace_id, second.trace_id);
+    assert_eq!(first.listener_id, second.listener_id);
+    assert_eq!(first.provider_id, second.provider_id);
+    assert_eq!(first.model, second.model);
+    assert_eq!(first.status_code, second.status_code);
+    assert_eq!(first.failure_hop, None);
+    assert_eq!(
+        hop_names(&first.hops),
+        vec![
+            "route_match",
+            "auth",
+            "budget",
+            "credential_injection",
+            "upstream",
+            "usage"
+        ],
+        "duplicate budget hop resolved to one entry, all hops present"
+    );
+    // The conflicting budget hop resolved to the upstream-origin entry in both orders.
+    let budget = first
+        .hops
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|hop| hop["hop"] == "budget")
+        .unwrap();
+    assert_eq!(budget["origin"], "upstream");
+    assert_eq!(first.status_code, Some(200));
+    assert_eq!(first.model.as_deref(), Some("gpt-5"));
+    assert!(first.trace_id.is_some());
+}
+
+#[tokio::test]
+async fn list_is_scoped_by_construction_and_finds_nothing_for_other_team() {
+    let Some(w) = world().await else { return };
+    let route_config_id = RouteConfigId::from(Uuid::now_v7());
+    let listener_id = ListenerId::from(Uuid::now_v7());
+    let request_id = Uuid::now_v7().to_string();
+    let event = listener_event(w.team_a, &request_id, route_config_id, listener_id);
+    ai_trace::upsert_trace_event(&w.pool, &event)
+        .await
+        .expect("upsert");
+
+    let mine = ai_trace::list_trace_events(
+        &w.pool,
+        w.team_a,
+        ai_trace::AiTraceQuery {
+            request_id: Some(&request_id),
+            trace_id: None,
+            limit: 10,
+        },
+    )
+    .await
+    .expect("own team list");
+    assert_eq!(mine.len(), 1);
+    assert_eq!(mine[0].team_id, w.team_a);
+
+    let theirs = ai_trace::list_trace_events(
+        &w.pool,
+        w.team_b,
+        ai_trace::AiTraceQuery {
+            request_id: Some(&request_id),
+            trace_id: None,
+            limit: 10,
+        },
+    )
+    .await
+    .expect("other team list");
+    assert!(theirs.is_empty(), "trace reads are team-scoped");
+
+    let by_trace_id = ai_trace::list_trace_events(
+        &w.pool,
+        w.team_a,
+        ai_trace::AiTraceQuery {
+            request_id: None,
+            trace_id: mine[0].trace_id.as_deref(),
+            limit: 10,
+        },
+    )
+    .await
+    .expect("trace id list");
+    assert!(by_trace_id.iter().any(|row| row.request_id == request_id));
+}
+
+#[tokio::test]
+async fn expires_at_defaults_to_thirty_days_after_created_at_without_policy_row() {
+    let Some(w) = world().await else { return };
+    let route_config_id = RouteConfigId::from(Uuid::now_v7());
+    let listener_id = ListenerId::from(Uuid::now_v7());
+    let request_id = Uuid::now_v7().to_string();
+    let event = listener_event(w.team_a, &request_id, route_config_id, listener_id);
+    ai_trace::upsert_trace_event(&w.pool, &event)
+        .await
+        .expect("upsert");
+
+    let exact: bool = sqlx::query(
+        "SELECT expires_at = created_at + make_interval(days => $3) AS exact \
+         FROM ai_trace_events WHERE team_id = $1 AND request_id = $2",
+    )
+    .bind(w.team_a.as_uuid())
+    .bind(&request_id)
+    .bind(ai_trace::DEFAULT_AI_TRACE_TTL_DAYS)
+    .fetch_one(&w.pool)
+    .await
+    .expect("expiry row")
+    .get("exact");
+    assert!(
+        exact,
+        "with no ai_retention_policies row expires_at is exactly created_at + 30 days"
+    );
+}
+
+#[tokio::test]
+async fn migration_enforces_unique_request_per_team_and_required_indexes() {
+    let Some(w) = world().await else { return };
+    // The unique upsert key and the two query indexes exist as designed.
+    let indexes: Vec<String> = sqlx::query(
+        "SELECT indexname FROM pg_indexes WHERE tablename = 'ai_trace_events' ORDER BY indexname",
+    )
+    .fetch_all(&w.pool)
+    .await
+    .expect("indexes")
+    .into_iter()
+    .map(|row| row.get::<String, _>("indexname"))
+    .collect();
+    for expected in [
+        "uq_ai_trace_events_team_request",
+        "idx_ai_trace_events_team_created",
+        "idx_ai_trace_events_expires",
+    ] {
+        assert!(
+            indexes.iter().any(|name| name == expected),
+            "missing index {expected}, found {indexes:?}"
+        );
+    }
+    // ai_retention_policies exists with a unique team_id.
+    let unique_team: bool = sqlx::query_scalar(
+        "SELECT EXISTS (\
+           SELECT 1 FROM pg_indexes WHERE tablename = 'ai_retention_policies' \
+           AND indexdef LIKE '%UNIQUE%' AND indexdef LIKE '%team_id%')",
+    )
+    .fetch_one(&w.pool)
+    .await
+    .expect("retention index");
+    assert!(unique_team, "ai_retention_policies.team_id must be unique");
+}

--- a/crates/fp-storage/tests/ai_trace.rs
+++ b/crates/fp-storage/tests/ai_trace.rs
@@ -87,7 +87,7 @@ fn upstream_event(
         hops: json!([
             {"hop": "budget", "started_at": "2026-07-04T00:00:00.300000Z", "ended_at": "2026-07-04T00:00:00.310000Z", "outcome": "allowed", "origin": "upstream", "failed": false, "detail": {"mode": "enforcing"}},
             {"hop": "credential_injection", "started_at": "2026-07-04T00:00:00.310000Z", "ended_at": "2026-07-04T00:00:00.320000Z", "outcome": "injected", "origin": "upstream", "failed": false, "detail": {"auth_header": "authorization"}},
-            {"hop": "upstream", "started_at": "2026-07-04T00:00:00.300000Z", "ended_at": "2026-07-04T00:00:00.900000Z", "outcome": "ok", "origin": "upstream", "failed": false, "detail": {"status": 200}},
+            {"hop": "upstream", "started_at": "2026-07-04T00:00:00.320000Z", "ended_at": "2026-07-04T00:00:00.900000Z", "outcome": "ok", "origin": "upstream", "failed": false, "detail": {"status": 200}},
             {"hop": "usage", "started_at": "2026-07-04T00:00:00.900000Z", "ended_at": "2026-07-04T00:00:00.900000Z", "outcome": "settled", "origin": "upstream", "failed": false, "detail": {"total_tokens": 5}},
         ]),
     }

--- a/crates/fp-storage/tests/ai_trace.rs
+++ b/crates/fp-storage/tests/ai_trace.rs
@@ -5,7 +5,8 @@
 
 #![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
 
-use fp_domain::{ListenerId, RouteConfigId, TeamId};
+use fp_domain::authz::TeamRef;
+use fp_domain::{ListenerId, OrgId, RouteConfigId, TeamId};
 use fp_storage::repos::{ai_trace, identity};
 use serde_json::{json, Value};
 use sqlx::{PgPool, Row};
@@ -20,8 +21,18 @@ fn unique(prefix: &str) -> String {
 
 struct World {
     pool: PgPool,
+    org: OrgId,
     team_a: TeamId,
     team_b: TeamId,
+}
+
+impl World {
+    fn team_ref(&self, team_id: TeamId) -> TeamRef {
+        TeamRef {
+            id: team_id,
+            org_id: self.org,
+        }
+    }
 }
 
 async fn world() -> Option<World> {
@@ -42,6 +53,7 @@ async fn world() -> Option<World> {
         .expect("team b");
     Some(World {
         pool,
+        org: org.id,
         team_a: team_a.id,
         team_b: team_b.id,
     })
@@ -271,6 +283,172 @@ async fn expires_at_defaults_to_thirty_days_after_created_at_without_policy_row(
     assert!(
         exact,
         "with no ai_retention_policies row expires_at is exactly created_at + 30 days"
+    );
+}
+
+// Slice s5: one policy row per team, PUT semantics — absent → None, set creates at version 1,
+// set again replaces in place (same row id) and bumps the version.
+#[tokio::test]
+async fn retention_policy_is_a_single_versioned_row_per_team() {
+    let Some(w) = world().await else { return };
+
+    assert!(
+        ai_trace::get_retention_policy(&w.pool, w.team_a)
+            .await
+            .expect("get absent")
+            .is_none(),
+        "no policy row until one is set"
+    );
+
+    let mut tx = w.pool.begin().await.expect("begin");
+    let created = ai_trace::set_retention_policy(&mut tx, w.team_ref(w.team_a), 7)
+        .await
+        .expect("set");
+    tx.commit().await.expect("commit");
+    assert_eq!(created.trace_ttl_days, 7);
+    assert_eq!(created.version, 1);
+    assert_eq!(created.team_id, w.team_a);
+
+    let mut tx = w.pool.begin().await.expect("begin");
+    let replaced = ai_trace::set_retention_policy(&mut tx, w.team_ref(w.team_a), 14)
+        .await
+        .expect("replace");
+    tx.commit().await.expect("commit replace");
+    assert_eq!(replaced.trace_ttl_days, 14);
+    assert_eq!(replaced.version, 2, "replace bumps the revision");
+    assert_eq!(
+        replaced.id, created.id,
+        "one row per team, replaced in place"
+    );
+
+    let fetched = ai_trace::get_retention_policy(&w.pool, w.team_a)
+        .await
+        .expect("get stored")
+        .expect("policy row");
+    assert_eq!(fetched.trace_ttl_days, 14);
+    assert_eq!(fetched.version, 2);
+
+    // Team B is untouched by team A's policy.
+    assert!(ai_trace::get_retention_policy(&w.pool, w.team_b)
+        .await
+        .expect("get team b")
+        .is_none());
+}
+
+// Slice s5 (design AC 13): with a team policy of N days, a NEW trace row's expires_at equals
+// created_at + N days; the no-policy 30-day default is covered by
+// `expires_at_defaults_to_thirty_days_after_created_at_without_policy_row` above.
+#[tokio::test]
+async fn insert_time_ttl_honors_a_preset_policy() {
+    let Some(w) = world().await else { return };
+    let mut tx = w.pool.begin().await.expect("begin");
+    ai_trace::set_retention_policy(&mut tx, w.team_ref(w.team_a), 7)
+        .await
+        .expect("set policy");
+    tx.commit().await.expect("commit");
+
+    let request_id = Uuid::now_v7().to_string();
+    let event = listener_event(
+        w.team_a,
+        &request_id,
+        RouteConfigId::from(Uuid::now_v7()),
+        ListenerId::from(Uuid::now_v7()),
+    );
+    ai_trace::upsert_trace_event(&w.pool, &event)
+        .await
+        .expect("upsert");
+
+    let exact: bool = sqlx::query(
+        "SELECT expires_at = created_at + make_interval(days => 7) AS exact \
+         FROM ai_trace_events WHERE team_id = $1 AND request_id = $2",
+    )
+    .bind(w.team_a.as_uuid())
+    .bind(&request_id)
+    .fetch_one(&w.pool)
+    .await
+    .expect("expiry row")
+    .get("exact");
+    assert!(
+        exact,
+        "with a 7-day policy expires_at is exactly created_at + 7 days"
+    );
+}
+
+// Slice s5 (design AC 13): the sweep removes only rows with expires_at <= as_of, and only
+// the owning team's data — an unexpired sibling row and another team's rows survive.
+#[tokio::test]
+async fn delete_expired_trace_events_scopes_to_expired_rows_only() {
+    let Some(w) = world().await else { return };
+    let route_config_id = RouteConfigId::from(Uuid::now_v7());
+    let listener_id = ListenerId::from(Uuid::now_v7());
+
+    // Team A: one row that will be expired, one that stays fresh. Team B: one fresh row.
+    let expired_id = Uuid::now_v7().to_string();
+    let fresh_a_id = Uuid::now_v7().to_string();
+    let fresh_b_id = Uuid::now_v7().to_string();
+    for (team, request_id) in [
+        (w.team_a, &expired_id),
+        (w.team_a, &fresh_a_id),
+        (w.team_b, &fresh_b_id),
+    ] {
+        let event = listener_event(team, request_id, route_config_id, listener_id);
+        ai_trace::upsert_trace_event(&w.pool, &event)
+            .await
+            .expect("upsert");
+    }
+    // Age one team-A row past its expiry (rows are otherwise 30-day fresh).
+    sqlx::query(
+        "UPDATE ai_trace_events SET expires_at = now() - interval '1 minute' \
+         WHERE team_id = $1 AND request_id = $2",
+    )
+    .bind(w.team_a.as_uuid())
+    .bind(&expired_id)
+    .execute(&w.pool)
+    .await
+    .expect("age row");
+
+    // The sweep deletes at least the aged row (the shared DB may hold other tests' expired
+    // rows, so assert on this world's rows, not the global count).
+    let deleted = ai_trace::delete_expired_trace_events(&w.pool, sqlx::types::chrono::Utc::now())
+        .await
+        .expect("sweep");
+    assert!(
+        deleted >= 1,
+        "the aged row must be swept, deleted={deleted}"
+    );
+
+    let survivors = |team: TeamId, request_id: &str| {
+        let pool = w.pool.clone();
+        let request_id = request_id.to_string();
+        async move {
+            ai_trace::list_trace_events(
+                &pool,
+                team,
+                ai_trace::AiTraceQuery {
+                    request_id: Some(&request_id),
+                    trace_id: None,
+                    limit: 10,
+                },
+            )
+            .await
+            .expect("list")
+            .len()
+        }
+    };
+    assert_eq!(
+        survivors(w.team_a, &expired_id).await,
+        0,
+        "expired row is gone"
+    );
+    assert_eq!(
+        survivors(w.team_a, &fresh_a_id).await,
+        1,
+        "same team's unexpired row survives"
+    );
+    assert_eq!(
+        survivors(w.team_b, &fresh_b_id).await,
+        1,
+        "other team's row survives"
     );
 }
 

--- a/crates/fp-storage/tests/ai_trace.rs
+++ b/crates/fp-storage/tests/ai_trace.rs
@@ -301,7 +301,7 @@ async fn retention_policy_is_a_single_versioned_row_per_team() {
     );
 
     let mut tx = w.pool.begin().await.expect("begin");
-    let created = ai_trace::set_retention_policy(&mut tx, w.team_ref(w.team_a), 7)
+    let created = ai_trace::set_retention_policy(&mut tx, w.team_ref(w.team_a), 7, None)
         .await
         .expect("set");
     tx.commit().await.expect("commit");
@@ -310,7 +310,7 @@ async fn retention_policy_is_a_single_versioned_row_per_team() {
     assert_eq!(created.team_id, w.team_a);
 
     let mut tx = w.pool.begin().await.expect("begin");
-    let replaced = ai_trace::set_retention_policy(&mut tx, w.team_ref(w.team_a), 14)
+    let replaced = ai_trace::set_retention_policy(&mut tx, w.team_ref(w.team_a), 14, None)
         .await
         .expect("replace");
     tx.commit().await.expect("commit replace");
@@ -335,6 +335,63 @@ async fn retention_policy_is_a_single_versioned_row_per_team() {
         .is_none());
 }
 
+#[tokio::test]
+async fn retention_policy_conditional_replace_enforces_expected_revision() {
+    let Some(w) = world().await else { return };
+
+    let mut tx = w.pool.begin().await.expect("begin");
+    let created = ai_trace::set_retention_policy(&mut tx, w.team_ref(w.team_a), 7, None)
+        .await
+        .expect("create");
+    tx.commit().await.expect("commit create");
+
+    let mut tx = w.pool.begin().await.expect("begin match");
+    let replaced =
+        ai_trace::set_retention_policy(&mut tx, w.team_ref(w.team_a), 14, Some(created.version))
+            .await
+            .expect("matching revision replaces");
+    tx.commit().await.expect("commit match");
+    assert_eq!(replaced.id, created.id);
+    assert_eq!(replaced.trace_ttl_days, 14);
+    assert_eq!(replaced.version, created.version + 1);
+
+    let mut tx = w.pool.begin().await.expect("begin stale");
+    let err =
+        ai_trace::set_retention_policy(&mut tx, w.team_ref(w.team_a), 21, Some(created.version))
+            .await
+            .expect_err("stale revision fails");
+    tx.commit().await.expect("commit stale tx");
+    assert_eq!(err.code, fp_domain::ErrorCode::RevisionMismatch);
+
+    let fetched = ai_trace::get_retention_policy(&w.pool, w.team_a)
+        .await
+        .expect("get after stale")
+        .expect("policy remains");
+    assert_eq!(fetched.id, created.id);
+    assert_eq!(fetched.trace_ttl_days, 14);
+    assert_eq!(fetched.version, replaced.version);
+}
+
+#[tokio::test]
+async fn retention_policy_conditional_replace_missing_row_does_not_create() {
+    let Some(w) = world().await else { return };
+
+    let mut tx = w.pool.begin().await.expect("begin");
+    let err = ai_trace::set_retention_policy(&mut tx, w.team_ref(w.team_a), 7, Some(1))
+        .await
+        .expect_err("missing row with precondition fails");
+    tx.commit().await.expect("commit");
+    assert_eq!(err.code, fp_domain::ErrorCode::RevisionMismatch);
+
+    assert!(
+        ai_trace::get_retention_policy(&w.pool, w.team_a)
+            .await
+            .expect("get absent")
+            .is_none(),
+        "conditional replace must not create a policy row"
+    );
+}
+
 // Slice s5 (design AC 13): with a team policy of N days, a NEW trace row's expires_at equals
 // created_at + N days; the no-policy 30-day default is covered by
 // `expires_at_defaults_to_thirty_days_after_created_at_without_policy_row` above.
@@ -342,7 +399,7 @@ async fn retention_policy_is_a_single_versioned_row_per_team() {
 async fn insert_time_ttl_honors_a_preset_policy() {
     let Some(w) = world().await else { return };
     let mut tx = w.pool.begin().await.expect("begin");
-    ai_trace::set_retention_policy(&mut tx, w.team_ref(w.team_a), 7)
+    ai_trace::set_retention_policy(&mut tx, w.team_ref(w.team_a), 7, None)
         .await
         .expect("set policy");
     tx.commit().await.expect("commit");

--- a/crates/fp-xds/Cargo.toml
+++ b/crates/fp-xds/Cargo.toml
@@ -10,6 +10,7 @@ publish.workspace = true
 [dependencies]
 aes-gcm = { workspace = true }
 base64 = { workspace = true }
+chrono = { workspace = true }
 envoy-types = { workspace = true }
 fp-domain = { workspace = true }
 fp-storage = { workspace = true }
@@ -27,7 +28,6 @@ uuid = { workspace = true }
 x509-parser = { workspace = true }
 
 [dev-dependencies]
-chrono = { workspace = true }
 fp-core = { workspace = true }
 sha2 = { workspace = true }
 

--- a/crates/fp-xds/Cargo.toml
+++ b/crates/fp-xds/Cargo.toml
@@ -30,6 +30,7 @@ x509-parser = { workspace = true }
 [dev-dependencies]
 fp-core = { workspace = true }
 sha2 = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/fp-xds/src/capture.rs
+++ b/crates/fp-xds/src/capture.rs
@@ -99,6 +99,7 @@ struct AiExtProcState {
     trace_id: Option<String>,
     model: Option<String>,
     request_headers_at: Option<DateTime<Utc>>,
+    response_body_end_seen: bool,
     hops: Vec<TraceHop>,
 }
 
@@ -167,6 +168,66 @@ impl AiExtProcState {
             detail,
         });
     }
+
+    /// Re-verdict an already-recorded hop as failed — used when a hop's outcome is only
+    /// knowable after it was opened (e.g. `route_match` turning out to have no eligible
+    /// backend once the model header is resolved against the route spec).
+    fn fail_hop(&mut self, hop: &'static str, outcome: &'static str) {
+        if let Some(entry) = self.hops.iter_mut().find(|entry| entry.hop == hop) {
+            entry.outcome = outcome;
+            entry.failed = true;
+            entry.ended_at = Utc::now().max(entry.started_at);
+        }
+    }
+}
+
+/// Verdict vocabulary of the `budget` hop (design AC 2/3): an exhausted enforcing budget
+/// rejects the request, an exhausted shadow budget only records that it *would* have.
+fn budget_verdict(enforcing: bool, exhausted: bool) -> &'static str {
+    match (enforcing, exhausted) {
+        (true, true) => "rejected",
+        (false, true) => "would_reject",
+        (_, false) => "allowed",
+    }
+}
+
+/// Map read-only shadow evaluations into the `budget` hop's `shadow` detail entries.
+fn shadow_budget_entries(evaluations: &[ai::ShadowBudgetEvaluation]) -> Value {
+    Value::Array(
+        evaluations
+            .iter()
+            .map(|eval| {
+                json!({
+                    "budget": eval.name,
+                    "verdict": budget_verdict(false, eval.used_units >= eval.limit_units),
+                    "used_units": eval.used_units,
+                    "limit_units": eval.limit_units,
+                })
+            })
+            .collect(),
+    )
+}
+
+/// Detail for an allowed enforcing-budget hop: matching shadow budgets are additionally
+/// evaluated read-only (design AC 3) and recorded per budget; evaluation failure degrades
+/// to an unannotated hop and never affects the request.
+async fn budget_allowed_detail(
+    pool: &sqlx::PgPool,
+    team_id: TeamId,
+    route_config_id: RouteConfigId,
+    provider_id: AiProviderId,
+) -> Value {
+    let mut detail = json!({"mode": "enforcing", "verdict": budget_verdict(true, false)});
+    match ai::evaluate_shadow_budgets(pool, team_id, route_config_id, provider_id).await {
+        Ok(evaluations) if !evaluations.is_empty() => {
+            detail["shadow"] = shadow_budget_entries(&evaluations);
+        }
+        Ok(_) => {}
+        Err(err) => {
+            tracing::debug!(team = %team_id, route_config = %route_config_id, "failed to evaluate AI shadow budgets: {}", err.message);
+        }
+    }
+    detail
 }
 
 /// Extract the 32-hex trace-id field from a W3C `traceparent` header value.
@@ -350,11 +411,17 @@ impl ExternalProcessor for LearningCaptureService {
     }
 }
 
-fn ai_process_stream(
+/// Generic over the message source so integration tests can drive the exact production
+/// loop with an in-memory stream (`tonic::Streaming` implements the same `Stream` shape).
+fn ai_process_stream<S>(
     pool: sqlx::PgPool,
-    mut stream: Streaming<ProcessingRequest>,
+    mut stream: S,
     context: Option<AiExtProcContext>,
-) -> tokio::sync::mpsc::Receiver<Result<ProcessingResponse, Status>> {
+) -> tokio::sync::mpsc::Receiver<Result<ProcessingResponse, Status>>
+where
+    S: tokio_stream::Stream<Item = Result<ProcessingRequest, Status>> + Send + Unpin + 'static,
+{
+    use tokio_stream::StreamExt;
     let (tx, rx) = tokio::sync::mpsc::channel::<Result<ProcessingResponse, Status>>(16);
     tokio::spawn(async move {
         let mut state = AiExtProcState {
@@ -362,24 +429,69 @@ fn ai_process_stream(
             ..Default::default()
         };
         loop {
-            match stream.message().await {
-                Ok(Some(message)) => {
+            match stream.next().await {
+                Some(Ok(message)) => {
                     let response = ai_response_with_pool(&pool, &mut state, message).await;
+                    let immediate = matches!(
+                        response.response,
+                        Some(processing_response::Response::ImmediateResponse(_))
+                    );
                     if tx.send(Ok(response)).await.is_err() {
                         break;
                     }
+                    if immediate {
+                        // Immediate responses (budget reject, credential failure) end HTTP
+                        // processing for the request; persist the row best-effort off this
+                        // fast path (design Risk 1) — never awaited before the client sees
+                        // the response. The stream-end persist below merges idempotently.
+                        let pool = pool.clone();
+                        let snapshot = state.clone();
+                        tokio::spawn(async move {
+                            persist_ai_trace(&pool, &snapshot, None).await;
+                        });
+                    }
                 }
-                Ok(None) => break,
-                Err(status) => {
+                None => break,
+                Some(Err(status)) => {
                     tracing::debug!(code = ?status.code(), message = %status.message(), "AI ExtProc stream ended with error");
                     break;
                 }
             }
         }
+        note_ai_client_disconnect(&mut state);
         let settlement = persist_ai_usage(&pool, &state).await;
         persist_ai_trace(&pool, &state, settlement).await;
     });
     rx
+}
+
+/// A client that disconnects mid-SSE tears both streams down before the response body
+/// completes. The upstream-side stream had already recorded its `upstream` hop as `ok`
+/// at response headers; rewrite it so the persisted partial row says what happened
+/// (design Risk 6). Not flagged failed: the gateway and provider did not fail.
+fn note_ai_client_disconnect(state: &mut AiExtProcState) {
+    if state.trace_origin() != "upstream" {
+        return;
+    }
+    if state.response_body_end_seen || state.last_usage.is_some() {
+        return;
+    }
+    let sse = state.response_content_type.as_deref().is_some_and(|value| {
+        value
+            .split(';')
+            .any(|part| part.trim() == "text/event-stream")
+    });
+    if !sse {
+        return;
+    }
+    if let Some(hop) = state
+        .hops
+        .iter_mut()
+        .find(|hop| hop.hop == "upstream" && hop.outcome == "ok")
+    {
+        hop.outcome = "client_disconnect";
+        hop.ended_at = Utc::now().max(hop.started_at);
+    }
 }
 
 fn is_ai_processor(metadata: &MetadataMap) -> bool {
@@ -917,6 +1029,7 @@ fn ai_response(state: &mut AiExtProcState, request: ProcessingRequest) -> Proces
                 .or_else(|| header_value(&map, "Content-Type"))
                 .map(|value| value.to_ascii_lowercase());
             note_ai_upstream_response(state);
+            note_ai_missing_upstream(state);
             response_headers_response(CommonResponse {
                 status: common_response::ResponseStatus::Continue as i32,
                 ..Default::default()
@@ -948,6 +1061,9 @@ fn ai_response(state: &mut AiExtProcState, request: ProcessingRequest) -> Proces
             }
         }
         processing_request::Request::ResponseBody(body) => {
+            if body.end_of_stream {
+                state.response_body_end_seen = true;
+            }
             let mutation = ai_response_body_mutation(state, body.body, body.end_of_stream);
             if let Some(body) = mutation {
                 response_body_response(CommonResponse {
@@ -968,12 +1084,25 @@ fn ai_response(state: &mut AiExtProcState, request: ProcessingRequest) -> Proces
     }
 }
 
+/// Outcome of resolving the model header against the route's backends on the listener side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BackendEligibility {
+    /// Exactly one backend matches — the listener stream owns budget + credential hops.
+    Single(AiProviderId, i32),
+    /// Zero backends match: the materialized route serves the direct 400
+    /// `no_eligible_ai_backend` (design AC 11) — mark the `route_match` hop failed.
+    NoneEligible,
+    /// More than one backend matches (weighted cluster) or the spec was not resolvable;
+    /// selection and provider-side hops belong to the upstream stream.
+    Deferred,
+}
+
 async fn single_eligible_backend(
     pool: &sqlx::PgPool,
     team_id: TeamId,
     route_config_id: RouteConfigId,
     model: &str,
-) -> Result<Option<(AiProviderId, i32)>, DomainError> {
+) -> Result<BackendEligibility, DomainError> {
     let row = sqlx::query_scalar::<_, serde_json::Value>(
         "SELECT r.spec \
          FROM ai_routes r \
@@ -986,7 +1115,7 @@ async fn single_eligible_backend(
     .await
     .map_err(|err| DomainError::internal(format!("load AI route for backend selection: {err}")))?;
     let Some(spec) = row else {
-        return Ok(None);
+        return Ok(BackendEligibility::Deferred);
     };
     let spec: AiRouteSpec = serde_json::from_value(spec).map_err(|err| {
         DomainError::internal(format!("AI route spec in DB does not parse: {err}"))
@@ -995,12 +1124,12 @@ async fn single_eligible_backend(
         backend.models.is_empty() || backend.models.iter().any(|m| m == model)
     });
     let Some((idx, backend)) = eligible.next() else {
-        return Ok(None);
+        return Ok(BackendEligibility::NoneEligible);
     };
     if eligible.next().is_some() {
-        return Ok(None);
+        return Ok(BackendEligibility::Deferred);
     }
-    Ok(Some((backend.provider_id, idx as i32)))
+    Ok(BackendEligibility::Single(backend.provider_id, idx as i32))
 }
 
 async fn ai_request_headers_response(
@@ -1030,7 +1159,7 @@ async fn ai_request_headers_response(
                 budget_started,
                 "rejected",
                 true,
-                json!({"mode": "enforcing", "budget": name}),
+                json!({"mode": "enforcing", "verdict": budget_verdict(true, true), "budget": name}),
             );
             metrics::counter!(
                 "fp_ai_budget_threshold_crossings_total",
@@ -1045,13 +1174,10 @@ async fn ai_request_headers_response(
             );
         }
         Ok(None) => {
-            state.push_hop(
-                "budget",
-                budget_started,
-                "allowed",
-                false,
-                json!({"mode": "enforcing"}),
-            );
+            let detail =
+                budget_allowed_detail(pool, context.team_id, context.route_config_id, provider_id)
+                    .await;
+            state.push_hop("budget", budget_started, "allowed", false, detail);
         }
         Err(err) => {
             state.push_hop(
@@ -1116,13 +1242,20 @@ async fn ai_request_headers_response(
                 ..Default::default()
             })
         }
-        Err(_) => {
-            state.push_hop(
-                "credential_injection",
+        Err(failure) => {
+            tracing::debug!(
+                team = %context.team_id,
+                route_config = %context.route_config_id,
+                code = ?failure.status.code(),
+                "AI credential injection failed: {}",
+                failure.status.message()
+            );
+            push_credential_failure_hop(
+                state,
                 credential_started,
-                "unavailable",
-                true,
-                json!({"provider_id": provider_id, "backend_position": backend_position}),
+                provider_id,
+                backend_position,
+                &failure,
             );
             immediate_response(500, "AI provider credential unavailable".into())
         }
@@ -1192,8 +1325,16 @@ async fn ai_listener_request_headers_response(
     )
     .await
     {
-        Ok(Some(selected)) => selected,
-        Ok(None) => {
+        Ok(BackendEligibility::Single(provider_id, backend_position)) => {
+            (provider_id, backend_position)
+        }
+        Ok(BackendEligibility::NoneEligible) => {
+            // The materialized route serves the direct 400 no_eligible_ai_backend; the
+            // listener stream still closes and persists the row (design AC 11).
+            state.fail_hop("route_match", "no_eligible_backend");
+            return request_headers_response(remove_internal_model_header());
+        }
+        Ok(BackendEligibility::Deferred) => {
             return request_headers_response(remove_internal_model_header());
         }
         Err(err) => {
@@ -1217,7 +1358,7 @@ async fn ai_listener_request_headers_response(
                 budget_started,
                 "rejected",
                 true,
-                json!({"mode": "enforcing", "budget": name}),
+                json!({"mode": "enforcing", "verdict": budget_verdict(true, true), "budget": name}),
             );
             metrics::counter!(
                 "fp_ai_budget_threshold_crossings_total",
@@ -1232,13 +1373,10 @@ async fn ai_listener_request_headers_response(
             );
         }
         Ok(None) => {
-            state.push_hop(
-                "budget",
-                budget_started,
-                "allowed",
-                false,
-                json!({"mode": "enforcing"}),
-            );
+            let detail =
+                budget_allowed_detail(pool, context.team_id, context.route_config_id, provider_id)
+                    .await;
+            state.push_hop("budget", budget_started, "allowed", false, detail);
         }
         Err(err) => {
             state.push_hop(
@@ -1292,13 +1430,20 @@ async fn ai_listener_request_headers_response(
                 ..Default::default()
             })
         }
-        Err(_) => {
-            state.push_hop(
-                "credential_injection",
+        Err(failure) => {
+            tracing::debug!(
+                team = %context.team_id,
+                route_config = %context.route_config_id,
+                code = ?failure.status.code(),
+                "AI credential injection failed: {}",
+                failure.status.message()
+            );
+            push_credential_failure_hop(
+                state,
                 credential_started,
-                "unavailable",
-                true,
-                json!({"provider_id": provider_id, "backend_position": backend_position}),
+                provider_id,
+                backend_position,
+                &failure,
             );
             immediate_response(500, "AI provider credential unavailable".into())
         }
@@ -1313,6 +1458,27 @@ struct SelectedBackendRuntime {
     model_override: Option<String>,
 }
 
+/// Why credential injection could not produce an auth value. `outcome` is the trace hop
+/// enum (design hop table: `secret_missing` / `decrypt_failed`; `unavailable` for failures
+/// upstream of the secret itself); `auth_header` is the provider's auth header *name* when
+/// the provider row was resolved — never any credential material.
+#[derive(Debug)]
+struct CredentialFailure {
+    outcome: &'static str,
+    auth_header: Option<String>,
+    status: Status,
+}
+
+impl CredentialFailure {
+    fn unavailable(status: Status) -> Self {
+        Self {
+            outcome: "unavailable",
+            auth_header: None,
+            status,
+        }
+    }
+}
+
 async fn selected_backend_runtime(
     pool: &sqlx::PgPool,
     team_id: TeamId,
@@ -1320,7 +1486,7 @@ async fn selected_backend_runtime(
     provider_id: AiProviderId,
     backend_position: Option<i32>,
     request_path: Option<&str>,
-) -> Result<SelectedBackendRuntime, Status> {
+) -> Result<SelectedBackendRuntime, CredentialFailure> {
     let selected = ai::get_backend_for_route_config(
         pool,
         team_id,
@@ -1329,35 +1495,76 @@ async fn selected_backend_runtime(
         backend_position,
     )
     .await
-    .map_err(status_from_domain)?
-    .ok_or_else(|| Status::not_found("AI provider not found for route"))?;
+    .map_err(|err| CredentialFailure::unavailable(status_from_domain(err)))?
+    .ok_or_else(|| {
+        CredentialFailure::unavailable(Status::not_found("AI provider not found for route"))
+    })?;
     let provider = selected.provider;
+    let auth_header = provider.spec.auth_header;
     let encrypted =
         secrets::get_encrypted_secret_by_id(pool, team_id, provider.spec.credential_secret_id)
             .await
-            .map_err(status_from_domain)?
-            .ok_or_else(|| Status::not_found("AI provider credential not found"))?;
+            .map_err(|err| CredentialFailure::unavailable(status_from_domain(err)))?
+            .ok_or_else(|| CredentialFailure {
+                outcome: "secret_missing",
+                auth_header: Some(auth_header.clone()),
+                status: Status::not_found("AI provider credential not found"),
+            })?;
+    let decrypt_failed = |status: Status| CredentialFailure {
+        outcome: "decrypt_failed",
+        auth_header: Some(auth_header.clone()),
+        status,
+    };
     let spec = crate::snapshot::decrypt_secret_spec(
         &encrypted.ciphertext,
         &encrypted.nonce,
         &encrypted.metadata.encryption_key_id,
     )
-    .map_err(status_from_domain)?;
+    .map_err(|err| decrypt_failed(status_from_domain(err)))?;
     let SecretSpec::GenericSecret { secret } = spec else {
-        return Err(Status::failed_precondition(
+        return Err(decrypt_failed(Status::failed_precondition(
             "AI provider credential is not a generic secret",
-        ));
+        )));
     };
     let value = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, secret)
-        .map_err(|_| Status::failed_precondition("AI provider credential is invalid"))?;
-    let value = String::from_utf8(value)
-        .map_err(|_| Status::failed_precondition("AI provider credential is not UTF-8"))?;
+        .map_err(|_| {
+            decrypt_failed(Status::failed_precondition(
+                "AI provider credential is invalid",
+            ))
+        })?;
+    let value = String::from_utf8(value).map_err(|_| {
+        decrypt_failed(Status::failed_precondition(
+            "AI provider credential is not UTF-8",
+        ))
+    })?;
     Ok(SelectedBackendRuntime {
-        auth_header: provider.spec.auth_header,
+        auth_header,
         auth_value: value,
         path_rewrite: provider_path_rewrite(provider.spec.path_prefix.as_deref(), request_path),
         model_override: selected.backend.model_override,
     })
+}
+
+/// Record a failed `credential_injection` hop: outcome enum + auth header *name* only —
+/// structurally no credential value exists on this path (design AC 6 / hop table).
+fn push_credential_failure_hop(
+    state: &mut AiExtProcState,
+    started_at: DateTime<Utc>,
+    provider_id: AiProviderId,
+    backend_position: i32,
+    failure: &CredentialFailure,
+) {
+    state.push_hop(
+        "credential_injection",
+        started_at,
+        failure.outcome,
+        true,
+        json!({
+            "provider_id": provider_id,
+            "backend_position": backend_position,
+            "auth_header": failure.auth_header,
+        }),
+    );
 }
 
 fn provider_path_rewrite(path_prefix: Option<&str>, request_path: Option<&str>) -> Option<String> {
@@ -1513,6 +1720,30 @@ fn note_ai_upstream_response(state: &mut AiExtProcState) {
     });
     let outcome = if failed { "error" } else { "ok" };
     state.push_hop("upstream", started, outcome, failed, detail);
+}
+
+/// Envoy answers 503 locally when the upstream connection fails, and no upstream-side
+/// ExtProc stream ever opens — so the listener stream records the gap as
+/// `no_upstream_connection` (design Risk/failure map). If a provider really answered 503,
+/// the upstream stream's own hop exists and wins the row merge by origin.
+fn note_ai_missing_upstream(state: &mut AiExtProcState) {
+    if state.trace_origin() != "listener" {
+        return;
+    }
+    if state.response_status != Some(503) {
+        return;
+    }
+    if state.hops.iter().any(|hop| hop.hop == "upstream") {
+        return;
+    }
+    let at = Utc::now();
+    state.push_hop(
+        "upstream",
+        at,
+        "no_upstream_connection",
+        true,
+        json!({"status": 503}),
+    );
 }
 
 /// Persist this stream's trace contribution — strictly best-effort: runs after the HTTP
@@ -3316,5 +3547,546 @@ mod tests {
         };
         state.push_hop("auth", Utc::now(), "not_configured", false, json!({}));
         persist_ai_trace(&pool, &state, None).await;
+    }
+
+    // ---- Slice s3: failure-path rows and shadow-budget verdict ----
+
+    #[test]
+    fn budget_verdict_maps_enforcing_and_shadow_evaluation_results() {
+        assert_eq!(budget_verdict(true, true), "rejected");
+        assert_eq!(budget_verdict(false, true), "would_reject");
+        assert_eq!(budget_verdict(true, false), "allowed");
+        assert_eq!(budget_verdict(false, false), "allowed");
+    }
+
+    #[test]
+    fn shadow_budget_entries_record_would_reject_per_exhausted_budget() {
+        let entries = shadow_budget_entries(&[
+            ai::ShadowBudgetEvaluation {
+                name: "exhausted".into(),
+                used_units: 5,
+                limit_units: 5,
+            },
+            ai::ShadowBudgetEvaluation {
+                name: "headroom".into(),
+                used_units: 1,
+                limit_units: 5,
+            },
+        ]);
+        assert_eq!(entries[0]["budget"], "exhausted");
+        assert_eq!(entries[0]["verdict"], "would_reject");
+        assert_eq!(entries[0]["used_units"], 5);
+        assert_eq!(entries[0]["limit_units"], 5);
+        assert_eq!(entries[1]["budget"], "headroom");
+        assert_eq!(entries[1]["verdict"], "allowed");
+    }
+
+    #[test]
+    fn credential_failure_hop_maps_outcomes_and_carries_no_secret_material() {
+        let team_id = TeamId::from(Uuid::now_v7());
+        let provider_id = AiProviderId::from(Uuid::now_v7());
+        for (outcome, auth_header) in [
+            ("secret_missing", Some("authorization".to_string())),
+            ("decrypt_failed", Some("x-api-key".to_string())),
+            ("unavailable", None),
+        ] {
+            let mut state = AiExtProcState {
+                context: Some(upstream_trace_context(team_id)),
+                ..Default::default()
+            };
+            let failure = CredentialFailure {
+                outcome,
+                auth_header: auth_header.clone(),
+                status: Status::not_found("credential lookup failed"),
+            };
+            push_credential_failure_hop(&mut state, Utc::now(), provider_id, 0, &failure);
+            let hop = &state.hops[0];
+            assert_eq!(hop.hop, "credential_injection");
+            assert_eq!(hop.outcome, outcome);
+            assert!(hop.failed);
+            match &auth_header {
+                Some(name) => assert_eq!(hop.detail["auth_header"], json!(name)),
+                None => assert_eq!(hop.detail["auth_header"], Value::Null),
+            }
+            // The mapped hop carries ids and the header *name* only — structurally no
+            // credential value can appear (design AC 6 / hop table).
+            let keys: Vec<&str> = hop
+                .detail
+                .as_object()
+                .expect("detail object")
+                .keys()
+                .map(String::as_str)
+                .collect();
+            assert_eq!(keys, vec!["auth_header", "backend_position", "provider_id"]);
+        }
+    }
+
+    #[test]
+    fn fail_hop_reverdicts_route_match_for_no_eligible_backend() {
+        let team_id = TeamId::from(Uuid::now_v7());
+        let mut state = AiExtProcState {
+            context: Some(listener_trace_context(team_id)),
+            ..Default::default()
+        };
+        state.push_hop(
+            "route_match",
+            Utc::now(),
+            "matched",
+            false,
+            json!({"model": "gpt-5"}),
+        );
+        state.push_hop("auth", Utc::now(), "not_configured", false, json!({}));
+        state.fail_hop("route_match", "no_eligible_backend");
+        assert_eq!(state.hops[0].outcome, "no_eligible_backend");
+        assert!(state.hops[0].failed);
+        assert!(state.hops[0].started_at <= state.hops[0].ended_at);
+        assert!(!state.hops[1].failed, "only the named hop is re-verdicted");
+
+        // Unknown hop name is a no-op.
+        state.fail_hop("upstream", "no_upstream_connection");
+        assert_eq!(state.hops.len(), 2);
+    }
+
+    #[test]
+    fn missing_upstream_hop_marks_local_503_on_listener_stream_only() {
+        let team_id = TeamId::from(Uuid::now_v7());
+        let mut listener = AiExtProcState {
+            context: Some(listener_trace_context(team_id)),
+            response_status: Some(503),
+            ..Default::default()
+        };
+        note_ai_missing_upstream(&mut listener);
+        assert_eq!(listener.hops.len(), 1);
+        assert_eq!(listener.hops[0].hop, "upstream");
+        assert_eq!(listener.hops[0].outcome, "no_upstream_connection");
+        assert!(listener.hops[0].failed);
+        assert_eq!(listener.hops[0].detail["status"], 503);
+        // Idempotent: a second response-header phase does not duplicate the hop.
+        note_ai_missing_upstream(&mut listener);
+        assert_eq!(listener.hops.len(), 1);
+
+        let mut upstream = AiExtProcState {
+            context: Some(upstream_trace_context(team_id)),
+            response_status: Some(503),
+            ..Default::default()
+        };
+        note_ai_missing_upstream(&mut upstream);
+        assert!(
+            upstream.hops.is_empty(),
+            "the upstream stream records its own upstream hop; no provisional entry"
+        );
+
+        let mut ok = AiExtProcState {
+            context: Some(listener_trace_context(team_id)),
+            response_status: Some(200),
+            ..Default::default()
+        };
+        note_ai_missing_upstream(&mut ok);
+        assert!(
+            ok.hops.is_empty(),
+            "non-503 statuses are not connect failures"
+        );
+    }
+
+    #[test]
+    fn client_disconnect_rewrites_unfinished_sse_upstream_hop_only() {
+        let team_id = TeamId::from(Uuid::now_v7());
+        let disconnected = || AiExtProcState {
+            context: Some(upstream_trace_context(team_id)),
+            response_status: Some(200),
+            response_content_type: Some("text/event-stream".into()),
+            request_headers_at: Some(Utc::now()),
+            ..Default::default()
+        };
+
+        // Mid-SSE teardown: upstream hop was "ok" at response headers, body never finished.
+        let mut state = disconnected();
+        note_ai_upstream_response(&mut state);
+        note_ai_client_disconnect(&mut state);
+        assert_eq!(state.hops[0].hop, "upstream");
+        assert_eq!(state.hops[0].outcome, "client_disconnect");
+        assert!(
+            !state.hops[0].failed,
+            "client disconnect is not a gateway failure"
+        );
+
+        // Completed SSE stream: end_of_stream was seen, hop stays ok.
+        let mut complete = disconnected();
+        note_ai_upstream_response(&mut complete);
+        complete.response_body_end_seen = true;
+        note_ai_client_disconnect(&mut complete);
+        assert_eq!(complete.hops[0].outcome, "ok");
+
+        // Usage already extracted implies the stream effectively completed.
+        let mut settled = disconnected();
+        note_ai_upstream_response(&mut settled);
+        settled.last_usage = Some(OpenAiTokenUsage {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: 2,
+        });
+        note_ai_client_disconnect(&mut settled);
+        assert_eq!(settled.hops[0].outcome, "ok");
+
+        // Unary JSON responses are not rewritten.
+        let mut unary = disconnected();
+        unary.response_content_type = Some("application/json".into());
+        note_ai_upstream_response(&mut unary);
+        note_ai_client_disconnect(&mut unary);
+        assert_eq!(unary.hops[0].outcome, "ok");
+
+        // Listener stream never owns the upstream hop rewrite.
+        let mut listener = AiExtProcState {
+            context: Some(listener_trace_context(team_id)),
+            response_status: Some(200),
+            response_content_type: Some("text/event-stream".into()),
+            ..Default::default()
+        };
+        note_ai_client_disconnect(&mut listener);
+        assert!(listener.hops.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ai_budget_reject_stream_returns_429_and_persists_row_off_fast_path() {
+        let _guard = crate::snapshot::ENV_LOCK.lock().await;
+        let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+            eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+            return;
+        };
+        let pool = fp_storage::connect(&url, 4).await.expect("connect");
+        fp_storage::migrate(&pool).await.expect("migrate");
+        let org = identity::create_org(&pool, &format!("org-{}", Uuid::now_v7()), "")
+            .await
+            .expect("org");
+        let team = identity::create_team(&pool, org.id, &format!("team-{}", Uuid::now_v7()), "")
+            .await
+            .expect("team");
+
+        // Exhausted enforcing budget scoped to the whole team (NULL provider/route scope).
+        let budget_id = Uuid::now_v7();
+        sqlx::query(
+            "INSERT INTO ai_budgets \
+             (id, team_id, org_id, name, mode, limit_units, window_seconds, provider_id, route_config_id, prompt_token_weight, completion_token_weight) \
+             VALUES ($1, $2, $3, 'reject-stop', 'enforcing', 1, 3600, NULL, NULL, 1, 1)",
+        )
+        .bind(budget_id)
+        .bind(team.id.as_uuid())
+        .bind(org.id.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("budget");
+        sqlx::query(
+            "INSERT INTO ai_budget_counters (budget_id, team_id, window_start, used_units) \
+             VALUES ($1, $2, to_timestamp(floor(extract(epoch FROM now()) / 3600) * 3600), 5)",
+        )
+        .bind(budget_id)
+        .bind(team.id.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("counter");
+
+        let request_id = Uuid::now_v7().to_string();
+        let route_config_id = RouteConfigId::from(Uuid::now_v7());
+        let provider_id = AiProviderId::from(Uuid::now_v7());
+        let headers = ProcessingRequest {
+            request: Some(processing_request::Request::RequestHeaders(
+                envoy_types::pb::envoy::service::ext_proc::v3::HttpHeaders {
+                    headers: Some(HeaderMap {
+                        headers: vec![
+                            HeaderValue {
+                                key: ":path".into(),
+                                value: "/v1/chat/completions".into(),
+                                raw_value: Vec::new(),
+                            },
+                            HeaderValue {
+                                key: "x-request-id".into(),
+                                value: request_id.clone(),
+                                raw_value: Vec::new(),
+                            },
+                        ],
+                    }),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        // The production stream loop, driven by an in-memory message source.
+        let mut rx = ai_process_stream(
+            pool.clone(),
+            tokio_stream::iter(vec![Ok(headers)]),
+            Some(AiExtProcContext {
+                team_id: team.id,
+                listener_id: None,
+                route_config_id,
+                provider_id: Some(provider_id),
+                backend_position: Some(0),
+                failover_chain: Vec::new(),
+            }),
+        );
+
+        // The 429 is received before any row read is attempted — the write is spawned
+        // off this path, never awaited in front of the immediate response (Risk 1).
+        let response = rx.recv().await.expect("immediate response");
+        let processing_response::Response::ImmediateResponse(immediate) = response
+            .expect("response ok")
+            .response
+            .expect("response set")
+        else {
+            panic!("expected budget immediate response");
+        };
+        assert_eq!(immediate.status.expect("status").code, 429);
+        assert_eq!(immediate.details, "flowplane_ai_budget_exceeded");
+
+        let mut row: Option<fp_domain::AiTraceEvent> = None;
+        for _ in 0..50 {
+            let rows = fp_storage::repos::ai_trace::list_trace_events(
+                &pool,
+                team.id,
+                fp_storage::repos::ai_trace::AiTraceQuery {
+                    request_id: Some(&request_id),
+                    trace_id: None,
+                    limit: 10,
+                },
+            )
+            .await
+            .expect("list trace events");
+            if let Some(found) = rows.into_iter().next() {
+                row = Some(found);
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        let row = row.expect("budget-reject trace row was persisted");
+        assert_eq!(row.failure_hop.as_deref(), Some("budget"));
+        let hops = row.hops.as_array().expect("hops array");
+        let budget_hop = hops
+            .iter()
+            .find(|hop| hop["hop"] == "budget")
+            .expect("budget hop");
+        assert_eq!(budget_hop["outcome"], "rejected");
+        assert_eq!(budget_hop["detail"]["verdict"], "rejected");
+        assert_eq!(budget_hop["detail"]["budget"], "reject-stop");
+        assert!(
+            !hops
+                .iter()
+                .any(|hop| hop["hop"] == "credential_injection" || hop["hop"] == "upstream"),
+            "a budget-rejected request never reaches credential injection or the upstream: {hops:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ai_credential_failure_stream_persists_secret_missing_and_decrypt_failed_rows() {
+        let _guard = crate::snapshot::ENV_LOCK.lock().await;
+        let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+            eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+            return;
+        };
+        use base64::Engine as _;
+        let key = *b"12345678901234567890123456789012";
+        std::env::set_var("FLOWPLANE_SECRET_ENCRYPTION_KEY_ID", "default");
+        std::env::set_var(
+            "FLOWPLANE_SECRET_ENCRYPTION_KEY",
+            String::from_utf8_lossy(&key).to_string(),
+        );
+        let pool = fp_storage::connect(&url, 4).await.expect("connect");
+        fp_storage::migrate(&pool).await.expect("migrate");
+        let org = identity::create_org(&pool, &format!("org-{}", Uuid::now_v7()), "")
+            .await
+            .expect("org");
+        let team = identity::create_team(&pool, org.id, &format!("team-{}", Uuid::now_v7()), "")
+            .await
+            .expect("team");
+
+        // Two failing credential shapes: an expired secret row (the read path treats it
+        // as absent -> secret_missing) and garbage ciphertext (-> decrypt_failed).
+        let secret_value_marker = "fp-s3-credential-marker";
+        let expired_secret_id = Uuid::now_v7();
+        sqlx::query(
+            "INSERT INTO secrets \
+             (id, team_id, org_id, name, description, secret_type, configuration_encrypted, nonce, encryption_key_id, expires_at) \
+             VALUES ($1, $2, $3, 'expired-key', '', 'generic_secret', $4, $5, 'default', now() - interval '1 hour')",
+        )
+        .bind(expired_secret_id)
+        .bind(team.id.as_uuid())
+        .bind(org.id.as_uuid())
+        .bind(secret_value_marker.as_bytes().to_vec())
+        .bind(vec![1_u8; 12])
+        .execute(&pool)
+        .await
+        .expect("expired secret");
+        let garbage_secret_id = Uuid::now_v7();
+        sqlx::query(
+            "INSERT INTO secrets \
+             (id, team_id, org_id, name, description, secret_type, configuration_encrypted, nonce, encryption_key_id) \
+             VALUES ($1, $2, $3, 'garbage-key', '', 'generic_secret', $4, $5, 'default')",
+        )
+        .bind(garbage_secret_id)
+        .bind(team.id.as_uuid())
+        .bind(org.id.as_uuid())
+        .bind(base64::engine::general_purpose::STANDARD.decode("Z2FyYmFnZS1ub3QtYWVzZ2Nt").expect("bytes"))
+        .bind(vec![2_u8; 12])
+        .execute(&pool)
+        .await
+        .expect("garbage secret");
+
+        let missing_provider_id = Uuid::now_v7();
+        let garbage_provider_id = Uuid::now_v7();
+        for (provider_id, secret_id, name) in [
+            (missing_provider_id, expired_secret_id, "p-missing"),
+            (garbage_provider_id, garbage_secret_id, "p-garbage"),
+        ] {
+            sqlx::query(
+                "INSERT INTO ai_providers \
+                 (id, team_id, org_id, name, kind, base_url, path_prefix, credential_secret_id, auth_header) \
+                 VALUES ($1, $2, $3, $4, 'openai', 'https://api.openai.com', NULL, $5, 'authorization')",
+            )
+            .bind(provider_id)
+            .bind(team.id.as_uuid())
+            .bind(org.id.as_uuid())
+            .bind(name)
+            .bind(secret_id)
+            .execute(&pool)
+            .await
+            .expect("provider");
+        }
+        let route_config_id = Uuid::now_v7();
+        sqlx::query(
+            "INSERT INTO route_configs (id, team_id, org_id, name, spec) \
+             VALUES ($1, $2, $3, 'ai-s3-cred-routes', '{}'::jsonb)",
+        )
+        .bind(route_config_id)
+        .bind(team.id.as_uuid())
+        .bind(org.id.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("route config");
+        let route_id = Uuid::now_v7();
+        let route_spec = serde_json::json!({
+            "listener_port": 19200,
+            "path": "/v1/chat/completions",
+            "backends": [
+                {"provider_id": missing_provider_id, "models": [], "weight": 1, "priority": 0},
+                {"provider_id": garbage_provider_id, "models": [], "weight": 1, "priority": 0}
+            ]
+        });
+        sqlx::query(
+            "INSERT INTO ai_routes \
+             (id, team_id, org_id, name, spec, cluster_names, route_config_name, listener_name) \
+             VALUES ($1, $2, $3, 'ai-s3-cred-route', $4, ARRAY['ai-s3-cred-b1'], 'ai-s3-cred-routes', 'ai-s3-cred-listener')",
+        )
+        .bind(route_id)
+        .bind(team.id.as_uuid())
+        .bind(org.id.as_uuid())
+        .bind(route_spec)
+        .execute(&pool)
+        .await
+        .expect("ai route");
+        for (provider_id, position) in [(missing_provider_id, 0), (garbage_provider_id, 1)] {
+            sqlx::query(
+                "INSERT INTO ai_route_backends (ai_route_id, team_id, provider_id, position) \
+                 VALUES ($1, $2, $3, $4)",
+            )
+            .bind(route_id)
+            .bind(team.id.as_uuid())
+            .bind(provider_id)
+            .bind(position)
+            .execute(&pool)
+            .await
+            .expect("backend");
+        }
+
+        for (provider_id, position, expected_outcome) in [
+            (missing_provider_id, 0, "secret_missing"),
+            (garbage_provider_id, 1, "decrypt_failed"),
+        ] {
+            let request_id = Uuid::now_v7().to_string();
+            let headers = ProcessingRequest {
+                request: Some(processing_request::Request::RequestHeaders(
+                    envoy_types::pb::envoy::service::ext_proc::v3::HttpHeaders {
+                        headers: Some(HeaderMap {
+                            headers: vec![
+                                HeaderValue {
+                                    key: ":path".into(),
+                                    value: "/v1/chat/completions".into(),
+                                    raw_value: Vec::new(),
+                                },
+                                HeaderValue {
+                                    key: "x-request-id".into(),
+                                    value: request_id.clone(),
+                                    raw_value: Vec::new(),
+                                },
+                            ],
+                        }),
+                        ..Default::default()
+                    },
+                )),
+                ..Default::default()
+            };
+            let mut rx = ai_process_stream(
+                pool.clone(),
+                tokio_stream::iter(vec![Ok(headers)]),
+                Some(AiExtProcContext {
+                    team_id: team.id,
+                    listener_id: None,
+                    route_config_id: RouteConfigId::from(route_config_id),
+                    provider_id: Some(AiProviderId::from(provider_id)),
+                    backend_position: Some(position),
+                    failover_chain: Vec::new(),
+                }),
+            );
+            let response = rx.recv().await.expect("immediate response");
+            let processing_response::Response::ImmediateResponse(immediate) = response
+                .expect("response ok")
+                .response
+                .expect("response set")
+            else {
+                panic!("expected credential immediate response for {expected_outcome}");
+            };
+            assert_eq!(immediate.status.expect("status").code, 500);
+            assert_eq!(
+                String::from_utf8(immediate.body).expect("body"),
+                "AI provider credential unavailable",
+                "the client-visible immediate response is unchanged"
+            );
+
+            let mut row: Option<fp_domain::AiTraceEvent> = None;
+            for _ in 0..50 {
+                let rows = fp_storage::repos::ai_trace::list_trace_events(
+                    &pool,
+                    team.id,
+                    fp_storage::repos::ai_trace::AiTraceQuery {
+                        request_id: Some(&request_id),
+                        trace_id: None,
+                        limit: 10,
+                    },
+                )
+                .await
+                .expect("list trace events");
+                if let Some(found) = rows.into_iter().next() {
+                    row = Some(found);
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+            let row = row.expect("credential-failure trace row was persisted");
+            assert_eq!(row.failure_hop.as_deref(), Some("credential_injection"));
+            assert_eq!(row.provider_id, Some(AiProviderId::from(provider_id)));
+            let hops = row.hops.as_array().expect("hops array");
+            let credential_hop = hops
+                .iter()
+                .find(|hop| hop["hop"] == "credential_injection")
+                .expect("credential hop");
+            assert_eq!(credential_hop["outcome"], json!(expected_outcome));
+            assert_eq!(credential_hop["detail"]["auth_header"], "authorization");
+            assert!(
+                !hops.iter().any(|hop| hop["hop"] == "upstream"),
+                "no upstream hop on a credential-failure request: {hops:?}"
+            );
+            let row_text = serde_json::to_string(&row.hops).expect("hops json");
+            assert!(
+                !row_text.contains(secret_value_marker),
+                "credential material must never appear in the trace row"
+            );
+        }
     }
 }

--- a/crates/fp-xds/src/capture.rs
+++ b/crates/fp-xds/src/capture.rs
@@ -156,8 +156,20 @@ impl AiExtProcState {
         failed: bool,
         detail: Value,
     ) {
-        let ended_at = Utc::now().max(started_at);
         let origin = self.trace_origin();
+        self.push_hop_with_origin(hop, started_at, outcome, origin, failed, detail);
+    }
+
+    fn push_hop_with_origin(
+        &mut self,
+        hop: &'static str,
+        started_at: DateTime<Utc>,
+        outcome: &'static str,
+        origin: &'static str,
+        failed: bool,
+        detail: Value,
+    ) {
+        let ended_at = Utc::now().max(started_at);
         self.hops.push(TraceHop {
             hop,
             started_at,
@@ -1154,10 +1166,11 @@ async fn ai_request_headers_response(
     .await
     {
         Ok(Some(name)) => {
-            state.push_hop(
+            state.push_hop_with_origin(
                 "budget",
                 budget_started,
                 "rejected",
+                "listener",
                 true,
                 json!({"mode": "enforcing", "verdict": budget_verdict(true, true), "budget": name}),
             );
@@ -1167,7 +1180,8 @@ async fn ai_request_headers_response(
                 "result" => "exhausted"
             )
             .increment(1);
-            return immediate_response_with_details(
+            return ai_immediate_response_with_details(
+                state,
                 429,
                 format!("AI budget \"{name}\" exceeded"),
                 "flowplane_ai_budget_exceeded",
@@ -1180,15 +1194,16 @@ async fn ai_request_headers_response(
             state.push_hop("budget", budget_started, "allowed", false, detail);
         }
         Err(err) => {
-            state.push_hop(
+            state.push_hop_with_origin(
                 "budget",
                 budget_started,
                 "check_failed",
+                "listener",
                 true,
                 json!({"mode": "enforcing"}),
             );
             tracing::debug!(team = %context.team_id, route_config = %context.route_config_id, "failed to check AI budget: {}", err.message);
-            return immediate_response(500, "AI budget check unavailable".into());
+            return ai_immediate_response(state, 500, "AI budget check unavailable".into());
         }
     }
     let request_path = match request.request {
@@ -1250,14 +1265,15 @@ async fn ai_request_headers_response(
                 "AI credential injection failed: {}",
                 failure.status.message()
             );
-            push_credential_failure_hop(
+            push_credential_failure_hop_with_origin(
                 state,
                 credential_started,
                 provider_id,
                 backend_position,
+                "listener",
                 &failure,
             );
-            immediate_response(500, "AI provider credential unavailable".into())
+            ai_immediate_response(state, 500, "AI provider credential unavailable".into())
         }
     }
 }
@@ -1366,7 +1382,8 @@ async fn ai_listener_request_headers_response(
                 "result" => "exhausted"
             )
             .increment(1);
-            return immediate_response_with_details(
+            return ai_immediate_response_with_details(
+                state,
                 429,
                 format!("AI budget \"{name}\" exceeded"),
                 "flowplane_ai_budget_exceeded",
@@ -1387,7 +1404,7 @@ async fn ai_listener_request_headers_response(
                 json!({"mode": "enforcing"}),
             );
             tracing::debug!(team = %context.team_id, route_config = %context.route_config_id, "failed to check AI budget: {}", err.message);
-            return immediate_response(500, "AI budget check unavailable".into());
+            return ai_immediate_response(state, 500, "AI budget check unavailable".into());
         }
     }
     let credential_started = Utc::now();
@@ -1445,7 +1462,7 @@ async fn ai_listener_request_headers_response(
                 backend_position,
                 &failure,
             );
-            immediate_response(500, "AI provider credential unavailable".into())
+            ai_immediate_response(state, 500, "AI provider credential unavailable".into())
         }
     }
 }
@@ -1554,10 +1571,29 @@ fn push_credential_failure_hop(
     backend_position: i32,
     failure: &CredentialFailure,
 ) {
-    state.push_hop(
+    push_credential_failure_hop_with_origin(
+        state,
+        started_at,
+        provider_id,
+        backend_position,
+        state.trace_origin(),
+        failure,
+    );
+}
+
+fn push_credential_failure_hop_with_origin(
+    state: &mut AiExtProcState,
+    started_at: DateTime<Utc>,
+    provider_id: AiProviderId,
+    backend_position: i32,
+    origin: &'static str,
+    failure: &CredentialFailure,
+) {
+    state.push_hop_with_origin(
         "credential_injection",
         started_at,
         failure.outcome,
+        origin,
         true,
         json!({
             "provider_id": provider_id,
@@ -1759,6 +1795,10 @@ async fn persist_ai_trace(pool: &sqlx::PgPool, state: &AiExtProcState, settlemen
     };
     let is_upstream = state.trace_origin() == "upstream";
     let mut hops: Vec<Value> = state.hops.iter().map(TraceHop::to_json).collect();
+    let reached_upstream = state
+        .hops
+        .iter()
+        .any(|hop| hop.hop == "upstream" && hop.outcome != "no_upstream_connection");
     if is_upstream {
         if let Some(usage_hop) = synthesized_usage_hop(state, settlement) {
             hops.push(usage_hop.to_json());
@@ -1792,7 +1832,7 @@ async fn persist_ai_trace(pool: &sqlx::PgPool, state: &AiExtProcState, settlemen
         } else {
             state.model.clone()
         },
-        status_code: if is_upstream {
+        status_code: if reached_upstream {
             None
         } else {
             state.response_status
@@ -2063,6 +2103,24 @@ fn response_body_response(common: CommonResponse) -> ProcessingResponse {
 
 fn immediate_response(status: u32, message: String) -> ProcessingResponse {
     immediate_response_with_details(status, message, "flowplane_ai_request_invalid")
+}
+
+fn ai_immediate_response(
+    state: &mut AiExtProcState,
+    status: u32,
+    message: String,
+) -> ProcessingResponse {
+    ai_immediate_response_with_details(state, status, message, "flowplane_ai_request_invalid")
+}
+
+fn ai_immediate_response_with_details(
+    state: &mut AiExtProcState,
+    status: u32,
+    message: String,
+    details: &str,
+) -> ProcessingResponse {
+    state.response_status = Some(status as i32);
+    immediate_response_with_details(status, message, details)
 }
 
 fn immediate_response_with_details(
@@ -3660,6 +3718,55 @@ mod tests {
         persist_ai_trace(&pool, &state, None).await;
     }
 
+    #[tokio::test]
+    async fn ai_trace_listener_local_503_persists_status_with_synthetic_upstream_hop() {
+        let _guard = crate::snapshot::ENV_LOCK.lock().await;
+        let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+            eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+            return;
+        };
+        let pool = fp_storage::connect(&url, 4).await.expect("connect");
+        fp_storage::migrate(&pool).await.expect("migrate");
+        let org = identity::create_org(&pool, &format!("org-{}", Uuid::now_v7()), "")
+            .await
+            .expect("org");
+        let team = identity::create_team(&pool, org.id, &format!("team-{}", Uuid::now_v7()), "")
+            .await
+            .expect("team");
+
+        let request_id = Uuid::now_v7().to_string();
+        let mut state = AiExtProcState {
+            context: Some(listener_trace_context(team.id)),
+            request_id: Some(request_id.clone()),
+            response_status: Some(503),
+            ..Default::default()
+        };
+        note_ai_missing_upstream(&mut state);
+        persist_ai_trace(&pool, &state, None).await;
+
+        let rows = fp_storage::repos::ai_trace::list_trace_events(
+            &pool,
+            team.id,
+            fp_storage::repos::ai_trace::AiTraceQuery {
+                request_id: Some(&request_id),
+                trace_id: None,
+                limit: 10,
+            },
+        )
+        .await
+        .expect("list trace events");
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.status_code, Some(503));
+        assert_eq!(row.failure_hop.as_deref(), Some("upstream"));
+        let hops = row.hops.as_array().expect("hops array");
+        let upstream_hop = hops
+            .iter()
+            .find(|hop| hop["hop"] == "upstream")
+            .expect("synthetic upstream hop");
+        assert_eq!(upstream_hop["outcome"], "no_upstream_connection");
+    }
+
     // ---- Slice s3: failure-path rows and shadow-budget verdict ----
 
     #[test]
@@ -3730,6 +3837,30 @@ mod tests {
                 .collect();
             assert_eq!(keys, vec!["auth_header", "backend_position", "provider_id"]);
         }
+    }
+
+    #[test]
+    fn ai_immediate_response_stamps_trace_status_before_building_response() {
+        let mut state = AiExtProcState::default();
+        let response = ai_immediate_response_with_details(
+            &mut state,
+            429,
+            "AI budget \"hard-stop\" exceeded".into(),
+            "flowplane_ai_budget_exceeded",
+        );
+
+        assert_eq!(state.response_status, Some(429));
+        let processing_response::Response::ImmediateResponse(immediate) =
+            response.response.expect("immediate response")
+        else {
+            panic!("expected immediate response");
+        };
+        assert_eq!(immediate.status.expect("status").code, 429);
+        assert_eq!(immediate.details, "flowplane_ai_budget_exceeded");
+        assert_eq!(
+            String::from_utf8(immediate.body).expect("body"),
+            "AI budget \"hard-stop\" exceeded"
+        );
     }
 
     #[test]
@@ -3968,6 +4099,7 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
         let row = row.expect("budget-reject trace row was persisted");
+        assert_eq!(row.status_code, Some(429));
         assert_eq!(row.failure_hop.as_deref(), Some("budget"));
         let hops = row.hops.as_array().expect("hops array");
         let budget_hop = hops
@@ -3982,6 +4114,134 @@ mod tests {
                 .iter()
                 .any(|hop| hop["hop"] == "credential_injection" || hop["hop"] == "upstream"),
             "a budget-rejected request never reaches credential injection or the upstream: {hops:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ai_budget_check_unavailable_stream_returns_500_and_persists_status() {
+        let _guard = crate::snapshot::ENV_LOCK.lock().await;
+        let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+            eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+            return;
+        };
+        let setup_pool = fp_storage::connect(&url, 4).await.expect("connect");
+        fp_storage::migrate(&setup_pool).await.expect("migrate");
+        let org = identity::create_org(&setup_pool, &format!("org-{}", Uuid::now_v7()), "")
+            .await
+            .expect("org");
+        let team =
+            identity::create_team(&setup_pool, org.id, &format!("team-{}", Uuid::now_v7()), "")
+                .await
+                .expect("team");
+
+        let mut lock_tx = setup_pool.begin().await.expect("begin lock transaction");
+        // Shared external test DB resource: hold ai_budgets only until the 50ms
+        // statement_timeout below forces the budget-check error path.
+        sqlx::query("LOCK TABLE ai_budgets IN ACCESS EXCLUSIVE MODE")
+            .execute(&mut *lock_tx)
+            .await
+            .expect("lock budgets");
+
+        let timeout_pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(4)
+            .after_connect(|conn, _meta| {
+                Box::pin(async move {
+                    sqlx::query("SET statement_timeout = '50ms'")
+                        .execute(conn)
+                        .await?;
+                    Ok(())
+                })
+            })
+            .connect(&url)
+            .await
+            .expect("connect timeout pool");
+
+        let request_id = Uuid::now_v7().to_string();
+        let route_config_id = RouteConfigId::from(Uuid::now_v7());
+        let provider_id = AiProviderId::from(Uuid::now_v7());
+        let headers = ProcessingRequest {
+            request: Some(processing_request::Request::RequestHeaders(
+                envoy_types::pb::envoy::service::ext_proc::v3::HttpHeaders {
+                    headers: Some(HeaderMap {
+                        headers: vec![
+                            HeaderValue {
+                                key: ":path".into(),
+                                value: "/v1/chat/completions".into(),
+                                raw_value: Vec::new(),
+                            },
+                            HeaderValue {
+                                key: "x-request-id".into(),
+                                value: request_id.clone(),
+                                raw_value: Vec::new(),
+                            },
+                        ],
+                    }),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        let mut rx = ai_process_stream(
+            timeout_pool.clone(),
+            tokio_stream::iter(vec![Ok(headers)]),
+            Some(AiExtProcContext {
+                team_id: team.id,
+                listener_id: None,
+                route_config_id,
+                provider_id: Some(provider_id),
+                backend_position: Some(0),
+                failover_chain: Vec::new(),
+            }),
+        );
+
+        let response = rx.recv().await.expect("immediate response");
+        let processing_response::Response::ImmediateResponse(immediate) = response
+            .expect("response ok")
+            .response
+            .expect("response set")
+        else {
+            panic!("expected budget-check immediate response");
+        };
+        assert_eq!(immediate.status.expect("status").code, 500);
+        assert_eq!(
+            String::from_utf8(immediate.body).expect("body"),
+            "AI budget check unavailable"
+        );
+        lock_tx.rollback().await.expect("release budget table lock");
+
+        let mut row: Option<fp_domain::AiTraceEvent> = None;
+        for _ in 0..50 {
+            let rows = fp_storage::repos::ai_trace::list_trace_events(
+                &timeout_pool,
+                team.id,
+                fp_storage::repos::ai_trace::AiTraceQuery {
+                    request_id: Some(&request_id),
+                    trace_id: None,
+                    limit: 10,
+                },
+            )
+            .await
+            .expect("list trace events");
+            if let Some(found) = rows.into_iter().next() {
+                row = Some(found);
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        let row = row.expect("budget-check-failed trace row was persisted");
+        assert_eq!(row.status_code, Some(500));
+        assert_eq!(row.failure_hop.as_deref(), Some("budget"));
+        let hops = row.hops.as_array().expect("hops array");
+        let budget_hop = hops
+            .iter()
+            .find(|hop| hop["hop"] == "budget")
+            .expect("budget hop");
+        assert_eq!(budget_hop["outcome"], "check_failed");
+        assert!(
+            !hops
+                .iter()
+                .any(|hop| hop["hop"] == "credential_injection" || hop["hop"] == "upstream"),
+            "a budget-check failure never reaches credential injection or the upstream: {hops:?}"
         );
     }
 
@@ -4180,6 +4440,7 @@ mod tests {
                 tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             }
             let row = row.expect("credential-failure trace row was persisted");
+            assert_eq!(row.status_code, Some(500));
             assert_eq!(row.failure_hop.as_deref(), Some("credential_injection"));
             assert_eq!(row.provider_id, Some(AiProviderId::from(provider_id)));
             let hops = row.hops.as_array().expect("hops array");

--- a/crates/fp-xds/src/capture.rs
+++ b/crates/fp-xds/src/capture.rs
@@ -26,9 +26,9 @@ use fp_domain::api_lifecycle::ObservationIngest;
 use fp_domain::discovery::DiscoveryObservationProvenance;
 use fp_domain::{
     openai_usage_from_json, prepare_openai_chat_request, rewrite_openai_chat_request_model,
-    strip_synthetic_openai_usage_sse, AiProviderId, AiRouteSpec, ApiDefinitionId, CaptureSessionId,
-    DiscoverySessionId, DomainError, ListenerId, OpenAiTokenUsage, RouteConfigId, SecretSpec,
-    TeamId, AI_MODEL_HEADER,
+    strip_synthetic_openai_usage_sse, AiProviderId, AiRouteSpec, AiTraceEvent, ApiDefinitionId,
+    CaptureSessionId, DiscoverySessionId, DomainError, ListenerId, OpenAiTokenUsage, RouteConfigId,
+    SecretSpec, TeamId, AI_MODEL_HEADER,
 };
 use fp_storage::repos::{ai, ai_trace, api_lifecycle, discovery, identity, secrets};
 use serde_json::{json, Map, Value};
@@ -1760,28 +1760,8 @@ async fn persist_ai_trace(pool: &sqlx::PgPool, state: &AiExtProcState, settlemen
     let is_upstream = state.trace_origin() == "upstream";
     let mut hops: Vec<Value> = state.hops.iter().map(TraceHop::to_json).collect();
     if is_upstream {
-        if let Some(usage) = state.last_usage {
-            let now = Utc::now();
-            hops.push(
-                TraceHop {
-                    hop: "usage",
-                    started_at: now,
-                    ended_at: now,
-                    outcome: match settlement {
-                        Some(true) => "settled",
-                        Some(false) => "settle_failed",
-                        None => "extracted",
-                    },
-                    origin: "upstream",
-                    failed: false,
-                    detail: json!({
-                        "prompt_tokens": usage.prompt_tokens,
-                        "completion_tokens": usage.completion_tokens,
-                        "total_tokens": usage.total_tokens,
-                    }),
-                }
-                .to_json(),
-            );
+        if let Some(usage_hop) = synthesized_usage_hop(state, settlement) {
+            hops.push(usage_hop.to_json());
         }
     } else if let Some(model) = &state.model {
         // The model routing header may only be known after the request body was parsed;
@@ -1819,9 +1799,140 @@ async fn persist_ai_trace(pool: &sqlx::PgPool, state: &AiExtProcState, settlemen
         },
         hops: Value::Array(hops),
     };
-    if let Err(err) = ai_trace::upsert_trace_event(pool, &event).await {
-        metrics::counter!("fp_ai_trace_dropped_total", "reason" => "db").increment(1);
-        tracing::debug!(team = %context.team_id, route_config = %context.route_config_id, "failed to persist AI trace event: {}", err.message);
+    match ai_trace::upsert_trace_event(pool, &event).await {
+        Ok(outcome) => {
+            // The upsert's row lock serializes the request's stream writes, so exactly
+            // one of them observes the merged timeline flip to complete — that write
+            // emits the request's single span timeline, from the merged row.
+            if !ai_timeline_complete(&outcome.previous_hops)
+                && ai_timeline_complete(&outcome.event.hops)
+            {
+                emit_ai_trace_spans(&outcome.event);
+            }
+        }
+        Err(err) => {
+            metrics::counter!("fp_ai_trace_dropped_total", "reason" => "db").increment(1);
+            tracing::debug!(team = %context.team_id, route_config = %context.route_config_id, "failed to persist AI trace event: {}", err.message);
+        }
+    }
+}
+
+/// The `usage` hop only exists at persistence time: the upstream stream extracts token
+/// counts from the response body and the settlement verdict is known after
+/// `persist_ai_usage` — so it is synthesized here rather than pushed during the stream.
+/// It lands in the merged row's hops, which is also what the span channel reads, so both
+/// report the same timeline.
+fn synthesized_usage_hop(state: &AiExtProcState, settlement: Option<bool>) -> Option<TraceHop> {
+    if state.trace_origin() != "upstream" {
+        return None;
+    }
+    let usage = state.last_usage?;
+    let now = Utc::now();
+    Some(TraceHop {
+        hop: "usage",
+        started_at: now,
+        ended_at: now,
+        outcome: match settlement {
+            Some(true) => "settled",
+            Some(false) => "settle_failed",
+            None => "extracted",
+        },
+        origin: "upstream",
+        failed: false,
+        detail: json!({
+            "prompt_tokens": usage.prompt_tokens,
+            "completion_tokens": usage.completion_tokens,
+            "total_tokens": usage.total_tokens,
+        }),
+    })
+}
+
+/// Span target for the AI trace secondary channel, filterable via FLOWPLANE_LOG.
+const AI_TRACE_SPAN_TARGET: &str = "flowplane::ai_trace";
+
+/// Whether a merged hop timeline is the request's final shape. The listener stream always
+/// exists and owns `route_match`/`auth`, so a timeline without a listener-origin hop is
+/// still waiting for it; once the listener has contributed, the request is over either
+/// when some hop failed (it terminated locally or at the provider — the failure classes
+/// all record a `failed` hop: budget reject, credential failure, no-eligible-backend,
+/// `no_upstream_connection`, provider error) or when the upstream stream has merged its
+/// provider-side hops. A listener-only timeline with no failure means the upstream stream
+/// is still in flight. The one shape this never marks complete is a request torn down
+/// before its upstream stream ever opened or failed — best-effort channel, nothing emits.
+fn ai_timeline_complete(hops: &Value) -> bool {
+    let Some(hops) = hops.as_array() else {
+        return false;
+    };
+    fn origin(hop: &Value) -> &str {
+        hop.get("origin").and_then(Value::as_str).unwrap_or("")
+    }
+    let has_listener = hops.iter().any(|hop| origin(hop) == "listener");
+    let has_upstream = hops.iter().any(|hop| origin(hop) == "upstream");
+    let any_failed = hops
+        .iter()
+        .any(|hop| hop.get("failed").and_then(Value::as_bool).unwrap_or(false));
+    has_listener && (any_failed || has_upstream)
+}
+
+/// Emit the request's merged hop timeline as `tracing` spans — the design's best-effort
+/// secondary channel. Called from `persist_ai_trace` by exactly the write that completed
+/// the merged row, so one request yields one `ai_request` span carrying the full hop
+/// timeline across both ExtProc streams, never one partial tree per stream. Spans flow
+/// through the process-wide subscriber; the OTel layer installed at serve time exports
+/// them iff FLOWPLANE_OTLP_ENDPOINT is set. Purely observational: runs after the HTTP
+/// exchange completed and the primary DB row was persisted, and can affect neither. Hop
+/// wall-clock timing travels as span fields (`started_at`/`ended_at`/`duration_ms`)
+/// because `tracing` spans cannot be backdated; each hop span is parented under one
+/// per-request `ai_request` span.
+fn emit_ai_trace_spans(event: &AiTraceEvent) {
+    let Some(hops) = event.hops.as_array() else {
+        return;
+    };
+    if hops.is_empty() {
+        return;
+    }
+    let request_span = tracing::info_span!(
+        target: AI_TRACE_SPAN_TARGET,
+        "ai_request",
+        request_id = event.request_id.as_str(),
+        team_id = %event.team_id,
+        route_config_id = %event.route_config_id,
+        trace_id = event.trace_id.as_deref(),
+        model = event.model.as_deref(),
+        status_code = event.status_code,
+        failure_hop = event.failure_hop.as_deref(),
+    );
+    for hop in hops {
+        let text = |key: &str| hop.get(key).and_then(Value::as_str).unwrap_or("");
+        let name = text("hop");
+        let failed = hop.get("failed").and_then(Value::as_bool).unwrap_or(false);
+        let started_at = text("started_at");
+        let ended_at = text("ended_at");
+        let _hop_span = tracing::info_span!(
+            target: AI_TRACE_SPAN_TARGET,
+            parent: &request_span,
+            "ai_hop",
+            otel.name = name,
+            hop = name,
+            origin = text("origin"),
+            outcome = text("outcome"),
+            failed = failed,
+            started_at = started_at,
+            ended_at = ended_at,
+            duration_ms = hop_duration_ms(started_at, ended_at),
+        );
+    }
+}
+
+/// Millisecond width of a hop's `[started_at, ended_at]` window as stored in the row
+/// (RFC 3339 strings); 0 when either bound is missing or unparsable.
+fn hop_duration_ms(started_at: &str, ended_at: &str) -> i64 {
+    match (
+        DateTime::parse_from_rfc3339(started_at),
+        DateTime::parse_from_rfc3339(ended_at),
+    ) {
+        (Ok(started), Ok(ended)) => (ended - started).num_milliseconds(),
+        _ => 0,
     }
 }
 
@@ -4088,5 +4199,784 @@ mod tests {
                 "credential material must never appear in the trace row"
             );
         }
+    }
+
+    // ---- Slice s6: OTLP hop spans (secondary channel) ----
+
+    /// Test subscriber layer recording every new span's name, target, explicit parent,
+    /// and fields — enough to assert the `ai_request`/`ai_hop` hierarchy and payload.
+    #[derive(Clone, Default)]
+    struct SpanCapture {
+        spans: std::sync::Arc<std::sync::Mutex<Vec<CapturedSpan>>>,
+    }
+
+    #[derive(Debug, Clone)]
+    struct CapturedSpan {
+        id: u64,
+        parent: Option<u64>,
+        name: String,
+        target: String,
+        fields: Map<String, Value>,
+    }
+
+    impl SpanCapture {
+        fn spans(&self) -> Vec<CapturedSpan> {
+            self.spans.lock().expect("span capture lock").clone()
+        }
+    }
+
+    struct FieldVisitor<'a>(&'a mut Map<String, Value>);
+
+    impl tracing::field::Visit for FieldVisitor<'_> {
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            self.0
+                .insert(field.name().to_string(), Value::String(value.to_string()));
+        }
+
+        fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+            self.0.insert(field.name().to_string(), Value::Bool(value));
+        }
+
+        fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+            self.0.insert(field.name().to_string(), json!(value));
+        }
+
+        fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+            self.0.insert(field.name().to_string(), json!(value));
+        }
+
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            self.0.insert(
+                field.name().to_string(),
+                Value::String(format!("{value:?}")),
+            );
+        }
+    }
+
+    impl<S> tracing_subscriber::Layer<S> for SpanCapture
+    where
+        S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+    {
+        fn on_new_span(
+            &self,
+            attrs: &tracing::span::Attributes<'_>,
+            id: &tracing::span::Id,
+            ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let mut fields = Map::new();
+            attrs.record(&mut FieldVisitor(&mut fields));
+            let parent = attrs
+                .parent()
+                .cloned()
+                .or_else(|| ctx.current_span().id().cloned())
+                .map(|id| id.into_u64());
+            self.spans
+                .lock()
+                .expect("span capture lock")
+                .push(CapturedSpan {
+                    id: id.into_u64(),
+                    parent,
+                    name: attrs.metadata().name().to_string(),
+                    target: attrs.metadata().target().to_string(),
+                    fields,
+                });
+        }
+    }
+
+    #[test]
+    fn ai_timeline_complete_requires_listener_contribution_and_a_terminal_signal() {
+        let hop =
+            |origin: &str, failed: bool| json!({"hop": "x", "origin": origin, "failed": failed});
+        // Waiting shapes: nothing merged yet, upstream-only (the listener stream always
+        // exists and is still to contribute), listener-only with no failure (the upstream
+        // stream is still in flight).
+        assert!(!ai_timeline_complete(&json!([])));
+        assert!(!ai_timeline_complete(&Value::Null));
+        assert!(!ai_timeline_complete(&json!([hop("upstream", false)])));
+        assert!(!ai_timeline_complete(&json!([hop("listener", false)])));
+        // Terminal shapes: a failed hop (the request ended locally or at the provider),
+        // or both streams' contributions merged.
+        assert!(ai_timeline_complete(&json!([hop("listener", true)])));
+        assert!(ai_timeline_complete(&json!([
+            hop("listener", false),
+            hop("upstream", false)
+        ])));
+    }
+
+    /// The merged-row shape `emit_ai_trace_spans` reads: identity columns plus the hops
+    /// JSON exactly as `upsert_trace_event` returns them.
+    fn merged_trace_event(request_id: &str, hops: Value) -> AiTraceEvent {
+        AiTraceEvent {
+            id: Uuid::now_v7(),
+            team_id: TeamId::from(Uuid::now_v7()),
+            request_id: request_id.into(),
+            trace_id: Some("0af7651916cd43dd8448eb211c80319c".into()),
+            route_config_id: RouteConfigId::from(Uuid::now_v7()),
+            listener_id: None,
+            provider_id: None,
+            model: Some("gpt-5".into()),
+            status_code: Some(200),
+            failure_hop: None,
+            hops,
+            created_at: Utc::now(),
+            expires_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn ai_trace_spans_emit_the_merged_row_timeline_under_one_request_span() {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let hop = |name: &str, origin: &str, outcome: &str, failed: bool, second: u32| {
+            json!({
+                "hop": name,
+                "started_at": format!("2026-07-04T00:00:0{second}.000000Z"),
+                "ended_at": format!("2026-07-04T00:00:0{second}.250000Z"),
+                "outcome": outcome,
+                "origin": origin,
+                "failed": failed,
+                "detail": {},
+            })
+        };
+        let event = merged_trace_event(
+            "req-spans-ok",
+            json!([
+                hop("route_match", "listener", "matched", false, 0),
+                hop("auth", "listener", "not_configured", false, 1),
+                hop("budget", "upstream", "allowed", false, 2),
+                hop("credential_injection", "upstream", "injected", false, 3),
+                hop("upstream", "upstream", "ok", false, 4),
+                hop("usage", "upstream", "settled", false, 5),
+            ]),
+        );
+
+        let capture = SpanCapture::default();
+        tracing::subscriber::with_default(
+            tracing_subscriber::registry().with(capture.clone()),
+            || emit_ai_trace_spans(&event),
+        );
+
+        let spans = capture.spans();
+        let requests: Vec<&CapturedSpan> = spans
+            .iter()
+            .filter(|span| span.name == "ai_request")
+            .collect();
+        assert_eq!(requests.len(), 1, "exactly one per-request span");
+        let request = requests[0];
+        assert_eq!(request.target, AI_TRACE_SPAN_TARGET);
+        assert_eq!(request.parent, None);
+        assert_eq!(request.fields["request_id"], json!("req-spans-ok"));
+        assert_eq!(request.fields["status_code"], json!(200));
+        assert_eq!(request.fields["model"], json!("gpt-5"));
+        assert_eq!(
+            request.fields["trace_id"],
+            json!("0af7651916cd43dd8448eb211c80319c")
+        );
+        assert!(
+            !request.fields.contains_key("failure_hop"),
+            "no failure on the success shape"
+        );
+
+        let hop_spans: Vec<&CapturedSpan> =
+            spans.iter().filter(|span| span.name == "ai_hop").collect();
+        let names: Vec<&str> = hop_spans
+            .iter()
+            .map(|span| span.fields["hop"].as_str().expect("hop field"))
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                "route_match",
+                "auth",
+                "budget",
+                "credential_injection",
+                "upstream",
+                "usage"
+            ],
+            "the full merged timeline — listener- and upstream-side hops — in row order"
+        );
+        for hop in &hop_spans {
+            assert_eq!(
+                hop.parent,
+                Some(request.id),
+                "hop span {:?} must nest under the per-request span",
+                hop.fields.get("hop")
+            );
+            assert_eq!(hop.target, AI_TRACE_SPAN_TARGET);
+            assert_eq!(
+                hop.fields["otel.name"], hop.fields["hop"],
+                "exported span name follows the hop name"
+            );
+            assert_eq!(
+                hop.fields["duration_ms"],
+                json!(250),
+                "duration derives from the row's started_at/ended_at window"
+            );
+        }
+        let usage = hop_spans
+            .iter()
+            .find(|span| span.fields["hop"] == "usage")
+            .expect("usage hop span");
+        assert_eq!(usage.fields["outcome"], json!("settled"));
+        assert_eq!(usage.fields["failed"], json!(false));
+
+        // Guards: an empty or missing hop array emits nothing.
+        let quiet = SpanCapture::default();
+        tracing::subscriber::with_default(
+            tracing_subscriber::registry().with(quiet.clone()),
+            || {
+                emit_ai_trace_spans(&merged_trace_event("req-empty", json!([])));
+                emit_ai_trace_spans(&merged_trace_event("req-null", Value::Null));
+            },
+        );
+        assert!(quiet.spans().is_empty(), "no spans for an empty timeline");
+    }
+
+    #[test]
+    fn ai_trace_spans_reject_shape_marks_failed_hop_and_failure_hop_field() {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let stamp = "2026-07-04T00:00:00.000000Z";
+        let mut event = merged_trace_event(
+            "req-spans-reject",
+            json!([
+                {"hop": "route_match", "started_at": stamp, "ended_at": stamp, "outcome": "matched", "origin": "listener", "failed": false, "detail": {}},
+                {"hop": "auth", "started_at": stamp, "ended_at": stamp, "outcome": "not_configured", "origin": "listener", "failed": false, "detail": {}},
+                {"hop": "budget", "started_at": stamp, "ended_at": stamp, "outcome": "rejected", "origin": "upstream", "failed": true, "detail": {"mode": "enforcing"}},
+            ]),
+        );
+        event.trace_id = None;
+        event.model = None;
+        event.status_code = None;
+        event.failure_hop = Some("budget".into());
+
+        let capture = SpanCapture::default();
+        tracing::subscriber::with_default(
+            tracing_subscriber::registry().with(capture.clone()),
+            || emit_ai_trace_spans(&event),
+        );
+
+        let spans = capture.spans();
+        let request = spans
+            .iter()
+            .find(|span| span.name == "ai_request")
+            .expect("per-request span");
+        assert_eq!(request.fields["request_id"], json!("req-spans-reject"));
+        assert_eq!(request.fields["failure_hop"], json!("budget"));
+        assert!(
+            !request.fields.contains_key("status_code"),
+            "no response status was observed on the reject path"
+        );
+        let budget = spans
+            .iter()
+            .find(|span| span.name == "ai_hop" && span.fields["hop"] == "budget")
+            .expect("budget hop span");
+        assert_eq!(budget.parent, Some(request.id));
+        assert_eq!(budget.fields["outcome"], json!("rejected"));
+        assert_eq!(budget.fields["failed"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn ai_trace_success_two_stream_capture_emits_one_merged_span_timeline() {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let _guard = crate::snapshot::ENV_LOCK.lock().await;
+        let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+            eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+            return;
+        };
+        use aes_gcm::aead::Aead;
+        use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+        use base64::Engine as _;
+
+        let key = *b"12345678901234567890123456789012";
+        std::env::set_var("FLOWPLANE_SECRET_ENCRYPTION_KEY_ID", "default");
+        std::env::set_var(
+            "FLOWPLANE_SECRET_ENCRYPTION_KEY",
+            String::from_utf8_lossy(&key).to_string(),
+        );
+        let pool = fp_storage::connect(&url, 4).await.expect("connect");
+        fp_storage::migrate(&pool).await.expect("migrate");
+        let org = identity::create_org(&pool, &format!("org-{}", Uuid::now_v7()), "")
+            .await
+            .expect("org");
+        let team = identity::create_team(&pool, org.id, &format!("team-{}", Uuid::now_v7()), "")
+            .await
+            .expect("team");
+
+        let secret_value = "Bearer fp-span-secret-value";
+        let spec = SecretSpec::GenericSecret {
+            secret: base64::engine::general_purpose::STANDARD.encode(secret_value),
+        };
+        let plaintext = serde_json::to_vec(&spec).expect("secret json");
+        let nonce = [9_u8; 12];
+        let cipher = Aes256Gcm::new_from_slice(&key).expect("cipher");
+        let ciphertext = cipher
+            .encrypt(Nonce::from_slice(&nonce), plaintext.as_ref())
+            .expect("encrypt");
+
+        let secret_id = Uuid::now_v7();
+        let provider_id = Uuid::now_v7();
+        let route_id = Uuid::now_v7();
+        let route_config_id = Uuid::now_v7();
+        let listener_id = Uuid::now_v7();
+        sqlx::query(
+            "INSERT INTO secrets \
+             (id, team_id, org_id, name, description, secret_type, configuration_encrypted, nonce, encryption_key_id) \
+             VALUES ($1, $2, $3, 'ai-span-key', '', 'generic_secret', $4, $5, 'default')",
+        )
+        .bind(secret_id)
+        .bind(team.id.as_uuid())
+        .bind(org.id.as_uuid())
+        .bind(ciphertext)
+        .bind(nonce.to_vec())
+        .execute(&pool)
+        .await
+        .expect("secret");
+        sqlx::query(
+            "INSERT INTO ai_providers \
+             (id, team_id, org_id, name, kind, base_url, path_prefix, credential_secret_id, auth_header) \
+             VALUES ($1, $2, $3, 'openai-span', 'openai', 'https://api.openai.com', NULL, $4, 'authorization')",
+        )
+        .bind(provider_id)
+        .bind(team.id.as_uuid())
+        .bind(org.id.as_uuid())
+        .bind(secret_id)
+        .execute(&pool)
+        .await
+        .expect("provider");
+        sqlx::query(
+            "INSERT INTO route_configs (id, team_id, org_id, name, spec) \
+             VALUES ($1, $2, $3, 'ai-span-routes', '{}'::jsonb)",
+        )
+        .bind(route_config_id)
+        .bind(team.id.as_uuid())
+        .bind(org.id.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("route config");
+        let route_spec = serde_json::json!({
+            "listener_port": 19101,
+            "path": "/v1/chat/completions",
+            "backends": [{
+                "provider_id": provider_id,
+                "models": [],
+                "weight": 1,
+                "priority": 0
+            }]
+        });
+        sqlx::query(
+            "INSERT INTO ai_routes \
+             (id, team_id, org_id, name, spec, cluster_names, route_config_name, listener_name) \
+             VALUES ($1, $2, $3, 'ai-span-route', $4, ARRAY['ai-span-b1'], 'ai-span-routes', 'ai-span-listener')",
+        )
+        .bind(route_id)
+        .bind(team.id.as_uuid())
+        .bind(org.id.as_uuid())
+        .bind(route_spec)
+        .execute(&pool)
+        .await
+        .expect("ai route");
+        sqlx::query(
+            "INSERT INTO ai_route_backends (ai_route_id, team_id, provider_id, position) \
+             VALUES ($1, $2, $3, 0)",
+        )
+        .bind(route_id)
+        .bind(team.id.as_uuid())
+        .bind(provider_id)
+        .execute(&pool)
+        .await
+        .expect("backend");
+
+        let request_id = Uuid::now_v7().to_string();
+        let traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        let request_headers = || ProcessingRequest {
+            request: Some(processing_request::Request::RequestHeaders(
+                envoy_types::pb::envoy::service::ext_proc::v3::HttpHeaders {
+                    headers: Some(HeaderMap {
+                        headers: [
+                            (":path", "/v1/chat/completions"),
+                            ("x-request-id", request_id.as_str()),
+                            (AI_MODEL_HEADER, "gpt-5"),
+                            ("traceparent", traceparent),
+                        ]
+                        .into_iter()
+                        .map(|(key, value)| HeaderValue {
+                            key: key.into(),
+                            value: value.into(),
+                            raw_value: Vec::new(),
+                        })
+                        .collect(),
+                    }),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        let request_body = ProcessingRequest {
+            request: Some(processing_request::Request::RequestBody(
+                envoy_types::pb::envoy::service::ext_proc::v3::HttpBody {
+                    body: br#"{"model":"gpt-5","messages":[{"role":"user","content":"hi"}]}"#
+                        .to_vec(),
+                    end_of_stream: true,
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        let response_headers = || ProcessingRequest {
+            request: Some(processing_request::Request::ResponseHeaders(
+                envoy_types::pb::envoy::service::ext_proc::v3::HttpHeaders {
+                    headers: Some(HeaderMap {
+                        headers: vec![
+                            HeaderValue {
+                                key: ":status".into(),
+                                value: "200".into(),
+                                raw_value: Vec::new(),
+                            },
+                            HeaderValue {
+                                key: "content-type".into(),
+                                value: "application/json".into(),
+                                raw_value: Vec::new(),
+                            },
+                        ],
+                    }),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        let response_body = || {
+            ProcessingRequest {
+            request: Some(processing_request::Request::ResponseBody(
+                envoy_types::pb::envoy::service::ext_proc::v3::HttpBody {
+                    body: br#"{"choices":[],"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5}}"#.to_vec(),
+                    end_of_stream: true,
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        }
+        };
+
+        // Thread-scoped default subscriber: the current-thread runtime polls the
+        // production stream tasks on this thread, so their spans land in the capture.
+        let capture = SpanCapture::default();
+        let _subscriber_guard =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(capture.clone()));
+
+        // Listener-side stream first, driven through the production stream loop: it owns
+        // route_match/auth (and the single-backend budget/credential gates) plus the row
+        // identity columns, and persists at stream end.
+        let mut rx = ai_process_stream(
+            pool.clone(),
+            tokio_stream::iter(vec![
+                Ok(request_headers()),
+                Ok(request_body),
+                Ok(response_headers()),
+                Ok(response_body()),
+            ]),
+            Some(AiExtProcContext {
+                team_id: team.id,
+                listener_id: Some(ListenerId::from(listener_id)),
+                route_config_id: RouteConfigId::from(route_config_id),
+                provider_id: None,
+                backend_position: None,
+                failover_chain: Vec::new(),
+            }),
+        );
+        while rx.recv().await.is_some() {}
+        assert!(
+            !capture
+                .spans()
+                .iter()
+                .any(|span| span.target == AI_TRACE_SPAN_TARGET),
+            "no partial span tree while the upstream stream is still outstanding"
+        );
+
+        // Upstream-side stream completes the request: provider-side budget/credential
+        // hops, the upstream exchange, and usage settlement. Its stream-end persist is
+        // the write that completes the merged row, so it emits the one span timeline.
+        let mut rx = ai_process_stream(
+            pool.clone(),
+            tokio_stream::iter(vec![
+                Ok(request_headers()),
+                Ok(response_headers()),
+                Ok(response_body()),
+            ]),
+            Some(AiExtProcContext {
+                team_id: team.id,
+                listener_id: None,
+                route_config_id: RouteConfigId::from(route_config_id),
+                provider_id: Some(AiProviderId::from(provider_id)),
+                backend_position: Some(0),
+                failover_chain: Vec::new(),
+            }),
+        );
+        while rx.recv().await.is_some() {}
+
+        // Primary channel: exactly one merged row.
+        let rows = fp_storage::repos::ai_trace::list_trace_events(
+            &pool,
+            team.id,
+            fp_storage::repos::ai_trace::AiTraceQuery {
+                request_id: Some(&request_id),
+                trace_id: None,
+                limit: 10,
+            },
+        )
+        .await
+        .expect("list trace events");
+        assert_eq!(rows.len(), 1, "both streams merged into one trace row");
+        let row = &rows[0];
+        assert_eq!(row.status_code, Some(200));
+        assert_eq!(row.failure_hop, None);
+
+        // Secondary channel: one per-request span carrying the full merged timeline.
+        let spans = capture.spans();
+        let requests: Vec<&CapturedSpan> = spans
+            .iter()
+            .filter(|span| span.name == "ai_request")
+            .collect();
+        assert_eq!(
+            requests.len(),
+            1,
+            "one span timeline per request, not one per ExtProc stream"
+        );
+        let request = requests[0];
+        assert_eq!(request.fields["request_id"], json!(request_id));
+        assert_eq!(
+            request.fields["trace_id"],
+            json!("0af7651916cd43dd8448eb211c80319c")
+        );
+        assert_eq!(request.fields["model"], json!("gpt-5"));
+        assert_eq!(request.fields["status_code"], json!(200));
+        assert!(!request.fields.contains_key("failure_hop"));
+
+        let hop_spans: Vec<&CapturedSpan> =
+            spans.iter().filter(|span| span.name == "ai_hop").collect();
+        let names: Vec<&str> = hop_spans
+            .iter()
+            .map(|span| span.fields["hop"].as_str().expect("hop field"))
+            .collect();
+        for expected in [
+            "route_match",
+            "auth",
+            "budget",
+            "credential_injection",
+            "upstream",
+            "usage",
+        ] {
+            assert_eq!(
+                names.iter().filter(|name| **name == expected).count(),
+                1,
+                "expected exactly one {expected} hop span, got {names:?}"
+            );
+        }
+        for hop in &hop_spans {
+            assert_eq!(
+                hop.parent,
+                Some(request.id),
+                "hop span {:?} must nest under the per-request span",
+                hop.fields.get("hop")
+            );
+        }
+        let usage = hop_spans
+            .iter()
+            .find(|span| span.fields["hop"] == "usage")
+            .expect("usage hop span");
+        assert_eq!(usage.fields["outcome"], json!("settled"));
+
+        // The span timeline and the persisted row describe the same request, hop for hop.
+        let row_names: Vec<&str> = row
+            .hops
+            .as_array()
+            .expect("hops array")
+            .iter()
+            .map(|hop| hop["hop"].as_str().expect("hop name"))
+            .collect();
+        assert_eq!(
+            names, row_names,
+            "span timeline mirrors the merged row, in row order"
+        );
+    }
+
+    #[tokio::test]
+    async fn ai_budget_reject_two_stream_capture_emits_one_failed_span_timeline() {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let _guard = crate::snapshot::ENV_LOCK.lock().await;
+        let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+            eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+            return;
+        };
+        let pool = fp_storage::connect(&url, 4).await.expect("connect");
+        fp_storage::migrate(&pool).await.expect("migrate");
+        let org = identity::create_org(&pool, &format!("org-{}", Uuid::now_v7()), "")
+            .await
+            .expect("org");
+        let team = identity::create_team(&pool, org.id, &format!("team-{}", Uuid::now_v7()), "")
+            .await
+            .expect("team");
+
+        let budget_id = Uuid::now_v7();
+        sqlx::query(
+            "INSERT INTO ai_budgets \
+             (id, team_id, org_id, name, mode, limit_units, window_seconds, provider_id, route_config_id, prompt_token_weight, completion_token_weight) \
+             VALUES ($1, $2, $3, 'span-reject-stop', 'enforcing', 1, 3600, NULL, NULL, 1, 1)",
+        )
+        .bind(budget_id)
+        .bind(team.id.as_uuid())
+        .bind(org.id.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("budget");
+        sqlx::query(
+            "INSERT INTO ai_budget_counters (budget_id, team_id, window_start, used_units) \
+             VALUES ($1, $2, to_timestamp(floor(extract(epoch FROM now()) / 3600) * 3600), 5)",
+        )
+        .bind(budget_id)
+        .bind(team.id.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("counter");
+
+        let route_config_id = RouteConfigId::from(Uuid::now_v7());
+        let request_id = Uuid::now_v7().to_string();
+        let headers = || ProcessingRequest {
+            request: Some(processing_request::Request::RequestHeaders(
+                envoy_types::pb::envoy::service::ext_proc::v3::HttpHeaders {
+                    headers: Some(HeaderMap {
+                        headers: vec![
+                            HeaderValue {
+                                key: ":path".into(),
+                                value: "/v1/chat/completions".into(),
+                                raw_value: Vec::new(),
+                            },
+                            HeaderValue {
+                                key: "x-request-id".into(),
+                                value: request_id.clone(),
+                                raw_value: Vec::new(),
+                            },
+                        ],
+                    }),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+
+        // Thread-scoped default subscriber: the current-thread runtime polls the
+        // production stream tasks on this thread, so their spans land in the capture.
+        let capture = SpanCapture::default();
+        let _subscriber_guard =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(capture.clone()));
+
+        // Listener-side stream: records route_match/auth; the request is then rejected on
+        // the upstream side, so this stream closes with no response passthrough and its
+        // persist leaves the timeline incomplete — no spans yet.
+        let mut rx = ai_process_stream(
+            pool.clone(),
+            tokio_stream::iter(vec![Ok(headers())]),
+            Some(AiExtProcContext {
+                team_id: team.id,
+                listener_id: Some(ListenerId::from(Uuid::now_v7())),
+                route_config_id,
+                provider_id: None,
+                backend_position: None,
+                failover_chain: Vec::new(),
+            }),
+        );
+        while rx.recv().await.is_some() {}
+        assert!(
+            !capture
+                .spans()
+                .iter()
+                .any(|span| span.target == AI_TRACE_SPAN_TARGET),
+            "a listener-only timeline without a failure is not emitted"
+        );
+
+        // Upstream-side stream: the enforcing budget rejects with an immediate response.
+        let mut rx = ai_process_stream(
+            pool.clone(),
+            tokio_stream::iter(vec![Ok(headers())]),
+            Some(AiExtProcContext {
+                team_id: team.id,
+                listener_id: None,
+                route_config_id,
+                provider_id: Some(AiProviderId::from(Uuid::now_v7())),
+                backend_position: Some(0),
+                failover_chain: Vec::new(),
+            }),
+        );
+        let response = rx.recv().await.expect("immediate response");
+        assert!(matches!(
+            response.expect("response ok").response,
+            Some(processing_response::Response::ImmediateResponse(_))
+        ));
+        while rx.recv().await.is_some() {}
+
+        // The immediate-response path also persists a snapshot from a detached task; let
+        // it run to prove the transition rule never duplicates the span timeline.
+        for _ in 0..10 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        let rows = fp_storage::repos::ai_trace::list_trace_events(
+            &pool,
+            team.id,
+            fp_storage::repos::ai_trace::AiTraceQuery {
+                request_id: Some(&request_id),
+                trace_id: None,
+                limit: 10,
+            },
+        )
+        .await
+        .expect("list trace events");
+        assert_eq!(rows.len(), 1, "both streams merged into one trace row");
+        assert_eq!(rows[0].failure_hop.as_deref(), Some("budget"));
+
+        let spans = capture.spans();
+        let requests: Vec<&CapturedSpan> = spans
+            .iter()
+            .filter(|span| span.name == "ai_request")
+            .collect();
+        assert_eq!(
+            requests.len(),
+            1,
+            "the span timeline is emitted exactly once, by the write that completed the row"
+        );
+        let request = requests[0];
+        assert_eq!(
+            request.fields["request_id"],
+            json!(request_id),
+            "the span timeline and the DB row describe the same request"
+        );
+        assert_eq!(request.fields["failure_hop"], json!("budget"));
+        assert!(
+            !request.fields.contains_key("status_code"),
+            "no response status was observed on the reject path"
+        );
+
+        let hop_spans: Vec<&CapturedSpan> =
+            spans.iter().filter(|span| span.name == "ai_hop").collect();
+        let names: Vec<&str> = hop_spans
+            .iter()
+            .map(|span| span.fields["hop"].as_str().expect("hop field"))
+            .collect();
+        assert_eq!(
+            names,
+            vec!["route_match", "auth", "budget"],
+            "the full per-request timeline across both streams, not just the rejecting stream's hops"
+        );
+        for hop in &hop_spans {
+            assert_eq!(hop.parent, Some(request.id));
+        }
+        let budget_span = hop_spans
+            .iter()
+            .find(|span| span.fields["hop"] == "budget")
+            .expect("budget hop span");
+        assert_eq!(budget_span.fields["outcome"], json!("rejected"));
+        assert_eq!(budget_span.fields["failed"], json!(true));
     }
 }

--- a/crates/fp-xds/src/capture.rs
+++ b/crates/fp-xds/src/capture.rs
@@ -5,6 +5,7 @@
 //! tenancy, quota, merge, TTL, and counter rules to storage.
 
 use crate::ads::TeamResolver;
+use chrono::{DateTime, SecondsFormat, Utc};
 use envoy_types::pb::envoy::config::core::v3::{
     header_value_option, HeaderMap, HeaderValue, HeaderValueOption, RequestMethod,
 };
@@ -29,9 +30,8 @@ use fp_domain::{
     DiscoverySessionId, DomainError, ListenerId, OpenAiTokenUsage, RouteConfigId, SecretSpec,
     TeamId, AI_MODEL_HEADER,
 };
-use fp_storage::repos::{ai, api_lifecycle, discovery, identity, secrets};
-use serde_json::{Map, Value};
-use sqlx::types::chrono::Utc;
+use fp_storage::repos::{ai, ai_trace, api_lifecycle, discovery, identity, secrets};
+use serde_json::{json, Map, Value};
 use std::sync::Arc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::metadata::MetadataMap;
@@ -95,6 +95,89 @@ struct AiExtProcState {
     last_usage: Option<OpenAiTokenUsage>,
     upstream_model_override: Option<String>,
     request_path: Option<String>,
+    request_id: Option<String>,
+    trace_id: Option<String>,
+    model: Option<String>,
+    request_headers_at: Option<DateTime<Utc>>,
+    hops: Vec<TraceHop>,
+}
+
+/// One entry of the per-request hop timeline persisted into `ai_trace_events.hops`.
+/// `origin` and `failed` are merge/derivation mechanics for the storage upsert: origin
+/// decides the winner when both ExtProc streams record the same hop name, and `failed`
+/// feeds the order-independent `failure_hop` derivation. Never carries request/response
+/// bodies or credential values — `detail` holds ids, header *names*, and counters only.
+#[derive(Debug, Clone)]
+struct TraceHop {
+    hop: &'static str,
+    started_at: DateTime<Utc>,
+    ended_at: DateTime<Utc>,
+    outcome: &'static str,
+    origin: &'static str,
+    failed: bool,
+    detail: Value,
+}
+
+impl TraceHop {
+    fn to_json(&self) -> Value {
+        json!({
+            "hop": self.hop,
+            "started_at": self.started_at.to_rfc3339_opts(SecondsFormat::Micros, true),
+            "ended_at": self.ended_at.to_rfc3339_opts(SecondsFormat::Micros, true),
+            "outcome": self.outcome,
+            "origin": self.origin,
+            "failed": self.failed,
+            "detail": self.detail,
+        })
+    }
+}
+
+impl AiExtProcState {
+    /// Which side of the request this ExtProc stream is: the listener-side router stream
+    /// carries a listener id, the upstream-side provider stream carries provider metadata
+    /// (`ai_context` admits no other shapes).
+    fn trace_origin(&self) -> &'static str {
+        match &self.context {
+            Some(context)
+                if context.provider_id.is_some() || !context.failover_chain.is_empty() =>
+            {
+                "upstream"
+            }
+            _ => "listener",
+        }
+    }
+
+    fn push_hop(
+        &mut self,
+        hop: &'static str,
+        started_at: DateTime<Utc>,
+        outcome: &'static str,
+        failed: bool,
+        detail: Value,
+    ) {
+        let ended_at = Utc::now().max(started_at);
+        let origin = self.trace_origin();
+        self.hops.push(TraceHop {
+            hop,
+            started_at,
+            ended_at,
+            outcome,
+            origin,
+            failed,
+            detail,
+        });
+    }
+}
+
+/// Extract the 32-hex trace-id field from a W3C `traceparent` header value.
+fn traceparent_trace_id(value: &str) -> Option<String> {
+    let mut parts = value.split('-');
+    let _version = parts.next()?;
+    let trace_id = parts.next()?;
+    (trace_id.len() == 32
+        && trace_id.bytes().all(|b| b.is_ascii_hexdigit())
+        && trace_id.bytes().any(|b| b != b'0'))
+    .then(|| trace_id.to_ascii_lowercase())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -293,7 +376,8 @@ fn ai_process_stream(
                 }
             }
         }
-        persist_ai_usage(&pool, &state).await;
+        let settlement = persist_ai_usage(&pool, &state).await;
+        persist_ai_trace(&pool, &state, settlement).await;
     });
     rx
 }
@@ -761,6 +845,7 @@ async fn ai_response_with_pool(
     if let Some(processing_request::Request::RequestHeaders(headers)) = request.request.as_ref() {
         let map = headers_from_header_map(headers.headers.as_ref());
         state.request_path = header_value(&map, ":path");
+        note_ai_request_identity(state, &map);
         return ai_request_headers_response(pool, state, request).await;
     }
     if matches!(
@@ -775,6 +860,21 @@ async fn ai_response_with_pool(
         return ai_upstream_request_body_response(state, request);
     }
     ai_response(state, request)
+}
+
+/// Record the request-identity facts the trace row is keyed and correlated by: the
+/// server-owned `x-request-id` (post-HCM-mutation, so both streams observe the same value),
+/// the inbound `traceparent` trace-id when present, and the model routing hint.
+fn note_ai_request_identity(state: &mut AiExtProcState, map: &Map<String, Value>) {
+    state.request_headers_at = Some(Utc::now());
+    state.request_id = header_value(map, "x-request-id");
+    if state.trace_id.is_none() {
+        state.trace_id =
+            header_value(map, "traceparent").and_then(|value| traceparent_trace_id(&value));
+    }
+    if state.model.is_none() {
+        state.model = header_value(map, AI_MODEL_HEADER);
+    }
 }
 
 fn ai_upstream_request_body_response(
@@ -816,6 +916,7 @@ fn ai_response(state: &mut AiExtProcState, request: ProcessingRequest) -> Proces
             state.response_content_type = header_value(&map, "content-type")
                 .or_else(|| header_value(&map, "Content-Type"))
                 .map(|value| value.to_ascii_lowercase());
+            note_ai_upstream_response(state);
             response_headers_response(CommonResponse {
                 status: common_response::ResponseStatus::Continue as i32,
                 ..Default::default()
@@ -825,6 +926,7 @@ fn ai_response(state: &mut AiExtProcState, request: ProcessingRequest) -> Proces
             match prepare_openai_chat_request(&body.body) {
                 Ok(prepared) => {
                     state.include_usage_injected = prepared.include_usage_injected;
+                    state.model = Some(prepared.model.clone());
                     let mut common = CommonResponse {
                         status: common_response::ResponseStatus::Continue as i32,
                         header_mutation: Some(HeaderMutation {
@@ -913,6 +1015,7 @@ async fn ai_request_headers_response(
     else {
         return ai_listener_request_headers_response(pool, state, request, context).await;
     };
+    let budget_started = Utc::now();
     match ai::exhausted_enforcing_budget(
         pool,
         context.team_id,
@@ -922,6 +1025,13 @@ async fn ai_request_headers_response(
     .await
     {
         Ok(Some(name)) => {
+            state.push_hop(
+                "budget",
+                budget_started,
+                "rejected",
+                true,
+                json!({"mode": "enforcing", "budget": name}),
+            );
             metrics::counter!(
                 "fp_ai_budget_threshold_crossings_total",
                 "mode" => "enforcing",
@@ -934,8 +1044,23 @@ async fn ai_request_headers_response(
                 "flowplane_ai_budget_exceeded",
             );
         }
-        Ok(None) => {}
+        Ok(None) => {
+            state.push_hop(
+                "budget",
+                budget_started,
+                "allowed",
+                false,
+                json!({"mode": "enforcing"}),
+            );
+        }
         Err(err) => {
+            state.push_hop(
+                "budget",
+                budget_started,
+                "check_failed",
+                true,
+                json!({"mode": "enforcing"}),
+            );
             tracing::debug!(team = %context.team_id, route_config = %context.route_config_id, "failed to check AI budget: {}", err.message);
             return immediate_response(500, "AI budget check unavailable".into());
         }
@@ -947,6 +1072,7 @@ async fn ai_request_headers_response(
         }
         _ => None,
     };
+    let credential_started = Utc::now();
     match selected_backend_runtime(
         pool,
         context.team_id,
@@ -962,6 +1088,17 @@ async fn ai_request_headers_response(
                 state_context.provider_id = Some(provider_id);
                 state_context.backend_position = Some(backend_position);
             }
+            state.push_hop(
+                "credential_injection",
+                credential_started,
+                "injected",
+                false,
+                json!({
+                    "provider_id": provider_id,
+                    "backend_position": backend_position,
+                    "auth_header": runtime.auth_header.clone(),
+                }),
+            );
             state.upstream_model_override = runtime.model_override;
             let mut set_headers = vec![mutation_header_value(
                 runtime.auth_header,
@@ -979,7 +1116,16 @@ async fn ai_request_headers_response(
                 ..Default::default()
             })
         }
-        Err(_) => immediate_response(500, "AI provider credential unavailable".into()),
+        Err(_) => {
+            state.push_hop(
+                "credential_injection",
+                credential_started,
+                "unavailable",
+                true,
+                json!({"provider_id": provider_id, "backend_position": backend_position}),
+            );
+            immediate_response(500, "AI provider credential unavailable".into())
+        }
     }
 }
 
@@ -1016,6 +1162,18 @@ async fn ai_listener_request_headers_response(
     request: ProcessingRequest,
     context: AiExtProcContext,
 ) -> ProcessingResponse {
+    // Listener-side hops: the request reached the AI listener and its route/team identity
+    // was reconstructed from CP-attached gRPC metadata; no per-request authn filter runs on
+    // AI listeners today, so the auth hop truthfully records `not_configured`.
+    let route_started = state.request_headers_at.unwrap_or_else(Utc::now);
+    let route_detail = json!({
+        "listener_id": context.listener_id,
+        "route_config_id": context.route_config_id,
+        "model": state.model.clone(),
+    });
+    state.push_hop("route_match", route_started, "matched", false, route_detail);
+    let auth_at = Utc::now();
+    state.push_hop("auth", auth_at, "not_configured", false, json!({}));
     let request_model = match request.request {
         Some(processing_request::Request::RequestHeaders(headers)) => {
             let map = headers_from_header_map(headers.headers.as_ref());
@@ -1044,6 +1202,7 @@ async fn ai_listener_request_headers_response(
         }
     };
     let (provider_id, backend_position) = selected;
+    let budget_started = Utc::now();
     match ai::exhausted_enforcing_budget(
         pool,
         context.team_id,
@@ -1053,6 +1212,13 @@ async fn ai_listener_request_headers_response(
     .await
     {
         Ok(Some(name)) => {
+            state.push_hop(
+                "budget",
+                budget_started,
+                "rejected",
+                true,
+                json!({"mode": "enforcing", "budget": name}),
+            );
             metrics::counter!(
                 "fp_ai_budget_threshold_crossings_total",
                 "mode" => "enforcing",
@@ -1065,12 +1231,28 @@ async fn ai_listener_request_headers_response(
                 "flowplane_ai_budget_exceeded",
             );
         }
-        Ok(None) => {}
+        Ok(None) => {
+            state.push_hop(
+                "budget",
+                budget_started,
+                "allowed",
+                false,
+                json!({"mode": "enforcing"}),
+            );
+        }
         Err(err) => {
+            state.push_hop(
+                "budget",
+                budget_started,
+                "check_failed",
+                true,
+                json!({"mode": "enforcing"}),
+            );
             tracing::debug!(team = %context.team_id, route_config = %context.route_config_id, "failed to check AI budget: {}", err.message);
             return immediate_response(500, "AI budget check unavailable".into());
         }
     }
+    let credential_started = Utc::now();
     match selected_backend_runtime(
         pool,
         context.team_id,
@@ -1082,6 +1264,17 @@ async fn ai_listener_request_headers_response(
     .await
     {
         Ok(runtime) => {
+            state.push_hop(
+                "credential_injection",
+                credential_started,
+                "injected",
+                false,
+                json!({
+                    "provider_id": provider_id,
+                    "backend_position": backend_position,
+                    "auth_header": runtime.auth_header.clone(),
+                }),
+            );
             state.upstream_model_override = runtime.model_override;
             let mut set_headers = vec![mutation_header_value(
                 runtime.auth_header,
@@ -1099,7 +1292,16 @@ async fn ai_listener_request_headers_response(
                 ..Default::default()
             })
         }
-        Err(_) => immediate_response(500, "AI provider credential unavailable".into()),
+        Err(_) => {
+            state.push_hop(
+                "credential_injection",
+                credential_started,
+                "unavailable",
+                true,
+                json!({"provider_id": provider_id, "backend_position": backend_position}),
+            );
+            immediate_response(500, "AI provider credential unavailable".into())
+        }
     }
 }
 
@@ -1265,14 +1467,15 @@ fn remember_ai_usage(state: &mut AiExtProcState, usage: OpenAiTokenUsage) {
     state.last_usage = Some(usage);
 }
 
-async fn persist_ai_usage(pool: &sqlx::PgPool, state: &AiExtProcState) {
+/// Persist token usage and settle budgets. Returns `Some(true)` when the usage event was
+/// recorded and settled, `Some(false)` when persistence failed, and `None` when this stream
+/// had no attributable usage to persist — feeds the trace `usage` hop's settlement outcome.
+async fn persist_ai_usage(pool: &sqlx::PgPool, state: &AiExtProcState) -> Option<bool> {
     let (Some(context), Some(usage)) = (&state.context, state.last_usage) else {
-        return;
+        return None;
     };
-    let Some(provider_id) = context.provider_id else {
-        return;
-    };
-    if let Err(err) = ai::record_usage_event_and_settle_budgets(
+    let provider_id = context.provider_id?;
+    match ai::record_usage_event_and_settle_budgets(
         pool,
         ai::AiUsageEventInsert {
             team_id: context.team_id,
@@ -1284,7 +1487,110 @@ async fn persist_ai_usage(pool: &sqlx::PgPool, state: &AiExtProcState) {
     )
     .await
     {
-        tracing::debug!(team = %context.team_id, route_config = %context.route_config_id, "failed to persist AI usage: {}", err.message);
+        Ok(()) => Some(true),
+        Err(err) => {
+            tracing::debug!(team = %context.team_id, route_config = %context.route_config_id, "failed to persist AI usage: {}", err.message);
+            Some(false)
+        }
+    }
+}
+
+/// Close the `upstream` hop when the upstream-side stream observes response headers. The
+/// listener-side stream records the final status in the row's top-level `status_code`
+/// column instead, so the hop stays owned by exactly one origin.
+fn note_ai_upstream_response(state: &mut AiExtProcState) {
+    if state.trace_origin() != "upstream" {
+        return;
+    }
+    let started = state.request_headers_at.unwrap_or_else(Utc::now);
+    let status = state.response_status;
+    let failed = status.is_none_or(|status| status >= 400);
+    let detail = json!({
+        "provider_id": state.context.as_ref().and_then(|context| context.provider_id),
+        "backend_position": state.context.as_ref().and_then(|context| context.backend_position),
+        "status": status,
+        "latency_ms": (Utc::now() - started).num_milliseconds(),
+    });
+    let outcome = if failed { "error" } else { "ok" };
+    state.push_hop("upstream", started, outcome, failed, detail);
+}
+
+/// Persist this stream's trace contribution — strictly best-effort: runs after the HTTP
+/// exchange has already completed (the ExtProc stream is closed), and any error is logged
+/// and counted, never surfaced. The listener stream owns the row identity columns; the
+/// upstream stream merges provider-side hops into the same `(team_id, request_id)` row.
+async fn persist_ai_trace(pool: &sqlx::PgPool, state: &AiExtProcState, settlement: Option<bool>) {
+    let Some(context) = &state.context else {
+        return;
+    };
+    let Some(request_id) = state.request_id.clone() else {
+        return;
+    };
+    let is_upstream = state.trace_origin() == "upstream";
+    let mut hops: Vec<Value> = state.hops.iter().map(TraceHop::to_json).collect();
+    if is_upstream {
+        if let Some(usage) = state.last_usage {
+            let now = Utc::now();
+            hops.push(
+                TraceHop {
+                    hop: "usage",
+                    started_at: now,
+                    ended_at: now,
+                    outcome: match settlement {
+                        Some(true) => "settled",
+                        Some(false) => "settle_failed",
+                        None => "extracted",
+                    },
+                    origin: "upstream",
+                    failed: false,
+                    detail: json!({
+                        "prompt_tokens": usage.prompt_tokens,
+                        "completion_tokens": usage.completion_tokens,
+                        "total_tokens": usage.total_tokens,
+                    }),
+                }
+                .to_json(),
+            );
+        }
+    } else if let Some(model) = &state.model {
+        // The model routing header may only be known after the request body was parsed;
+        // backfill the route_match hop detail recorded at header time.
+        for hop in &mut hops {
+            if hop.get("hop").and_then(Value::as_str) == Some("route_match") {
+                if let Some(detail) = hop.get_mut("detail") {
+                    if detail.get("model").is_none_or(Value::is_null) {
+                        detail["model"] = Value::String(model.clone());
+                    }
+                }
+            }
+        }
+    }
+    let event = ai_trace::AiTraceEventUpsert {
+        team_id: context.team_id,
+        request_id,
+        trace_id: if is_upstream {
+            None
+        } else {
+            state.trace_id.clone()
+        },
+        route_config_id: context.route_config_id,
+        listener_id: context.listener_id,
+        provider_id: context.provider_id,
+        model: if is_upstream {
+            None
+        } else {
+            state.model.clone()
+        },
+        status_code: if is_upstream {
+            None
+        } else {
+            state.response_status
+        },
+        hops: Value::Array(hops),
+    };
+    if let Err(err) = ai_trace::upsert_trace_event(pool, &event).await {
+        metrics::counter!("fp_ai_trace_dropped_total", "reason" => "db").increment(1);
+        tracing::debug!(team = %context.team_id, route_config = %context.route_config_id, "failed to persist AI trace event: {}", err.message);
     }
 }
 
@@ -2432,5 +2738,583 @@ mod tests {
             body_mutation::Mutation::Body(body) => Some(body),
             _ => None,
         }
+    }
+
+    fn header_map(pairs: &[(&str, &str)]) -> Map<String, Value> {
+        pairs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), Value::String((*value).to_string())))
+            .collect()
+    }
+
+    fn listener_trace_context(team_id: TeamId) -> AiExtProcContext {
+        AiExtProcContext {
+            team_id,
+            listener_id: Some(ListenerId::from(Uuid::now_v7())),
+            route_config_id: RouteConfigId::from(Uuid::now_v7()),
+            provider_id: None,
+            backend_position: None,
+            failover_chain: Vec::new(),
+        }
+    }
+
+    fn upstream_trace_context(team_id: TeamId) -> AiExtProcContext {
+        AiExtProcContext {
+            team_id,
+            listener_id: None,
+            route_config_id: RouteConfigId::from(Uuid::now_v7()),
+            provider_id: Some(AiProviderId::from(Uuid::now_v7())),
+            backend_position: Some(0),
+            failover_chain: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn traceparent_trace_id_extracts_valid_ids_only() {
+        assert_eq!(
+            traceparent_trace_id("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+                .as_deref(),
+            Some("0af7651916cd43dd8448eb211c80319c")
+        );
+        assert_eq!(
+            traceparent_trace_id("00-0AF7651916CD43DD8448EB211C80319C-b7ad6b7169203331-01")
+                .as_deref(),
+            Some("0af7651916cd43dd8448eb211c80319c"),
+            "trace id is normalized to lowercase"
+        );
+        assert_eq!(traceparent_trace_id("not-a-traceparent"), None);
+        assert_eq!(
+            traceparent_trace_id("00-00000000000000000000000000000000-b7ad6b7169203331-01"),
+            None,
+            "all-zero trace id is invalid per W3C"
+        );
+        assert_eq!(traceparent_trace_id("00-shorttrace-b7ad-01"), None);
+    }
+
+    #[test]
+    fn note_ai_request_identity_captures_request_id_trace_id_and_model() {
+        let mut state = AiExtProcState::default();
+        note_ai_request_identity(
+            &mut state,
+            &header_map(&[
+                ("x-request-id", "req-abc"),
+                (
+                    "traceparent",
+                    "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+                ),
+                (AI_MODEL_HEADER, "gpt-5"),
+            ]),
+        );
+        assert_eq!(state.request_id.as_deref(), Some("req-abc"));
+        assert_eq!(
+            state.trace_id.as_deref(),
+            Some("0af7651916cd43dd8448eb211c80319c")
+        );
+        assert_eq!(state.model.as_deref(), Some("gpt-5"));
+        assert!(state.request_headers_at.is_some());
+
+        let mut bare = AiExtProcState::default();
+        note_ai_request_identity(&mut bare, &header_map(&[("x-request-id", "req-xyz")]));
+        assert_eq!(
+            bare.trace_id, None,
+            "absent traceparent leaves trace_id unset"
+        );
+        assert_eq!(bare.model, None);
+    }
+
+    #[test]
+    fn push_hop_stamps_origin_and_monotonic_hop_window() {
+        let team_id = TeamId::from(Uuid::now_v7());
+        let mut listener = AiExtProcState {
+            context: Some(listener_trace_context(team_id)),
+            ..Default::default()
+        };
+        let started = Utc::now();
+        listener.push_hop("auth", started, "not_configured", false, json!({}));
+        assert_eq!(listener.hops.len(), 1);
+        let hop = &listener.hops[0];
+        assert_eq!(hop.hop, "auth");
+        assert_eq!(hop.origin, "listener");
+        assert!(!hop.failed);
+        assert!(hop.started_at <= hop.ended_at);
+
+        let mut upstream = AiExtProcState {
+            context: Some(upstream_trace_context(team_id)),
+            ..Default::default()
+        };
+        upstream.push_hop("budget", Utc::now(), "rejected", true, json!({}));
+        assert_eq!(upstream.hops[0].origin, "upstream");
+        assert!(upstream.hops[0].failed);
+
+        let serialized = upstream.hops[0].to_json();
+        assert_eq!(serialized["hop"], "budget");
+        assert_eq!(serialized["outcome"], "rejected");
+        assert_eq!(serialized["origin"], "upstream");
+        assert_eq!(serialized["failed"], true);
+        assert!(
+            serialized["started_at"].as_str().unwrap() <= serialized["ended_at"].as_str().unwrap()
+        );
+    }
+
+    #[test]
+    fn upstream_response_hop_maps_status_to_outcome_and_skips_listener_stream() {
+        let team_id = TeamId::from(Uuid::now_v7());
+        let mut ok = AiExtProcState {
+            context: Some(upstream_trace_context(team_id)),
+            response_status: Some(200),
+            request_headers_at: Some(Utc::now()),
+            ..Default::default()
+        };
+        note_ai_upstream_response(&mut ok);
+        assert_eq!(ok.hops.len(), 1);
+        assert_eq!(ok.hops[0].hop, "upstream");
+        assert_eq!(ok.hops[0].outcome, "ok");
+        assert!(!ok.hops[0].failed);
+        assert_eq!(ok.hops[0].detail["status"], 200);
+
+        let mut error = AiExtProcState {
+            context: Some(upstream_trace_context(team_id)),
+            response_status: Some(500),
+            ..Default::default()
+        };
+        note_ai_upstream_response(&mut error);
+        assert_eq!(error.hops[0].outcome, "error");
+        assert!(error.hops[0].failed);
+
+        let mut listener = AiExtProcState {
+            context: Some(listener_trace_context(team_id)),
+            response_status: Some(200),
+            ..Default::default()
+        };
+        note_ai_upstream_response(&mut listener);
+        assert!(
+            listener.hops.is_empty(),
+            "the listener stream owns status_code, not the upstream hop"
+        );
+    }
+
+    #[tokio::test]
+    async fn ai_trace_two_stream_capture_persists_merged_redacted_row() {
+        let _guard = crate::snapshot::ENV_LOCK.lock().await;
+        let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+            eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+            return;
+        };
+        use aes_gcm::aead::Aead;
+        use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+        use base64::Engine as _;
+
+        let key = *b"12345678901234567890123456789012";
+        std::env::set_var("FLOWPLANE_SECRET_ENCRYPTION_KEY_ID", "default");
+        std::env::set_var(
+            "FLOWPLANE_SECRET_ENCRYPTION_KEY",
+            String::from_utf8_lossy(&key).to_string(),
+        );
+        let pool = fp_storage::connect(&url, 4).await.expect("connect");
+        fp_storage::migrate(&pool).await.expect("migrate");
+        let org = identity::create_org(&pool, &format!("org-{}", Uuid::now_v7()), "")
+            .await
+            .expect("org");
+        let team = identity::create_team(&pool, org.id, &format!("team-{}", Uuid::now_v7()), "")
+            .await
+            .expect("team");
+        let other_team =
+            identity::create_team(&pool, org.id, &format!("team-{}", Uuid::now_v7()), "")
+                .await
+                .expect("other team");
+
+        let secret_value = "Bearer fp-trace-secret-value";
+        let spec = SecretSpec::GenericSecret {
+            secret: base64::engine::general_purpose::STANDARD.encode(secret_value),
+        };
+        let plaintext = serde_json::to_vec(&spec).expect("secret json");
+        let nonce = [9_u8; 12];
+        let cipher = Aes256Gcm::new_from_slice(&key).expect("cipher");
+        let ciphertext = cipher
+            .encrypt(Nonce::from_slice(&nonce), plaintext.as_ref())
+            .expect("encrypt");
+
+        let secret_id = Uuid::now_v7();
+        let provider_id = Uuid::now_v7();
+        let route_id = Uuid::now_v7();
+        let route_config_id = Uuid::now_v7();
+        let listener_id = Uuid::now_v7();
+        sqlx::query(
+            "INSERT INTO secrets \
+             (id, team_id, org_id, name, description, secret_type, configuration_encrypted, nonce, encryption_key_id) \
+             VALUES ($1, $2, $3, 'ai-trace-key', '', 'generic_secret', $4, $5, 'default')",
+        )
+        .bind(secret_id)
+        .bind(team.id.as_uuid())
+        .bind(org.id.as_uuid())
+        .bind(ciphertext)
+        .bind(nonce.to_vec())
+        .execute(&pool)
+        .await
+        .expect("secret");
+        sqlx::query(
+            "INSERT INTO ai_providers \
+             (id, team_id, org_id, name, kind, base_url, path_prefix, credential_secret_id, auth_header) \
+             VALUES ($1, $2, $3, 'openai-trace', 'openai', 'https://api.openai.com', NULL, $4, 'authorization')",
+        )
+        .bind(provider_id)
+        .bind(team.id.as_uuid())
+        .bind(org.id.as_uuid())
+        .bind(secret_id)
+        .execute(&pool)
+        .await
+        .expect("provider");
+        sqlx::query(
+            "INSERT INTO route_configs (id, team_id, org_id, name, spec) \
+             VALUES ($1, $2, $3, 'ai-trace-routes', '{}'::jsonb)",
+        )
+        .bind(route_config_id)
+        .bind(team.id.as_uuid())
+        .bind(org.id.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("route config");
+        let route_spec = serde_json::json!({
+            "listener_port": 19100,
+            "path": "/v1/chat/completions",
+            "backends": [{
+                "provider_id": provider_id,
+                "models": [],
+                "weight": 1,
+                "priority": 0
+            }]
+        });
+        sqlx::query(
+            "INSERT INTO ai_routes \
+             (id, team_id, org_id, name, spec, cluster_names, route_config_name, listener_name) \
+             VALUES ($1, $2, $3, 'ai-trace-route', $4, ARRAY['ai-trace-b1'], 'ai-trace-routes', 'ai-trace-listener')",
+        )
+        .bind(route_id)
+        .bind(team.id.as_uuid())
+        .bind(org.id.as_uuid())
+        .bind(route_spec)
+        .execute(&pool)
+        .await
+        .expect("ai route");
+        sqlx::query(
+            "INSERT INTO ai_route_backends (ai_route_id, team_id, provider_id, position) \
+             VALUES ($1, $2, $3, 0)",
+        )
+        .bind(route_id)
+        .bind(team.id.as_uuid())
+        .bind(provider_id)
+        .execute(&pool)
+        .await
+        .expect("backend");
+
+        let request_id = Uuid::now_v7().to_string();
+        let traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+        let prompt_marker = format!("fp-trace-prompt-{}", Uuid::now_v7());
+        let request_headers = |extra: &[(&str, &str)]| {
+            let mut headers = vec![
+                (":path", "/v1/chat/completions"),
+                ("x-request-id", request_id.as_str()),
+                (AI_MODEL_HEADER, "gpt-5"),
+            ];
+            headers.extend_from_slice(extra);
+            ProcessingRequest {
+                request: Some(processing_request::Request::RequestHeaders(
+                    envoy_types::pb::envoy::service::ext_proc::v3::HttpHeaders {
+                        headers: Some(HeaderMap {
+                            headers: headers
+                                .into_iter()
+                                .map(|(key, value)| HeaderValue {
+                                    key: key.into(),
+                                    value: value.into(),
+                                    raw_value: Vec::new(),
+                                })
+                                .collect(),
+                        }),
+                        ..Default::default()
+                    },
+                )),
+                ..Default::default()
+            }
+        };
+        let response_headers = ProcessingRequest {
+            request: Some(processing_request::Request::ResponseHeaders(
+                envoy_types::pb::envoy::service::ext_proc::v3::HttpHeaders {
+                    headers: Some(HeaderMap {
+                        headers: vec![
+                            HeaderValue {
+                                key: ":status".into(),
+                                value: "200".into(),
+                                raw_value: Vec::new(),
+                            },
+                            HeaderValue {
+                                key: "content-type".into(),
+                                value: "application/json".into(),
+                                raw_value: Vec::new(),
+                            },
+                        ],
+                    }),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        let response_body = ProcessingRequest {
+            request: Some(processing_request::Request::ResponseBody(
+                envoy_types::pb::envoy::service::ext_proc::v3::HttpBody {
+                    body: br#"{"choices":[],"usage":{"prompt_tokens":2,"completion_tokens":3,"total_tokens":5}}"#.to_vec(),
+                    end_of_stream: true,
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+
+        // Listener-side stream: route_match/auth (+ single-backend budget/credential) hops.
+        let mut listener_state = AiExtProcState {
+            context: Some(AiExtProcContext {
+                team_id: team.id,
+                listener_id: Some(ListenerId::from(listener_id)),
+                route_config_id: RouteConfigId::from(route_config_id),
+                provider_id: None,
+                backend_position: None,
+                failover_chain: Vec::new(),
+            }),
+            ..Default::default()
+        };
+        ai_response_with_pool(
+            &pool,
+            &mut listener_state,
+            request_headers(&[("traceparent", traceparent)]),
+        )
+        .await;
+        let request_body = ProcessingRequest {
+            request: Some(processing_request::Request::RequestBody(
+                envoy_types::pb::envoy::service::ext_proc::v3::HttpBody {
+                    body: format!(
+                        r#"{{"model":"gpt-5","messages":[{{"role":"user","content":"{prompt_marker}"}}]}}"#
+                    )
+                    .into_bytes(),
+                    end_of_stream: true,
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        ai_response_with_pool(&pool, &mut listener_state, request_body).await;
+        ai_response_with_pool(&pool, &mut listener_state, response_headers.clone()).await;
+        ai_response_with_pool(&pool, &mut listener_state, response_body.clone()).await;
+        let settlement = persist_ai_usage(&pool, &listener_state).await;
+        assert_eq!(
+            settlement, None,
+            "the listener stream has no attributed usage"
+        );
+        persist_ai_trace(&pool, &listener_state, settlement).await;
+
+        // Upstream-side stream: budget/credential/upstream/usage hops merged into the row.
+        let mut upstream_state = AiExtProcState {
+            context: Some(AiExtProcContext {
+                team_id: team.id,
+                listener_id: None,
+                route_config_id: RouteConfigId::from(route_config_id),
+                provider_id: Some(AiProviderId::from(provider_id)),
+                backend_position: Some(0),
+                failover_chain: Vec::new(),
+            }),
+            ..Default::default()
+        };
+        ai_response_with_pool(
+            &pool,
+            &mut upstream_state,
+            request_headers(&[("traceparent", traceparent)]),
+        )
+        .await;
+        ai_response_with_pool(&pool, &mut upstream_state, response_headers).await;
+        ai_response_with_pool(&pool, &mut upstream_state, response_body).await;
+        let settlement = persist_ai_usage(&pool, &upstream_state).await;
+        assert_eq!(
+            settlement,
+            Some(true),
+            "usage settles on the upstream stream"
+        );
+        persist_ai_trace(&pool, &upstream_state, settlement).await;
+
+        // Exactly one merged row with the full hop timeline and no sensitive strings.
+        let rows = fp_storage::repos::ai_trace::list_trace_events(
+            &pool,
+            team.id,
+            fp_storage::repos::ai_trace::AiTraceQuery {
+                request_id: Some(&request_id),
+                trace_id: None,
+                limit: 10,
+            },
+        )
+        .await
+        .expect("list trace events");
+        assert_eq!(rows.len(), 1, "both streams merged into one trace row");
+        let row = &rows[0];
+        assert_eq!(row.status_code, Some(200));
+        assert_eq!(row.failure_hop, None);
+        assert_eq!(row.model.as_deref(), Some("gpt-5"));
+        assert_eq!(row.listener_id, Some(ListenerId::from(listener_id)));
+        assert_eq!(row.provider_id, Some(AiProviderId::from(provider_id)));
+        assert_eq!(
+            row.trace_id.as_deref(),
+            Some("0af7651916cd43dd8448eb211c80319c")
+        );
+        let hops = row.hops.as_array().expect("hops array");
+        let names: Vec<&str> = hops
+            .iter()
+            .map(|hop| hop["hop"].as_str().expect("hop name"))
+            .collect();
+        for expected in [
+            "route_match",
+            "auth",
+            "budget",
+            "credential_injection",
+            "upstream",
+            "usage",
+        ] {
+            assert_eq!(
+                names.iter().filter(|name| **name == expected).count(),
+                1,
+                "expected exactly one {expected} hop, got {names:?}"
+            );
+        }
+        for hop in hops {
+            let started = hop["started_at"].as_str().expect("started_at");
+            let ended = hop["ended_at"].as_str().expect("ended_at");
+            assert!(started <= ended, "hop {} window inverted", hop["hop"]);
+        }
+        let usage_hop = hops
+            .iter()
+            .find(|hop| hop["hop"] == "usage")
+            .expect("usage hop");
+        assert_eq!(usage_hop["outcome"], "settled");
+        assert_eq!(usage_hop["detail"]["total_tokens"], 5);
+        let auth_hop = hops
+            .iter()
+            .find(|hop| hop["hop"] == "auth")
+            .expect("auth hop");
+        assert_eq!(auth_hop["outcome"], "not_configured");
+        let upstream_hop = hops
+            .iter()
+            .find(|hop| hop["hop"] == "upstream")
+            .expect("upstream hop");
+        assert_eq!(upstream_hop["detail"]["status"], 200);
+
+        // Column-level sensitive scan: neither the prompt nor the secret value anywhere.
+        let row_text: String = sqlx::query_scalar(
+            "SELECT row_to_json(t)::text FROM \
+             (SELECT * FROM ai_trace_events WHERE team_id = $1 AND request_id = $2) t",
+        )
+        .bind(team.id.as_uuid())
+        .bind(&request_id)
+        .fetch_one(&pool)
+        .await
+        .expect("row json");
+        assert!(
+            !row_text.contains(secret_value),
+            "credential value must never appear in the trace row"
+        );
+        assert!(
+            !row_text.contains(&prompt_marker),
+            "prompt content must never appear in the trace row"
+        );
+
+        // Cross-team scoping: the other team sees nothing for this request id.
+        let foreign = fp_storage::repos::ai_trace::list_trace_events(
+            &pool,
+            other_team.id,
+            fp_storage::repos::ai_trace::AiTraceQuery {
+                request_id: Some(&request_id),
+                trace_id: None,
+                limit: 10,
+            },
+        )
+        .await
+        .expect("foreign list");
+        assert!(foreign.is_empty());
+
+        // Absent traceparent leaves trace_id null (AC 9, negative half).
+        let bare_request_id = Uuid::now_v7().to_string();
+        let mut bare_state = AiExtProcState {
+            context: Some(AiExtProcContext {
+                team_id: team.id,
+                listener_id: Some(ListenerId::from(listener_id)),
+                route_config_id: RouteConfigId::from(route_config_id),
+                provider_id: None,
+                backend_position: None,
+                failover_chain: Vec::new(),
+            }),
+            ..Default::default()
+        };
+        let bare_headers = ProcessingRequest {
+            request: Some(processing_request::Request::RequestHeaders(
+                envoy_types::pb::envoy::service::ext_proc::v3::HttpHeaders {
+                    headers: Some(HeaderMap {
+                        headers: vec![
+                            HeaderValue {
+                                key: ":path".into(),
+                                value: "/v1/chat/completions".into(),
+                                raw_value: Vec::new(),
+                            },
+                            HeaderValue {
+                                key: "x-request-id".into(),
+                                value: bare_request_id.clone(),
+                                raw_value: Vec::new(),
+                            },
+                            HeaderValue {
+                                key: AI_MODEL_HEADER.into(),
+                                value: "gpt-5".into(),
+                                raw_value: Vec::new(),
+                            },
+                        ],
+                    }),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        ai_response_with_pool(&pool, &mut bare_state, bare_headers).await;
+        persist_ai_trace(&pool, &bare_state, None).await;
+        let bare_rows = fp_storage::repos::ai_trace::list_trace_events(
+            &pool,
+            team.id,
+            fp_storage::repos::ai_trace::AiTraceQuery {
+                request_id: Some(&bare_request_id),
+                trace_id: None,
+                limit: 10,
+            },
+        )
+        .await
+        .expect("bare list");
+        assert_eq!(bare_rows.len(), 1);
+        assert_eq!(bare_rows[0].trace_id, None);
+    }
+
+    #[tokio::test]
+    async fn ai_trace_persistence_failure_is_swallowed_best_effort() {
+        let _guard = crate::snapshot::ENV_LOCK.lock().await;
+        let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+            eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+            return;
+        };
+        let pool = fp_storage::connect(&url, 4).await.expect("connect");
+        fp_storage::migrate(&pool).await.expect("migrate");
+        // A team that does not exist violates the FK — the write fails, the call must not.
+        let mut state = AiExtProcState {
+            context: Some(AiExtProcContext {
+                team_id: TeamId::from(Uuid::now_v7()),
+                listener_id: Some(ListenerId::from(Uuid::now_v7())),
+                route_config_id: RouteConfigId::from(Uuid::now_v7()),
+                provider_id: None,
+                backend_position: None,
+                failover_chain: Vec::new(),
+            }),
+            request_id: Some(Uuid::now_v7().to_string()),
+            ..Default::default()
+        };
+        state.push_hop("auth", Utc::now(), "not_configured", false, json!({}));
+        persist_ai_trace(&pool, &state, None).await;
     }
 }

--- a/crates/fp-xds/src/capture.rs
+++ b/crates/fp-xds/src/capture.rs
@@ -25,10 +25,10 @@ use envoy_types::pb::envoy::service::ext_proc::v3::{
 use fp_domain::api_lifecycle::ObservationIngest;
 use fp_domain::discovery::DiscoveryObservationProvenance;
 use fp_domain::{
-    openai_usage_from_json, prepare_openai_chat_request, rewrite_openai_chat_request_model,
-    strip_synthetic_openai_usage_sse, AiProviderId, AiRouteSpec, AiTraceEvent, ApiDefinitionId,
-    CaptureSessionId, DiscoverySessionId, DomainError, ListenerId, OpenAiTokenUsage, RouteConfigId,
-    SecretSpec, TeamId, AI_MODEL_HEADER,
+    ai_error_envelope, openai_usage_from_json, prepare_openai_chat_request,
+    rewrite_openai_chat_request_model, strip_synthetic_openai_usage_sse, AiProviderId, AiRouteSpec,
+    AiTraceEvent, ApiDefinitionId, CaptureSessionId, DiscoverySessionId, DomainError, ListenerId,
+    OpenAiTokenUsage, RouteConfigId, SecretSpec, TeamId, AI_MODEL_HEADER,
 };
 use fp_storage::repos::{ai, ai_trace, api_lifecycle, discovery, identity, secrets};
 use serde_json::{json, Map, Value};
@@ -2138,7 +2138,14 @@ fn immediate_response_with_details(
                         status as i32
                     },
                 }),
-                body: message.into_bytes(),
+                headers: Some(HeaderMutation {
+                    set_headers: vec![mutation_header_value(
+                        "content-type".into(),
+                        "application/json".into(),
+                    )],
+                    ..Default::default()
+                }),
+                body: ai_error_envelope(details, &message).into_bytes(),
                 details: details.into(),
                 ..Default::default()
             },
@@ -2172,6 +2179,48 @@ mod tests {
     use envoy_types::pb::google::protobuf::UInt32Value;
     use std::collections::HashMap;
     use tonic::Code;
+
+    /// Assert an ext_proc `ImmediateResponse` carries the AI JSON error envelope
+    /// (`{"code":…,"message":…}`) with `content-type: application/json`, that its
+    /// `details` (the `%RESPONSE_CODE_DETAILS%` value) still equals the envelope
+    /// `code`, and return the envelope `message` for callers that pin it. The
+    /// `code`/`details` parity guard means every rejection path is checked for an
+    /// unchanged detail even when its human message is incidental.
+    fn assert_json_error_envelope_code(response: &ImmediateResponse, code: &str) -> String {
+        assert_eq!(response.details, code, "response-code details unchanged");
+        let envelope: Value =
+            serde_json::from_slice(&response.body).expect("immediate response body is JSON");
+        assert_eq!(envelope["code"], code, "envelope code");
+        let message = envelope["message"]
+            .as_str()
+            .expect("envelope message is a string")
+            .to_string();
+        assert!(!message.is_empty(), "envelope message is non-empty");
+        let has_json_content_type = response
+            .headers
+            .as_ref()
+            .expect("immediate response sets headers")
+            .set_headers
+            .iter()
+            .any(|option| {
+                option.header.as_ref().is_some_and(|header| {
+                    header.key.eq_ignore_ascii_case("content-type")
+                        && header.raw_value == b"application/json"
+                })
+            });
+        assert!(
+            has_json_content_type,
+            "content-type: application/json header"
+        );
+        message
+    }
+
+    /// As [`assert_json_error_envelope_code`], additionally pinning the exact
+    /// human `message`.
+    fn assert_json_error_envelope(response: &ImmediateResponse, code: &str, message: &str) {
+        let actual = assert_json_error_envelope_code(response, code);
+        assert_eq!(actual, message, "envelope message");
+    }
 
     struct FixedTeamResolver {
         team_id: TeamId,
@@ -2646,9 +2695,10 @@ mod tests {
         };
         assert_eq!(response.status.expect("status").code, 429);
         assert_eq!(response.details, "flowplane_ai_budget_exceeded");
-        assert_eq!(
-            String::from_utf8(response.body).expect("body"),
-            "AI budget \"hard-stop\" exceeded"
+        assert_json_error_envelope(
+            &response,
+            "flowplane_ai_budget_exceeded",
+            "AI budget \"hard-stop\" exceeded",
         );
 
         assert_eq!(
@@ -2897,6 +2947,9 @@ mod tests {
             response.status.expect("status").code,
             StatusCode::BadRequest as i32
         );
+        // The generic invalid-request path also speaks the JSON error envelope with a
+        // content-type: application/json header (its message is validation-dependent).
+        assert_json_error_envelope_code(&response, "flowplane_ai_request_invalid");
     }
 
     #[test]
@@ -3857,9 +3910,10 @@ mod tests {
         };
         assert_eq!(immediate.status.expect("status").code, 429);
         assert_eq!(immediate.details, "flowplane_ai_budget_exceeded");
-        assert_eq!(
-            String::from_utf8(immediate.body).expect("body"),
-            "AI budget \"hard-stop\" exceeded"
+        assert_json_error_envelope(
+            &immediate,
+            "flowplane_ai_budget_exceeded",
+            "AI budget \"hard-stop\" exceeded",
         );
     }
 
@@ -4203,9 +4257,10 @@ mod tests {
             panic!("expected budget-check immediate response");
         };
         assert_eq!(immediate.status.expect("status").code, 500);
-        assert_eq!(
-            String::from_utf8(immediate.body).expect("body"),
-            "AI budget check unavailable"
+        assert_json_error_envelope(
+            &immediate,
+            "flowplane_ai_request_invalid",
+            "AI budget check unavailable",
         );
         lock_tx.rollback().await.expect("release budget table lock");
 
@@ -4414,10 +4469,10 @@ mod tests {
                 panic!("expected credential immediate response for {expected_outcome}");
             };
             assert_eq!(immediate.status.expect("status").code, 500);
-            assert_eq!(
-                String::from_utf8(immediate.body).expect("body"),
+            assert_json_error_envelope(
+                &immediate,
+                "flowplane_ai_request_invalid",
                 "AI provider credential unavailable",
-                "the client-visible immediate response is unchanged"
             );
 
             let mut row: Option<fp_domain::AiTraceEvent> = None;
@@ -4460,6 +4515,111 @@ mod tests {
                 "credential material must never appear in the trace row"
             );
         }
+
+        // Listener-side single-eligible-backend credential failure exercises the *other*
+        // immediate-response callsite (ai_listener_request_headers_response): the context
+        // carries no provider, so the backend is resolved on the listener stream. The same
+        // JSON error-envelope contract must hold on that path too.
+        let listener_route_config_id = Uuid::now_v7();
+        sqlx::query(
+            "INSERT INTO route_configs (id, team_id, org_id, name, spec) \
+             VALUES ($1, $2, $3, 'ai-s3-cred-listener-routes', '{}'::jsonb)",
+        )
+        .bind(listener_route_config_id)
+        .bind(team.id.as_uuid())
+        .bind(org.id.as_uuid())
+        .execute(&pool)
+        .await
+        .expect("listener route config");
+        let listener_route_id = Uuid::now_v7();
+        let listener_route_spec = serde_json::json!({
+            "listener_port": 19201,
+            "path": "/v1/chat/completions",
+            "backends": [
+                {"provider_id": garbage_provider_id, "models": [], "weight": 1, "priority": 0}
+            ]
+        });
+        sqlx::query(
+            "INSERT INTO ai_routes \
+             (id, team_id, org_id, name, spec, cluster_names, route_config_name, listener_name) \
+             VALUES ($1, $2, $3, 'ai-s3-cred-listener-route', $4, ARRAY['ai-s3-cred-lb1'], 'ai-s3-cred-listener-routes', 'ai-s3-cred-listener-l')",
+        )
+        .bind(listener_route_id)
+        .bind(team.id.as_uuid())
+        .bind(org.id.as_uuid())
+        .bind(listener_route_spec)
+        .execute(&pool)
+        .await
+        .expect("listener ai route");
+        sqlx::query(
+            "INSERT INTO ai_route_backends (ai_route_id, team_id, provider_id, position) \
+             VALUES ($1, $2, $3, 0)",
+        )
+        .bind(listener_route_id)
+        .bind(team.id.as_uuid())
+        .bind(garbage_provider_id)
+        .execute(&pool)
+        .await
+        .expect("listener backend");
+
+        let listener_request_id = Uuid::now_v7().to_string();
+        let listener_headers = ProcessingRequest {
+            request: Some(processing_request::Request::RequestHeaders(
+                envoy_types::pb::envoy::service::ext_proc::v3::HttpHeaders {
+                    headers: Some(HeaderMap {
+                        headers: vec![
+                            HeaderValue {
+                                key: ":path".into(),
+                                value: "/v1/chat/completions".into(),
+                                raw_value: Vec::new(),
+                            },
+                            HeaderValue {
+                                key: "x-request-id".into(),
+                                value: listener_request_id.clone(),
+                                raw_value: Vec::new(),
+                            },
+                            HeaderValue {
+                                key: AI_MODEL_HEADER.into(),
+                                value: "gpt-4o-mini".into(),
+                                raw_value: Vec::new(),
+                            },
+                        ],
+                    }),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        let mut listener_rx = ai_process_stream(
+            pool.clone(),
+            tokio_stream::iter(vec![Ok(listener_headers)]),
+            Some(AiExtProcContext {
+                team_id: team.id,
+                listener_id: Some(ListenerId::from(Uuid::now_v7())),
+                route_config_id: RouteConfigId::from(listener_route_config_id),
+                provider_id: None,
+                backend_position: None,
+                failover_chain: Vec::new(),
+            }),
+        );
+        let listener_response = listener_rx
+            .recv()
+            .await
+            .expect("listener immediate response");
+        let processing_response::Response::ImmediateResponse(listener_immediate) =
+            listener_response
+                .expect("response ok")
+                .response
+                .expect("response set")
+        else {
+            panic!("expected listener-side credential immediate response");
+        };
+        assert_eq!(listener_immediate.status.expect("status").code, 500);
+        assert_json_error_envelope(
+            &listener_immediate,
+            "flowplane_ai_request_invalid",
+            "AI provider credential unavailable",
+        );
     }
 
     // ---- Slice s6: OTLP hop spans (secondary channel) ----
@@ -5214,9 +5374,10 @@ mod tests {
             "the span timeline and the DB row describe the same request"
         );
         assert_eq!(request.fields["failure_hop"], json!("budget"));
-        assert!(
-            !request.fields.contains_key("status_code"),
-            "no response status was observed on the reject path"
+        assert_eq!(
+            request.fields["status_code"],
+            json!(429),
+            "listener-side budget rejection stamps the 429 the client received (#231)"
         );
 
         let hop_spans: Vec<&CapturedSpan> =

--- a/crates/fp-xds/src/snapshot.rs
+++ b/crates/fp-xds/src/snapshot.rs
@@ -2236,6 +2236,122 @@ mod tests {
         );
     }
 
+    /// Regression: an AI route whose `cluster_names` array is shorter than its backend
+    /// positions produces a NULL `cluster_name` in `ai_cluster_metadata`. `Row::get` used
+    /// to panic on that NULL, taking down xDS snapshot priming (and `flowplane serve`
+    /// startup). Priming must degrade — skip the gap and keep the aligned backends.
+    #[tokio::test]
+    async fn ai_cluster_metadata_skips_backend_with_no_materialized_cluster_name() {
+        use fp_domain::{AiProviderKind, AiProviderSpec};
+
+        let _guard = ENV_LOCK.lock().await;
+        let Some((pool, team, _, ctx, _)) = world().await else {
+            return;
+        };
+        std::env::set_var(
+            "FLOWPLANE_SECRET_ENCRYPTION_KEY",
+            "12345678901234567890123456789012",
+        );
+
+        let secret = fp_core::services::secrets::create_secret(
+            &pool,
+            &ctx,
+            team,
+            fp_core::services::secrets::SecretWrite {
+                name: &unique("ai-key"),
+                description: "",
+                spec: SecretSpec::GenericSecret {
+                    secret: "aGVsbG8=".into(),
+                },
+                expires_at: None,
+            },
+            RequestId::generate(),
+        )
+        .await
+        .expect("secret");
+        let provider = fp_core::services::ai::create_provider(
+            &pool,
+            &ctx,
+            team,
+            &unique("provider"),
+            AiProviderSpec {
+                kind: AiProviderKind::OpenaiCompatible,
+                base_url: "https://upstream.example".into(),
+                path_prefix: Some("/v1".into()),
+                credential_secret_id: secret.id,
+                models: vec!["gpt-5".into()],
+                auth_header: "authorization".into(),
+            },
+            RequestId::generate(),
+        )
+        .await
+        .expect("provider");
+
+        // Malformed materialization injected via raw SQL (the create_route builder keeps
+        // cluster_names aligned with backends, so it cannot produce this gap): two backends,
+        // but a single-element cluster_names, so position 1 -> cluster_names[2] -> NULL.
+        let route_config_name = unique("cn-routes");
+        let route_id = uuid::Uuid::now_v7();
+        let aligned_cluster = unique("aligned-cluster");
+        sqlx::query(
+            "INSERT INTO route_configs (id, team_id, org_id, name, spec) \
+             VALUES ($1, $2, $3, $4, '{}'::jsonb)",
+        )
+        .bind(uuid::Uuid::now_v7())
+        .bind(team.id.as_uuid())
+        .bind(team.org_id.as_uuid())
+        .bind(&route_config_name)
+        .execute(&pool)
+        .await
+        .expect("route config");
+        sqlx::query(
+            "INSERT INTO ai_routes \
+             (id, team_id, org_id, name, spec, cluster_names, route_config_name, listener_name) \
+             VALUES ($1, $2, $3, $4, $5, ARRAY[$6], $7, $8)",
+        )
+        .bind(route_id)
+        .bind(team.id.as_uuid())
+        .bind(team.org_id.as_uuid())
+        .bind(unique("cn-route"))
+        .bind(serde_json::json!({
+            "listener_port": 21000, "path": "/v1/chat/completions", "backends": []
+        }))
+        .bind(&aligned_cluster)
+        .bind(&route_config_name)
+        .bind(unique("cn-listener"))
+        .execute(&pool)
+        .await
+        .expect("ai route");
+        for position in [0_i32, 1_i32] {
+            sqlx::query(
+                "INSERT INTO ai_route_backends (ai_route_id, team_id, provider_id, position) \
+                 VALUES ($1, $2, $3, $4)",
+            )
+            .bind(route_id)
+            .bind(team.id.as_uuid())
+            .bind(provider.id.as_uuid())
+            .bind(position)
+            .execute(&pool)
+            .await
+            .expect("backend");
+        }
+
+        // Must return Ok (not panic). The team is fresh, so exactly the aligned backend
+        // survives and the NULL-cluster_name backend at position 1 is skipped.
+        let meta = ai_cluster_metadata(&pool, team.id)
+            .await
+            .expect("ai_cluster_metadata must not fail on a NULL cluster_name");
+        assert_eq!(meta.len(), 1, "only the aligned backend is kept: {meta:?}");
+        assert!(
+            meta.contains_key(&aligned_cluster),
+            "position 0's materialized cluster is kept"
+        );
+        assert_eq!(
+            meta[&aligned_cluster].backend_position, 0,
+            "the surviving entry is the aligned position-0 backend"
+        );
+    }
+
     fn metadata_header(key: &str, value: String) -> envoy_core::HeaderValue {
         envoy_core::HeaderValue {
             key: key.to_string(),

--- a/crates/fp-xds/src/snapshot.rs
+++ b/crates/fp-xds/src/snapshot.rs
@@ -2064,12 +2064,20 @@ mod tests {
         // explicitly for a readable failure before the whole-proto compare.
         assert!(!manager.preserve_external_request_id);
         assert_eq!(
+            manager.use_remote_address,
+            Some(wkt::BoolValue { value: true }),
+            "AI listener HCM must set use_remote_address so requests are edge requests"
+        );
+        assert_eq!(
             manager.internal_address_config,
             Some(hcm::http_connection_manager::InternalAddressConfig {
                 unix_sockets: false,
-                cidr_ranges: Vec::new(),
+                cidr_ranges: vec![envoy_core::CidrRange {
+                    address_prefix: "240.0.0.0".to_string(),
+                    prefix_len: Some(wkt::UInt32Value { value: 4 }),
+                }],
             }),
-            "AI listener HCM must pin an explicit empty internal-address allowlist"
+            "AI listener HCM must declare no client peer internal via a non-matching CIDR"
         );
         assert!(
             manager
@@ -2190,9 +2198,13 @@ mod tests {
             ],
             generate_request_id: Some(wkt::BoolValue { value: true }),
             always_set_request_id_in_response: true,
+            use_remote_address: Some(wkt::BoolValue { value: true }),
             internal_address_config: Some(hcm::http_connection_manager::InternalAddressConfig {
                 unix_sockets: false,
-                cidr_ranges: Vec::new(),
+                cidr_ranges: vec![envoy_core::CidrRange {
+                    address_prefix: "240.0.0.0".to_string(),
+                    prefix_len: Some(wkt::UInt32Value { value: 4 }),
+                }],
             }),
             ..Default::default()
         };

--- a/crates/fp-xds/src/snapshot.rs
+++ b/crates/fp-xds/src/snapshot.rs
@@ -1058,8 +1058,14 @@ pub const XDS_CONSUMER: &str = "xds-snapshot";
 #[allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use envoy_types::pb::envoy::config::common::mutation_rules::v3 as mutation_rules;
+    use envoy_types::pb::envoy::config::core::v3 as envoy_core;
     use envoy_types::pb::envoy::config::listener::v3 as lst;
+    use envoy_types::pb::envoy::extensions::filters::http::ext_proc::v3 as ext_proc;
+    use envoy_types::pb::envoy::extensions::filters::http::router::v3::Router;
     use envoy_types::pb::envoy::extensions::filters::network::http_connection_manager::v3 as hcm;
+    use envoy_types::pb::envoy::r#type::matcher::v3 as matcher_type;
+    use envoy_types::pb::google::protobuf as wkt;
     use fp_core::{GrantSet, PrincipalCtx};
     use fp_domain::api_lifecycle::{ApiDefinitionSpec, ApiRouteBindingSpec, CaptureSessionSpec};
     use fp_domain::authz::TeamRef;
@@ -1951,5 +1957,261 @@ mod tests {
         let fixed = cache.team(team.id).await.endpoints;
         assert_ne!(fixed.resources, initial.resources);
         assert_ne!(fixed.resources, updated.resources);
+    }
+
+    // -------- ai-gateway-e2e-trace s1: server-owned x-request-id on AI listeners --------
+    //
+    // DB-backed: an AI route materialized through fp-core services (secret + provider +
+    // route → owner_kind 'ai' listener row) must come out of rebuild_team with the
+    // request-identity fields pinned on its HCM. Skips when FLOWPLANE_TEST_DATABASE_URL
+    // is unset; ENV_LOCK serializes FLOWPLANE_SECRET_ENCRYPTION_KEY (shared process env).
+
+    #[tokio::test]
+    #[allow(deprecated)]
+    async fn materialized_ai_listener_snapshot_pins_server_owned_request_identity() {
+        use fp_domain::{AiProviderKind, AiProviderSpec, AiRouteBackend, AiRouteSpec};
+
+        let _guard = ENV_LOCK.lock().await;
+        let Some((pool, team, _, ctx, _)) = world().await else {
+            return;
+        };
+        std::env::set_var(
+            "FLOWPLANE_SECRET_ENCRYPTION_KEY",
+            "12345678901234567890123456789012",
+        );
+
+        let secret = fp_core::services::secrets::create_secret(
+            &pool,
+            &ctx,
+            team,
+            fp_core::services::secrets::SecretWrite {
+                name: &unique("ai-key"),
+                description: "",
+                spec: SecretSpec::GenericSecret {
+                    secret: "aGVsbG8=".into(),
+                },
+                expires_at: None,
+            },
+            RequestId::generate(),
+        )
+        .await
+        .expect("secret");
+        let provider = fp_core::services::ai::create_provider(
+            &pool,
+            &ctx,
+            team,
+            &unique("provider"),
+            AiProviderSpec {
+                kind: AiProviderKind::OpenaiCompatible,
+                base_url: "https://upstream.example".into(),
+                path_prefix: Some("/v1".into()),
+                credential_secret_id: secret.id,
+                models: vec!["gpt-5".into()],
+                auth_header: "authorization".into(),
+            },
+            RequestId::generate(),
+        )
+        .await
+        .expect("provider");
+
+        // Unique per-test listener port: this is product state in the shared test
+        // PostgreSQL, not a bound socket, but uniqueness keeps parallel runs disjoint.
+        let port = 20000 + (uuid::Uuid::now_v7().as_u128() % 10_000) as u16;
+        let route_name = unique("ai-route");
+        fp_core::services::ai::create_route(
+            &pool,
+            &ctx,
+            team,
+            &route_name,
+            AiRouteSpec {
+                listener_port: port,
+                path: "/v1/chat/completions".into(),
+                backends: vec![AiRouteBackend {
+                    provider_id: provider.id,
+                    models: vec!["gpt-5".into()],
+                    model_override: None,
+                    weight: 1,
+                    priority: 0,
+                }],
+            },
+            RequestId::generate(),
+        )
+        .await
+        .expect("ai route");
+
+        let cache = SnapshotCache::new();
+        cache.rebuild_team(&pool, team.id).await.expect("rebuild");
+        let snap = cache.team(team.id).await;
+
+        let listener_name = format!("ai-{route_name}-listener");
+        let listener = snap
+            .listeners
+            .resources
+            .iter()
+            .map(|any| {
+                assert_eq!(any.type_url, LISTENER_TYPE_URL);
+                lst::Listener::decode(any.value.as_slice()).expect("decode listener")
+            })
+            .find(|listener| listener.name == listener_name)
+            .expect("materialized AI listener in snapshot");
+        let hcm_bytes = match &listener.filter_chains[0].filters[0].config_type {
+            Some(lst::filter::ConfigType::TypedConfig(any)) => any.value.clone(),
+            _ => panic!("expected typed HCM"),
+        };
+        let manager = hcm::HttpConnectionManager::decode(hcm_bytes.as_slice()).expect("decode hcm");
+
+        // Pinned request-identity fields (ai-gateway-e2e-trace s1), asserted
+        // explicitly for a readable failure before the whole-proto compare.
+        assert!(!manager.preserve_external_request_id);
+        assert_eq!(
+            manager.internal_address_config,
+            Some(hcm::http_connection_manager::InternalAddressConfig {
+                unix_sockets: false,
+                cidr_ranges: Vec::new(),
+            }),
+            "AI listener HCM must pin an explicit empty internal-address allowlist"
+        );
+        assert!(
+            manager
+                .generate_request_id
+                .as_ref()
+                .expect("generate_request_id")
+                .value
+        );
+        assert!(manager.always_set_request_id_in_response);
+
+        // The ext_proc initial metadata carries the materialized row ids.
+        let listener_id: uuid::Uuid =
+            sqlx::query_scalar("SELECT id FROM listeners WHERE team_id = $1 AND name = $2")
+                .bind(team.id.as_uuid())
+                .bind(&listener_name)
+                .fetch_one(&pool)
+                .await
+                .expect("listener row id");
+        let route_config_name = format!("ai-{route_name}-routes");
+        let route_config_id: uuid::Uuid =
+            sqlx::query_scalar("SELECT id FROM route_configs WHERE team_id = $1 AND name = $2")
+                .bind(team.id.as_uuid())
+                .bind(&route_config_name)
+                .fetch_one(&pool)
+                .await
+                .expect("route config row id");
+
+        // Whole-proto compare: the complete HCM expected for a materialized AI
+        // listener, spelled out field-by-field so drift anywhere in the HCM —
+        // not just the identity pins — fails this test.
+        const EXT_PROC_TYPE_NAME: &str =
+            "envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor";
+        const ROUTER_TYPE_NAME: &str = "envoy.extensions.filters.http.router.v3.Router";
+        let expected_ext_proc = ext_proc::ExternalProcessor {
+            grpc_service: Some(envoy_core::GrpcService {
+                timeout: Some(wkt::Duration {
+                    seconds: 5,
+                    nanos: 0,
+                }),
+                initial_metadata: vec![
+                    metadata_header("x-flowplane-ai-processor", "true".into()),
+                    metadata_header("x-flowplane-team-id", team.id.as_uuid().to_string()),
+                    metadata_header("x-flowplane-listener-id", listener_id.to_string()),
+                    metadata_header("x-flowplane-route-config-id", route_config_id.to_string()),
+                ],
+                target_specifier: Some(envoy_core::grpc_service::TargetSpecifier::EnvoyGrpc(
+                    envoy_core::grpc_service::EnvoyGrpc {
+                        cluster_name: "xds_cluster".to_string(),
+                        ..Default::default()
+                    },
+                )),
+                ..Default::default()
+            }),
+            failure_mode_allow: false,
+            processing_mode: Some(ext_proc::ProcessingMode {
+                request_header_mode: ext_proc::processing_mode::HeaderSendMode::Send as i32,
+                response_header_mode: ext_proc::processing_mode::HeaderSendMode::Send as i32,
+                request_body_mode: ext_proc::processing_mode::BodySendMode::Buffered as i32,
+                response_body_mode: ext_proc::processing_mode::BodySendMode::BufferedPartial as i32,
+                request_trailer_mode: ext_proc::processing_mode::HeaderSendMode::Skip as i32,
+                response_trailer_mode: ext_proc::processing_mode::HeaderSendMode::Skip as i32,
+            }),
+            message_timeout: Some(wkt::Duration {
+                seconds: 5,
+                nanos: 0,
+            }),
+            stat_prefix: "flowplane_ai".to_string(),
+            mutation_rules: Some(mutation_rules::HeaderMutationRules {
+                allow_all_routing: Some(wkt::BoolValue { value: true }),
+                allow_expression: Some(matcher_type::RegexMatcher {
+                    regex: "^(authorization|x-api-key|x-flowplane-ai-model|content-length|:path)$"
+                        .to_string(),
+                    engine_type: Some(matcher_type::regex_matcher::EngineType::GoogleRe2(
+                        matcher_type::regex_matcher::GoogleRe2::default(),
+                    )),
+                }),
+                ..Default::default()
+            }),
+            observability_mode: false,
+            disable_immediate_response: false,
+            route_cache_action: ext_proc::external_processor::RouteCacheAction::Default as i32,
+            ..Default::default()
+        };
+        let expected = hcm::HttpConnectionManager {
+            codec_type: hcm::http_connection_manager::CodecType::Http1 as i32,
+            stat_prefix: listener_name.clone(),
+            route_specifier: Some(hcm::http_connection_manager::RouteSpecifier::Rds(
+                hcm::Rds {
+                    route_config_name,
+                    config_source: Some(envoy_core::ConfigSource {
+                        resource_api_version: envoy_core::ApiVersion::V3 as i32,
+                        config_source_specifier: Some(
+                            envoy_core::config_source::ConfigSourceSpecifier::Ads(
+                                envoy_core::AggregatedConfigSource {},
+                            ),
+                        ),
+                        ..Default::default()
+                    }),
+                },
+            )),
+            http_filters: vec![
+                hcm::HttpFilter {
+                    name: "envoy.filters.http.ext_proc.flowplane_ai".to_string(),
+                    config_type: Some(hcm::http_filter::ConfigType::TypedConfig(wkt::Any {
+                        type_url: format!("type.googleapis.com/{EXT_PROC_TYPE_NAME}"),
+                        value: expected_ext_proc.encode_to_vec(),
+                    })),
+                    ..Default::default()
+                },
+                hcm::HttpFilter {
+                    name: "envoy.filters.http.router".to_string(),
+                    config_type: Some(hcm::http_filter::ConfigType::TypedConfig(wkt::Any {
+                        type_url: format!("type.googleapis.com/{ROUTER_TYPE_NAME}"),
+                        value: Router::default().encode_to_vec(),
+                    })),
+                    ..Default::default()
+                },
+            ],
+            generate_request_id: Some(wkt::BoolValue { value: true }),
+            always_set_request_id_in_response: true,
+            internal_address_config: Some(hcm::http_connection_manager::InternalAddressConfig {
+                unix_sockets: false,
+                cidr_ranges: Vec::new(),
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            manager, expected,
+            "materialized AI listener HCM drifted from the full expected proto"
+        );
+        assert_eq!(
+            hcm_bytes,
+            expected.encode_to_vec(),
+            "materialized AI listener HCM bytes drifted (deterministic encoding)"
+        );
+    }
+
+    fn metadata_header(key: &str, value: String) -> envoy_core::HeaderValue {
+        envoy_core::HeaderValue {
+            key: key.to_string(),
+            value,
+            raw_value: Vec::new(),
+        }
     }
 }

--- a/crates/fp-xds/src/snapshot.rs
+++ b/crates/fp-xds/src/snapshot.rs
@@ -720,8 +720,25 @@ async fn ai_cluster_metadata(
     .map_err(|err| DomainError::internal(format!("list AI cluster metadata: {err}")))?;
     let mut out = HashMap::with_capacity(rows.len());
     for row in rows {
+        // `cluster_names[position + 1]` is NULL when a backend position has no matching
+        // materialized cluster name (short/misaligned cluster_names array). That is a data
+        // gap for an incompletely materialized route, not a fatal condition — skip it and
+        // keep priming, mirroring the undecryptable-secret resilience elsewhere in rebuild.
+        // Row::get would panic on the NULL, taking down snapshot priming (and startup).
+        let cluster_name: Option<String> = row.try_get("cluster_name").map_err(|err| {
+            DomainError::internal(format!("decode AI cluster metadata cluster_name: {err}"))
+        })?;
+        let Some(cluster_name) = cluster_name else {
+            let position: i32 = row.try_get("position").unwrap_or_default();
+            tracing::warn!(
+                team = %team_id,
+                position,
+                "skipping AI cluster metadata: backend position has no materialized cluster name"
+            );
+            continue;
+        };
         out.insert(
-            row.get("cluster_name"),
+            cluster_name,
             translate::AiUpstreamProcessorMetadata {
                 team_id: team_id.as_uuid(),
                 route_config_id: RouteConfigId::from(row.get::<uuid::Uuid, _>("route_config_id"))

--- a/crates/fp-xds/src/translate.rs
+++ b/crates/fp-xds/src/translate.rs
@@ -2240,16 +2240,27 @@ pub fn listener_to_proto_with_learning_and_ai(
         ..Default::default()
     };
     if ai.is_some() {
-        // AI listeners: the server owns x-request-id. A client-supplied id is never
-        // preserved, and the explicit empty internal-address allowlist means no
-        // downstream peer is "internal", so Envoy always overwrites the request id
-        // regardless of peer address (Envoy < 1.33 treats RFC1918 peers as internal
-        // by default). AI-scoped so non-AI listener output stays byte-identical.
+        // AI listeners: the server owns x-request-id — a client-supplied id is never
+        // preserved, so a caller cannot choose or collide another request's trace key.
+        //
+        // Envoy only *regenerates* a supplied x-request-id on an *edge request* (one whose
+        // downstream peer is not "internal"); otherwise it merely generates an id when none is
+        // present. Both settings below are required, and both are AI-scoped so non-AI listener
+        // output stays byte-identical:
+        //   1. use_remote_address = true makes the request an edge request. Without it Envoy
+        //      never regenerates a supplied id, for ANY peer address.
+        //   2. internal_address_config with an explicit non-matching CIDR (reserved 240.0.0.0/4,
+        //      which no real client peer occupies) declares that no client is internal. An
+        //      *empty* cidr_ranges does NOT achieve this: Envoy falls back to its default
+        //      (loopback + RFC1918 treated as internal), so loopback/internal callers would keep
+        //      their supplied id. Verified behaviorally against Envoy 1.38 — see
+        //      scripts/e2e/18-p1f-ai-trace.sh AC14.
         manager.preserve_external_request_id = false;
+        manager.use_remote_address = Some(bool_value(true));
         manager.internal_address_config =
             Some(hcm::http_connection_manager::InternalAddressConfig {
                 unix_sockets: false,
-                cidr_ranges: Vec::new(),
+                cidr_ranges: vec![cidr_range("240.0.0.0/4")],
             });
     }
     let transport_socket = spec
@@ -3981,13 +3992,18 @@ mod tests {
         };
 
         assert!(!manager.preserve_external_request_id);
+        // Regenerating a supplied x-request-id requires an edge request: use_remote_address
+        // true + an internal-address set that excludes every real client peer (reserved
+        // 240.0.0.0/4). An empty cidr_ranges falls back to Envoy's default (loopback/RFC1918
+        // internal) and would NOT regenerate. Behaviorally verified by 18-p1f-ai-trace.sh AC14.
+        assert_eq!(manager.use_remote_address, Some(bool_value(true)));
         assert_eq!(
             manager.internal_address_config,
             Some(hcm::http_connection_manager::InternalAddressConfig {
                 unix_sockets: false,
-                cidr_ranges: Vec::new(),
+                cidr_ranges: vec![cidr_range("240.0.0.0/4")],
             }),
-            "AI listener must carry an explicit empty internal-address allowlist"
+            "AI listener must declare no client peer internal via a non-matching CIDR"
         );
         assert_eq!(manager.generate_request_id, Some(bool_value(true)));
         assert!(manager.always_set_request_id_in_response);
@@ -4011,6 +4027,10 @@ mod tests {
         assert!(
             manager.internal_address_config.is_none(),
             "non-AI listeners must not carry the AI-only internal_address_config"
+        );
+        assert!(
+            manager.use_remote_address.is_none(),
+            "non-AI listeners must not carry the AI-only use_remote_address"
         );
         assert_eq!(manager.generate_request_id, Some(bool_value(true)));
         assert!(manager.always_set_request_id_in_response);

--- a/crates/fp-xds/src/translate.rs
+++ b/crates/fp-xds/src/translate.rs
@@ -2221,7 +2221,7 @@ pub fn listener_to_proto_with_learning_and_ai(
         ..Default::default()
     });
 
-    let manager = hcm::HttpConnectionManager {
+    let mut manager = hcm::HttpConnectionManager {
         codec_type: listener_codec_type(spec) as i32,
         stat_prefix: name.to_string(),
         route_specifier: Some(hcm::http_connection_manager::RouteSpecifier::Rds(
@@ -2239,6 +2239,19 @@ pub fn listener_to_proto_with_learning_and_ai(
         always_set_request_id_in_response: true,
         ..Default::default()
     };
+    if ai.is_some() {
+        // AI listeners: the server owns x-request-id. A client-supplied id is never
+        // preserved, and the explicit empty internal-address allowlist means no
+        // downstream peer is "internal", so Envoy always overwrites the request id
+        // regardless of peer address (Envoy < 1.33 treats RFC1918 peers as internal
+        // by default). AI-scoped so non-AI listener output stays byte-identical.
+        manager.preserve_external_request_id = false;
+        manager.internal_address_config =
+            Some(hcm::http_connection_manager::InternalAddressConfig {
+                unix_sockets: false,
+                cidr_ranges: Vec::new(),
+            });
+    }
     let transport_socket = spec
         .tls_context
         .as_ref()
@@ -3937,6 +3950,119 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(names, vec!["envoy.filters.http.router"]);
+    }
+
+    #[test]
+    fn ai_listener_pins_server_owned_request_identity() {
+        let spec = ListenerSpec {
+            address: "0.0.0.0".into(),
+            port: 10000,
+            public_base_url: None,
+            protocol: ListenerProtocol::Http,
+            route_config: Some("ai-chat-routes".into()),
+            http_filters: Vec::new(),
+            access_logs: Vec::new(),
+            tls_context: None,
+        };
+        let ai = AiProcessorMetadata {
+            team_id: uuid::Uuid::now_v7(),
+            listener_id: uuid::Uuid::now_v7(),
+            route_config_id: uuid::Uuid::now_v7(),
+        };
+
+        let proto =
+            listener_to_proto_with_learning_and_ai("ai-chat-listener", &spec, &[], Some(&ai))
+                .expect("translate");
+        let manager = match &proto.filter_chains[0].filters[0].config_type {
+            Some(lst::filter::ConfigType::TypedConfig(any)) => {
+                hcm::HttpConnectionManager::decode(any.value.as_slice()).expect("hcm")
+            }
+            _ => panic!("expected typed HCM"),
+        };
+
+        assert!(!manager.preserve_external_request_id);
+        assert_eq!(
+            manager.internal_address_config,
+            Some(hcm::http_connection_manager::InternalAddressConfig {
+                unix_sockets: false,
+                cidr_ranges: Vec::new(),
+            }),
+            "AI listener must carry an explicit empty internal-address allowlist"
+        );
+        assert_eq!(manager.generate_request_id, Some(bool_value(true)));
+        assert!(manager.always_set_request_id_in_response);
+    }
+
+    #[test]
+    fn non_ai_listener_omits_internal_address_config() {
+        let spec = ListenerSpec {
+            address: "0.0.0.0".into(),
+            port: 10000,
+            public_base_url: None,
+            protocol: ListenerProtocol::Http,
+            route_config: Some("routes".into()),
+            http_filters: Vec::new(),
+            access_logs: Vec::new(),
+            tls_context: None,
+        };
+
+        let manager = hcm_of(&spec);
+        assert!(!manager.preserve_external_request_id);
+        assert!(
+            manager.internal_address_config.is_none(),
+            "non-AI listeners must not carry the AI-only internal_address_config"
+        );
+        assert_eq!(manager.generate_request_id, Some(bool_value(true)));
+        assert!(manager.always_set_request_id_in_response);
+    }
+
+    #[test]
+    fn non_ai_listener_hcm_bytes_match_pre_ai_identity_baseline() {
+        let spec = ListenerSpec {
+            address: "0.0.0.0".into(),
+            port: 10000,
+            public_base_url: None,
+            protocol: ListenerProtocol::Http,
+            route_config: Some("routes".into()),
+            http_filters: Vec::new(),
+            access_logs: Vec::new(),
+            tls_context: None,
+        };
+        let proto = listener_to_proto("edge", &spec).expect("translate");
+        let actual = match &proto.filter_chains[0].filters[0].config_type {
+            Some(lst::filter::ConfigType::TypedConfig(any)) => any.value.clone(),
+            _ => panic!("expected typed HCM"),
+        };
+
+        // The exact HCM emitted for this spec before AI request-identity pinning:
+        // no internal_address_config, preserve_external_request_id at proto default.
+        // Byte equality proves non-AI listener output is unchanged.
+        let expected = hcm::HttpConnectionManager {
+            codec_type: hcm::http_connection_manager::CodecType::Http1 as i32,
+            stat_prefix: "edge".into(),
+            route_specifier: Some(hcm::http_connection_manager::RouteSpecifier::Rds(
+                hcm::Rds {
+                    route_config_name: "routes".into(),
+                    config_source: Some(ads_config_source()),
+                },
+            )),
+            http_filters: vec![hcm::HttpFilter {
+                name: "envoy.filters.http.router".to_string(),
+                config_type: Some(hcm::http_filter::ConfigType::TypedConfig(any(
+                    ROUTER_TYPE_URL,
+                    &Router::default(),
+                ))),
+                ..Default::default()
+            }],
+            generate_request_id: Some(bool_value(true)),
+            always_set_request_id_in_response: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            actual,
+            expected.encode_to_vec(),
+            "non-AI listener HCM bytes drifted from the pre-AI-identity baseline"
+        );
     }
 
     #[test]

--- a/docs/how-to/ai-gateway-route-budget.md
+++ b/docs/how-to/ai-gateway-route-budget.md
@@ -164,3 +164,9 @@ flowplane ai usage --provider-id <provider-id-from-step-1>
 ```
 
 This GETs `/api/v1/teams/{team}/ai/usage` and returns `AiUsageSummary` rows with `prompt_tokens`, `completion_tokens`, `total_tokens`, and `event_count`. A non-zero `event_count` confirms the request routed to the provider and was accounted against the budget. You can also filter by `--route-config-id`.
+
+Every request through the AI listener also records a per-hop trace — including
+budget rejections (enforcing mode) and `would_reject` verdicts (shadow mode) —
+retrievable with `flowplane ai trace --request-id <id from the response>`. To
+debug a failing or slow request hop by hop, see
+[Trace an AI request through the gateway](./trace-ai-requests.md).

--- a/docs/how-to/trace-ai-requests.md
+++ b/docs/how-to/trace-ai-requests.md
@@ -1,0 +1,195 @@
+# Trace an AI request through the gateway
+
+> Audience: api-teams, operators · Status: stable
+
+Every request that reaches an AI listener leaves a **trace row**: a per-hop
+timeline of what the gateway did (route match, auth, budget check, credential
+injection, upstream call, usage accounting), with an outcome and timing for each
+hop. This guide shows how to retrieve that timeline to answer "where did my AI
+request die, and why" — without reading Envoy logs — and how to control how long
+trace rows are kept.
+
+Prerequisites: a working AI provider + route (see
+[Create an AI provider, route traffic to it, and attach a token budget](./ai-gateway-route-budget.md))
+and a token with the `ai-usage` read grant for the team. Command surface details
+are in the [CLI reference](../reference/cli.md); endpoint shapes are in the
+[REST API reference](../reference/rest-api.md).
+
+## 1. Send a request and capture its request id
+
+Send a chat completion through your AI listener and keep the response headers:
+
+```bash
+curl -sS -D /tmp/ai-headers.txt \
+  -H 'content-type: application/json' \
+  -H 'x-flowplane-ai-model: gpt-4o-mini' \
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}' \
+  http://127.0.0.1:19000/v1/chat/completions
+
+grep -i '^x-request-id:' /tmp/ai-headers.txt
+```
+
+Expected result: the completion body, and a header like
+
+```text
+x-request-id: 019f2f5a-9ae3-76d1-bd61-dcc24cfe6e6c
+```
+
+That id is the key to the trace row.
+
+> **AI listeners always generate their own `x-request-id`.** A client-supplied
+> `x-request-id` header is ignored on AI listeners (unlike the control-plane
+> REST API): the server generates a fresh id, returns it in the response, and
+> only that server id keys a trace. If you send your own id, it will not find
+> a trace — use the id from the *response*.
+
+## 2. Retrieve the hop timeline
+
+```bash
+flowplane ai trace --request-id 019f2f5a-9ae3-76d1-bd61-dcc24cfe6e6c --json
+```
+
+Expected output (a successful request; timestamps trimmed):
+
+```json
+{
+  "data": {
+    "traces": [
+      {
+        "request_id": "019f2f5a-9ae3-76d1-bd61-dcc24cfe6e6c",
+        "status_code": 200,
+        "failure_hop": null,
+        "model": "gpt-4o-mini",
+        "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+        "hops": [
+          { "hop": "route_match", "origin": "listener", "outcome": "matched",
+            "detail": { "model": "gpt-4o-mini", "listener_id": "…", "route_config_id": "…" } },
+          { "hop": "auth", "origin": "listener", "outcome": "not_configured", "detail": {} },
+          { "hop": "budget", "origin": "upstream", "outcome": "allowed",
+            "detail": { "mode": "enforcing", "verdict": "allowed" } },
+          { "hop": "credential_injection", "origin": "upstream", "outcome": "injected",
+            "detail": { "provider_id": "…", "auth_header": "authorization" } },
+          { "hop": "upstream", "origin": "upstream", "outcome": "ok",
+            "detail": { "status": 200, "latency_ms": 8, "provider_id": "…" } },
+          { "hop": "usage", "origin": "upstream", "outcome": "settled",
+            "detail": { "prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5 } }
+        ],
+        "created_at": "2026-07-04T22:58:14.883109Z",
+        "expires_at": "2026-08-03T22:58:14.883109Z"
+      }
+    ]
+  },
+  "kind": "aiTrace",
+  "schemaVersion": 1
+}
+```
+
+Each hop carries `started_at`/`ended_at` (elided above), so slow requests show
+*where* the time went — `upstream.detail.latency_ms` is the provider round trip.
+
+Trace rows never contain prompt or completion text, request/response bodies, or
+credential values; the schema stores outcomes, ids, timings, and token counts
+only.
+
+## 3. Correlate with your own distributed trace
+
+If your client sends a W3C `traceparent` header, the AI listener forwards it to
+the provider unchanged and stores its `trace_id` on the row. Look traces up by
+that id to join the gateway's view to your APM's view of the same request:
+
+```bash
+flowplane ai trace --trace-id 4bf92f3577b34da6a3ce929d0e0e4736 --json
+```
+
+Requests without a `traceparent` store `trace_id: null` — they are only
+findable by `--request-id`.
+
+## 4. Triage a failed request
+
+On failure, `failure_hop` names the first hop that failed and its outcome tells
+you the class:
+
+| `failure_hop` | hop outcome | client saw | meaning |
+|---|---|---|---|
+| `route_match` | `no_eligible_backend` | 400 `no_eligible_ai_backend` | the request's model matches no backend on the route — check the route's `backends[].models` and the `x-flowplane-ai-model` header |
+| `budget` | verdict `rejected` | 429 `flowplane_ai_budget_exceeded` | an enforcing budget is exhausted — raise the budget or wait for the window to reset |
+| `credential_injection` | `secret_missing` or `decrypt_failed` | "AI provider credential unavailable" | the provider's credential secret is missing, expired, or undecryptable — rotate the secret referenced by the provider |
+| `upstream` | provider status (e.g. `500`) | provider error passthrough | the provider answered with an error — `detail.status` has the code |
+| `upstream` | `no_upstream_connection` | 503 | Envoy could not connect to the provider — check `base_url` and network reachability |
+| `upstream` | `client_disconnect` | — | the client dropped mid-stream; the partial row is still persisted |
+
+A **shadow** budget that would have rejected shows up on *successful* requests:
+the `budget` hop records verdict `would_reject` while the request still returns
+2xx — use it to preview an enforcement change before flipping the budget mode.
+
+## 5. When there is no trace
+
+A lookup that finds nothing returns an explicit miss, not an empty list:
+
+```json
+{
+  "data": {
+    "miss": {
+      "message": "no trace row found",
+      "hint": "no trace row exists for this id; requests that never complete HTTP processing at the AI listener are never traced: TCP/TLS-level failures, client disconnect before request headers, and pre-ExtProc declared-filter denials"
+    },
+    "traces": []
+  },
+  "kind": "aiTrace",
+  "schemaVersion": 1
+}
+```
+
+Two common causes: you queried the *client-supplied* request id instead of the
+server-returned one (step 1), or the request failed before HTTP processing
+completed at the listener (the classes the hint names).
+
+## Control how long traces are kept
+
+Trace rows expire. With no team policy, rows live **30 days**:
+
+```bash
+flowplane ai retention get --json
+```
+
+```json
+{
+  "data": { "is_default": true, "trace_ttl_days": 30 },
+  "kind": "aiRetention",
+  "schemaVersion": 1
+}
+```
+
+Set a team TTL (1–365 days):
+
+```bash
+flowplane ai retention set --days 7 --json
+```
+
+```json
+{
+  "data": { "is_default": false, "revision": 1, "trace_ttl_days": 7,
+            "updated_at": "2026-07-05T11:06:28.118358Z" },
+  "kind": "aiRetention",
+  "schemaVersion": 1
+}
+```
+
+The TTL is stamped at capture time: changing it affects only traces recorded
+*after* the change; existing rows keep the expiry they were written with. A
+control-plane background sweep deletes expired rows hourly. Setting the policy
+requires the `ai-usage` update grant.
+
+## Export the timeline as OTLP spans
+
+When the control plane runs with `FLOWPLANE_OTLP_ENDPOINT` set, every hop is
+also emitted as a tracing span (nested under a per-request span) to your OTLP
+collector. Export is best-effort — the trace row above remains the primary
+record and is unaffected by collector availability. See the
+[configuration reference](../reference/configuration.md).
+
+## Further reading
+
+- [CLI reference — `ai trace`, `ai retention`](../reference/cli.md)
+- [REST API reference — request correlation and the `ai/trace`, `ai/retention` endpoints](../reference/rest-api.md)
+- [Observability alert pack — `fp_ai_trace_dropped_total`](../reference/observability-alerts.md)

--- a/docs/how-to/trace-ai-requests.md
+++ b/docs/how-to/trace-ai-requests.md
@@ -66,7 +66,18 @@ Expected output (a successful request; timestamps trimmed):
             "detail": { "model": "gpt-4o-mini", "listener_id": "…", "route_config_id": "…" } },
           { "hop": "auth", "origin": "listener", "outcome": "not_configured", "detail": {} },
           { "hop": "budget", "origin": "upstream", "outcome": "allowed",
-            "detail": { "mode": "enforcing", "verdict": "allowed" } },
+            "detail": {
+              "mode": "enforcing",
+              "verdict": "allowed",
+              "shadow": [
+                {
+                  "budget": "preview-team-monthly",
+                  "verdict": "would_reject",
+                  "used_units": 100000,
+                  "limit_units": 100000
+                }
+              ]
+            } },
           { "hop": "credential_injection", "origin": "upstream", "outcome": "injected",
             "detail": { "provider_id": "…", "auth_header": "authorization" } },
           { "hop": "upstream", "origin": "upstream", "outcome": "ok",
@@ -139,9 +150,12 @@ you the class:
 | `upstream` | `no_upstream_connection` | 503 | Envoy could not connect to the provider — check `base_url` and network reachability |
 | `upstream` | `client_disconnect` | — | the client dropped mid-stream; the partial row is still persisted |
 
-A **shadow** budget that would have rejected shows up on *successful* requests:
-the `budget` hop records verdict `would_reject` while the request still returns
-2xx — use it to preview an enforcement change before flipping the budget mode.
+A **shadow** budget preview that would have rejected shows up on *successful*
+requests under `budget.detail.shadow[]`. The budget hop's top-level
+`detail.mode` and `detail.verdict` describe the enforcing gate for the request,
+so a successful request can keep top-level `detail.verdict: "allowed"` while a
+shadow entry reports `detail.shadow[].verdict: "would_reject"`. Use shadow
+entries to preview an enforcement change before flipping the budget mode.
 
 ## 5. When there is no trace
 

--- a/docs/how-to/trace-ai-requests.md
+++ b/docs/how-to/trace-ai-requests.md
@@ -2,12 +2,12 @@
 
 > Audience: api-teams, operators · Status: stable
 
-Every request that reaches an AI listener leaves a **trace row**: a per-hop
-timeline of what the gateway did (route match, auth, budget check, credential
-injection, upstream call, usage accounting), with an outcome and timing for each
-hop. This guide shows how to retrieve that timeline to answer "where did my AI
-request die, and why" — without reading Envoy logs — and how to control how long
-trace rows are kept.
+Every request that reaches an AI listener leaves a **trace row**: one merged
+record of the ExtProc stream contributions for the request (route match, auth,
+budget check, credential injection, upstream call, usage accounting), with an
+outcome and timing window for each hop. This guide shows how to retrieve that
+row to answer "where did my AI request die, and why" — without reading Envoy
+logs — and how to control how long trace rows are kept.
 
 Prerequisites: a working AI provider + route (see
 [Create an AI provider, route traffic to it, and attach a token budget](./ai-gateway-route-budget.md))
@@ -43,7 +43,7 @@ That id is the key to the trace row.
 > only that server id keys a trace. If you send your own id, it will not find
 > a trace — use the id from the *response*.
 
-## 2. Retrieve the hop timeline
+## 2. Retrieve the hop record
 
 ```bash
 flowplane ai trace --request-id 019f2f5a-9ae3-76d1-bd61-dcc24cfe6e6c --json
@@ -84,8 +84,29 @@ Expected output (a successful request; timestamps trimmed):
 }
 ```
 
-Each hop carries `started_at`/`ended_at` (elided above), so slow requests show
-*where* the time went — `upstream.detail.latency_ms` is the provider round trip.
+The `hops` array is a merged row view of one or more ExtProc stream
+contributions, not the execution-order contract for the request. Do not infer a
+single sequential waterfall from array position. `origin` is the stream-context
+label attached to the hop, such as `listener` or `upstream`; it is not a
+physical-side guarantee and it does not by itself prove the order in which gates
+executed.
+
+Each hop carries `started_at`/`ended_at` (elided above). These timestamps are
+per-hop windows from the stream that pushed the hop, so windows may overlap or
+appear back-anchored. In the successful sample above, the surviving `budget`,
+`credential_injection`, `upstream`, and `usage` hops all have
+`origin: "upstream"` because they are upstream-labeled stream contributions
+after merge. The `upstream` hop can start before or overlap the same-origin
+`budget` and `credential_injection` hops because it is anchored to that stream's
+request-header window, while the budget and credential windows start when those
+checks run later in the stream.
+
+That timestamp shape does not mean the checks were skipped or bypassed.
+Enforcing budget rejection and credential failure short-circuit before upstream
+forwarding; failed traces for those cases do not produce an upstream hop.
+`upstream.detail.latency_ms` remains the upstream-hop latency signal, but it is
+measured from the upstream-labeled stream window rather than promised as pure
+provider-only time.
 
 Trace rows never contain prompt or completion text, request/response bodies, or
 credential values; the schema stores outcomes, ids, timings, and token counts

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -286,6 +286,9 @@ AI gateway resources. `providers`, `routes`, and `budgets` each use the shared r
 | `ai routes <RESOURCE_CMD>` | shared resource subcommands (see `cluster`) |
 | `ai budgets <RESOURCE_CMD>` | shared resource subcommands (see `cluster`) |
 | `ai usage` | `--team <TEAM>`, `--provider-id <ID>`, `--route-config-id <ID>`, `--limit <N>` (i64, default 50), `--offset <N>` (i64, default 0) |
+| `ai trace` | `--team <TEAM>`, `--request-id <ID>` (server-generated `x-request-id` from the AI data-plane response), `--trace-id <ID>` (W3C trace id from an inbound `traceparent`), `--limit <N>` (i64, default 50) |
+| `ai retention get` | `--team <TEAM>` — shows the trace TTL in force (team policy or the built-in 30-day default) |
+| `ai retention set` | `--team <TEAM>`, `--days <DAYS>` (i32, 1–365, required) — create-or-replace; affects only newly captured traces |
 
 ### `learn`
 Learning capture sessions.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -29,7 +29,7 @@ Booleans accept `true`/`1`/`yes` and `false`/`0`/`no`. Invalid server values fai
 | `FLOWPLANE_XDS_TLS_CLIENT_CA` | server | — | no ³ | CA bundle dataplane client certs must chain to. |
 | `FLOWPLANE_LOG_FORMAT` | server | `json` | no | Log format: `json` or `pretty`. |
 | `FLOWPLANE_LOG` | server | `info` | no | `tracing` env-filter directive. |
-| `FLOWPLANE_OTLP_ENDPOINT` | server | — | no | OTLP trace export endpoint; unset disables export. |
+| `FLOWPLANE_OTLP_ENDPOINT` | server | — | no | OTLP trace export endpoint; unset disables export. When set, AI gateway hop timelines are also exported as spans (one span per hop, nested under a per-request span); export is best-effort and never affects request handling or trace-row persistence. |
 | `FLOWPLANE_DEV_MODE` | server | `false` | no ⁴ | In-process OIDC issuer + seeded resources; needs the `dev-oidc` build feature. |
 | `FLOWPLANE_DEV_MODE_ACK` | server | — | no ⁴ | In release builds, dev mode requires this to equal `yes-this-is-not-production`. |
 | `FLOWPLANE_DEV_TOKEN_PATH` | server | — | no | Dev mode only: also write the per-boot dev bearer token to this file (it is otherwise only logged), so a sibling/init container can read it. Ignored outside dev mode. |

--- a/docs/reference/observability-alerts.md
+++ b/docs/reference/observability-alerts.md
@@ -34,6 +34,7 @@ Native OpenTelemetry `gen_ai.*` semantic-convention meters are deferred for v1.0
 | Outbox handler failures | `fp_outbox_handler_failures_total` | counter | `consumer` | outbox consumer |
 | Capture drops | `fp_capture_dropped_total` | counter | `source`, `reason` | ALS/ext_proc capture ingest |
 | AI budget threshold crossings | `fp_ai_budget_threshold_crossings_total` | counter | `mode`, `result` | capture budget enforcement |
+| AI trace persistence drops | `fp_ai_trace_dropped_total` | counter | `reason` | ext_proc trace capture; trace writes are best-effort, so a sustained rate here means AI request traces are being lost (DB pressure) while traffic itself is unaffected |
 | Sampler failures | `fp_observability_sampler_failures_total` | counter | `source` | serve-owned sampler |
 
 ## Alert Baseline

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -78,6 +78,7 @@ Endpoints that use `ListQuery` return the uniform `Page<T>` envelope:
 
 - Every request is assigned a request id, honoring a syntactically valid inbound `x-request-id` header (otherwise generated). The id is echoed in the `x-request-id` response header and included in the error envelope as `request_id`.
 - A W3C `traceparent` header on the request is honored, joining Flowplane spans to the caller's distributed trace.
+- **AI data-plane listeners differ deliberately**: they ignore a client-supplied `x-request-id`, always generate a server-owned id, and always return it in the response. Only the server-generated id keys the request's trace row (`GET /api/v1/teams/{team}/ai/trace`). An inbound `traceparent` is forwarded to the AI provider unchanged and its `trace_id` is stored on the trace row for cross-system correlation. See [Trace an AI request through the gateway](../how-to/trace-ai-requests.md).
 
 ### Errors
 
@@ -427,7 +428,7 @@ configured). The 60 s reconcile loop is the backstop; this is only a fast path.
 | POST | `/api/v1/teams/{team}/route-generation-plans` |
 | POST | `/api/v1/teams/{team}/route-generation-plans/{plan_id}/apply` |
 
-### AI (providers, routes, budgets, usage)
+### AI (providers, routes, budgets, usage, trace, retention)
 
 | Method | Path |
 |--------|------|
@@ -447,6 +448,11 @@ configured). The 60 s reconcile loop is the backstop; this is only a fast path.
 | PATCH  | `/api/v1/teams/{team}/ai/budgets/{name}` |
 | DELETE | `/api/v1/teams/{team}/ai/budgets/{name}` |
 | GET    | `/api/v1/teams/{team}/ai/usage` |
+| GET    | `/api/v1/teams/{team}/ai/trace` |
+| GET    | `/api/v1/teams/{team}/ai/retention` |
+| PUT    | `/api/v1/teams/{team}/ai/retention` |
+
+`GET ai/trace` takes `request_id`, `trace_id`, and `limit` query parameters and returns the per-hop trace timeline for AI data-plane requests; a lookup with no matching row returns an explicit miss object naming the never-traced request classes. `PUT ai/retention` sets the team's trace TTL in days (1–365; default 30 when no policy exists) and requires the `ai-usage` update grant.
 
 ### Dataplanes (+ proxy certificates, telemetry, envoy config)
 

--- a/scripts/e2e/18-p1f-ai-trace.sh
+++ b/scripts/e2e/18-p1f-ai-trace.sh
@@ -1,0 +1,266 @@
+# E2E phase P1f — sourced by scripts/e2e/run.sh (shares the runner shell: $TOKEN, auth[], helpers).
+REQUIRES=""
+
+# ---- Phase 1f: AI e2e trace rows (feature ai-gateway-e2e-trace, slice s2).
+# Covers design AC 1 (success trace with the full hop timeline), AC 14 (server-owned
+# request identity — client-supplied x-request-id never keys a row), AC 9 inbound-only
+# (traceparent reaches the stub unchanged and trace_id lands on the row / stays NULL when
+# absent), AC 6 (no prompt/secret strings in the stored row), and the 30-day default TTL.
+# Trace retrieval REST/CLI is slice s4; this phase asserts the persisted rows directly,
+# the same way earlier phases assert ai_usage_events.
+#
+# Parallel-safety shape (constitution invariant 18, plan s2 e2e layer): this phase creates
+# its own uniquely named team with its own dataplane and Envoy (xDS is team-scoped, so the
+# harness Envoy bound to team default cannot serve another team's listener), uses uniquely
+# suffixed resource names, and no fixed ports — the stub upstream binds port 0 and reports
+# the kernel-chosen port back; the gateway listener and Envoy admin ports must be concrete
+# numbers in config, so they come from a bind-0-then-release per-run allocation.
+
+AI_TRACE_SFX=$(python3 -c 'import secrets; print(secrets.token_hex(4))')
+AI_TRACE_TEAM="e2e-trace-$AI_TRACE_SFX"
+AI_TRACE_ROUTE_NAME="ai-e2e-trace-$AI_TRACE_SFX"
+AI_TRACE_SECRET_VALUE="Bearer fp-e2e-trace-secret"
+AI_TRACE_SECRET_B64=$(python3 -c 'import base64; print(base64.b64encode(b"Bearer fp-e2e-trace-secret").decode())')
+
+# Gateway listener + trace-Envoy admin ports: unique per-run kernel allocations (both
+# sockets held open together so the two ports cannot collide with each other).
+AI_TRACE_PORTS=$(python3 - <<'PY'
+import socket
+socks = [socket.socket() for _ in range(2)]
+for s in socks:
+    s.bind(("127.0.0.1", 0))
+print(" ".join(str(s.getsockname()[1]) for s in socks))
+for s in socks:
+    s.close()
+PY
+)
+AI_TRACE_GATEWAY_PORT=${AI_TRACE_PORTS%% *}
+AI_TRACE_ADMIN_PORT=${AI_TRACE_PORTS##* }
+
+# Header-logging stub provider: binds port 0, writes the chosen port to a file, and records
+# traceparent/x-request-id/authorization per request.
+cat >/tmp/fp-e2e-ai-trace-provider.py <<'PY'
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+port_file = sys.argv[1]
+log_path = sys.argv[2]
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *_):
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("content-length", "0"))
+        self.rfile.read(length)
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps({
+                "traceparent": self.headers.get("traceparent"),
+                "x_request_id": self.headers.get("x-request-id"),
+                "authorization": self.headers.get("authorization"),
+            }) + "\n")
+        body = {
+            "id": "chatcmpl-fp-e2e-trace",
+            "object": "chat.completion",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "mock-ai-trace-ok"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5},
+        }
+        data = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+with open(port_file, "w", encoding="utf-8") as f:
+    f.write(str(server.server_address[1]))
+server.serve_forever()
+PY
+: >/tmp/fp-e2e-ai-trace-upstream.jsonl
+rm -f /tmp/fp-e2e-ai-trace-provider.port
+python3 /tmp/fp-e2e-ai-trace-provider.py /tmp/fp-e2e-ai-trace-provider.port /tmp/fp-e2e-ai-trace-upstream.jsonl >/tmp/fp-e2e-ai-trace-provider.log 2>&1 &
+AI_TRACE_STUB_PID=$!
+AI_TRACE_PROVIDER_PORT=""
+for i in $(seq 1 20); do
+  AI_TRACE_PROVIDER_PORT=$(cat /tmp/fp-e2e-ai-trace-provider.port 2>/dev/null || true)
+  [ -n "$AI_TRACE_PROVIDER_PORT" ] && break
+  sleep 0.5
+done
+[ -n "$AI_TRACE_PROVIDER_PORT" ] || fail "AI trace stub provider did not report its bound port"
+
+# Unique team + its own dataplane and Envoy (xDS is team-scoped; see phase header).
+AI_TRACE_TEAM_ID=$(curl -fsS "${auth[@]}" -X POST http://$API/api/v1/teams -d "{\"name\":\"$AI_TRACE_TEAM\"}" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['id'])")
+[ -n "$AI_TRACE_TEAM_ID" ] || fail "AI trace team $AI_TRACE_TEAM was not created"
+
+AI_TRACE_SECRET_ID=$(curl -fsS "${auth[@]}" -X POST http://$API/api/v1/teams/$AI_TRACE_TEAM/secrets \
+  -d "{\"name\":\"ai-e2e-trace-key-$AI_TRACE_SFX\",\"description\":\"AI e2e trace credential\",\"spec\":{\"type\":\"generic_secret\",\"secret\":\"$AI_TRACE_SECRET_B64\"}}" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['id'])")
+AI_TRACE_PROVIDER_ID=$(curl -fsS "${auth[@]}" -X POST http://$API/api/v1/teams/$AI_TRACE_TEAM/ai/providers \
+  -d "{\"name\":\"ai-e2e-trace-provider-$AI_TRACE_SFX\",\"spec\":{\"kind\":\"openai-compatible\",\"base_url\":\"http://127.0.0.1:$AI_TRACE_PROVIDER_PORT\",\"credential_secret_id\":\"$AI_TRACE_SECRET_ID\",\"auth_header\":\"authorization\",\"models\":[\"gpt-5\"]}}" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['id'])")
+AI_TRACE_ROUTE_ID=$(curl -fsS "${auth[@]}" -X POST http://$API/api/v1/teams/$AI_TRACE_TEAM/ai/routes \
+  -d "{\"name\":\"$AI_TRACE_ROUTE_NAME\",\"spec\":{\"listener_port\":$AI_TRACE_GATEWAY_PORT,\"backends\":[{\"provider_id\":\"$AI_TRACE_PROVIDER_ID\",\"models\":[],\"weight\":1}]}}" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['id'])")
+AI_TRACE_ROUTE_CONFIG_ID=$(psql "$PG_DB_URL" -Atc "SELECT id FROM route_configs WHERE team_id = '$AI_TRACE_TEAM_ID' AND name = 'ai-$AI_TRACE_ROUTE_NAME-routes' AND owner_kind = 'ai'")
+[ -n "$AI_TRACE_ROUTE_CONFIG_ID" ] || fail "AI trace route materialized route config not found"
+
+FLOWPLANE_TEAM=$AI_TRACE_TEAM ./target/debug/flowplane dataplane create "dp-trace-$AI_TRACE_SFX" \
+  --description "AI trace e2e Envoy" >/dev/null
+FLOWPLANE_TEAM=$AI_TRACE_TEAM ./target/debug/flowplane --out /tmp/fp-e2e-ai-trace-bootstrap.yaml \
+  dataplane bootstrap "dp-trace-$AI_TRACE_SFX" --mode dev \
+  --xds-host 127.0.0.1 --xds-port "$XDS_PORT" --admin-port "$AI_TRACE_ADMIN_PORT"
+if [ "$ENVOY_MODE" = docker ]; then
+  docker run -d --name fp-e2e-envoy-trace --network host \
+    -v /tmp/fp-e2e-ai-trace-bootstrap.yaml:/etc/envoy/envoy.yaml:ro \
+    envoyproxy/envoy:v${ENVOY_VERSION} -c /etc/envoy/envoy.yaml --log-level info >/dev/null
+else
+  # --base-id 1: a second Envoy process on the same host must not share the default
+  # shared-memory region with the harness Envoy.
+  envoy -c /tmp/fp-e2e-ai-trace-bootstrap.yaml --base-id 1 --log-level info \
+    > /tmp/fp-e2e-ai-trace-envoy.log 2>&1 &
+  AI_TRACE_ENVOY_PID=$!
+fi
+for i in $(seq 1 50); do
+  curl -fsS http://127.0.0.1:$AI_TRACE_ADMIN_PORT/config_dump >/tmp/fp-e2e-ai-trace-dump.json 2>/dev/null || true
+  grep -q "ai-$AI_TRACE_ROUTE_NAME-listener" /tmp/fp-e2e-ai-trace-dump.json && break
+  sleep 1
+done
+grep -q "ai-$AI_TRACE_ROUTE_NAME-listener" /tmp/fp-e2e-ai-trace-dump.json || fail "AI trace listener did not converge on the trace-team Envoy"
+
+AI_TRACE_PROMPT="fp-e2e-trace-prompt-$AI_TRACE_SFX"
+AI_TRACE_REQUEST="{\"model\":\"gpt-5\",\"messages\":[{\"role\":\"user\",\"content\":\"$AI_TRACE_PROMPT\"}]}"
+AI_TRACE_TRACEPARENT="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+# ---- AC 1 + AC 9 (inbound traceparent) + AC 6 + TTL: successful chat completion.
+AI_TRACE_CODE=""
+for i in $(seq 1 50); do
+  AI_TRACE_CODE=$(curl -sS -o /tmp/fp-e2e-ai-trace-1.json -D /tmp/fp-e2e-ai-trace-1.hdrs -w '%{http_code}' \
+    -H "content-type: application/json" -H "x-flowplane-ai-model: gpt-5" \
+    -H "traceparent: $AI_TRACE_TRACEPARENT" --data "$AI_TRACE_REQUEST" \
+    http://127.0.0.1:$AI_TRACE_GATEWAY_PORT/v1/chat/completions 2>/dev/null || true)
+  [ "$AI_TRACE_CODE" = "200" ] && break
+  sleep 1
+done
+[ "$AI_TRACE_CODE" = "200" ] || fail "AI trace route never served stub provider (last code $AI_TRACE_CODE)"
+grep -q "mock-ai-trace-ok" /tmp/fp-e2e-ai-trace-1.json || fail "AI trace stub response did not reach client"
+AI_TRACE_REQ_ID=$(grep -i '^x-request-id:' /tmp/fp-e2e-ai-trace-1.hdrs | head -1 | awk '{print $2}' | tr -d '\r')
+[ -n "$AI_TRACE_REQ_ID" ] || fail "AI trace response did not carry x-request-id"
+
+# Both ExtProc streams persist at stream end — poll until the merged row is complete.
+AI_TRACE_ROW=""
+for i in $(seq 1 20); do
+  AI_TRACE_ROW=$(psql "$PG_DB_URL" -Atc "SELECT row_to_json(t)::text FROM (SELECT * FROM ai_trace_events WHERE team_id = '$AI_TRACE_TEAM_ID' AND request_id = '$AI_TRACE_REQ_ID') t" 2>/dev/null || true)
+  grep -q '"usage"' <<<"$AI_TRACE_ROW" && grep -q '"route_match"' <<<"$AI_TRACE_ROW" && break
+  sleep 1
+done
+[ -n "$AI_TRACE_ROW" ] || fail "no ai_trace_events row for request $AI_TRACE_REQ_ID"
+printf '%s' "$AI_TRACE_ROW" > /tmp/fp-e2e-ai-trace-row.json
+python3 - "$AI_TRACE_PROVIDER_ID" /tmp/fp-e2e-ai-trace-row.json <<'PY' || fail "AI trace success row failed hop-timeline assertions"
+import json, sys
+row = json.load(open(sys.argv[2], encoding="utf-8"))
+hops = row["hops"]
+by_name = {h["hop"]: h for h in hops}
+expected = ["route_match", "auth", "budget", "credential_injection", "upstream", "usage"]
+assert sorted(by_name) == sorted(expected), f"hops {sorted(by_name)}"
+assert len(hops) == len(expected), "duplicate hop entries"
+assert by_name["auth"]["outcome"] == "not_configured"
+assert by_name["budget"]["outcome"] == "allowed"
+assert by_name["credential_injection"]["outcome"] == "injected"
+assert by_name["upstream"]["detail"]["status"] == 200
+assert by_name["usage"]["detail"]["total_tokens"] > 0
+for h in hops:
+    assert h["started_at"] <= h["ended_at"], f"hop {h['hop']} window inverted"
+assert row["failure_hop"] is None
+assert row["status_code"] == 200
+assert row["trace_id"] == "4bf92f3577b34da6a3ce929d0e0e4736"
+assert row["listener_id"] is not None
+assert row["provider_id"] == sys.argv[1]
+PY
+# AC 9: the stub upstream received the inbound traceparent unchanged.
+grep -q "$AI_TRACE_TRACEPARENT" /tmp/fp-e2e-ai-trace-upstream.jsonl || fail "inbound traceparent did not reach the stub upstream unchanged"
+# AC 6: neither the prompt string nor the secret value is stored anywhere in the row.
+if grep -q "$AI_TRACE_PROMPT" <<<"$AI_TRACE_ROW"; then
+  fail "prompt string leaked into ai_trace_events row"
+fi
+if grep -q "$AI_TRACE_SECRET_VALUE" <<<"$AI_TRACE_ROW"; then
+  fail "AI credential value leaked into ai_trace_events row"
+fi
+# Default TTL: with no ai_retention_policies row, expires_at = created_at + 30 days exactly.
+AI_TRACE_TTL_OK=$(psql "$PG_DB_URL" -Atc "SELECT expires_at = created_at + interval '30 days' FROM ai_trace_events WHERE team_id = '$AI_TRACE_TEAM_ID' AND request_id = '$AI_TRACE_REQ_ID'")
+[ "$AI_TRACE_TTL_OK" = "t" ] || fail "ai_trace_events expires_at is not created_at + 30 days (got $AI_TRACE_TTL_OK)"
+
+# ---- AC 14: server-owned request identity under a reused client-supplied x-request-id.
+AI_TRACE_CLIENT_ID="11111111-2222-4333-8444-555555555555"
+AI_TRACE_ID_A=""
+AI_TRACE_ID_B=""
+for attempt in A B; do
+  curl -sS -o /tmp/fp-e2e-ai-trace-dup.json -D /tmp/fp-e2e-ai-trace-dup.hdrs \
+    -H "content-type: application/json" -H "x-flowplane-ai-model: gpt-5" \
+    -H "x-request-id: $AI_TRACE_CLIENT_ID" --data "$AI_TRACE_REQUEST" \
+    http://127.0.0.1:$AI_TRACE_GATEWAY_PORT/v1/chat/completions >/dev/null
+  SERVED_ID=$(grep -i '^x-request-id:' /tmp/fp-e2e-ai-trace-dup.hdrs | head -1 | awk '{print $2}' | tr -d '\r')
+  [ -n "$SERVED_ID" ] || fail "duplicate-id request $attempt returned no x-request-id"
+  [ "$SERVED_ID" != "$AI_TRACE_CLIENT_ID" ] || fail "server honored the client-supplied x-request-id on AI listener (attempt $attempt)"
+  if [ "$attempt" = "A" ]; then AI_TRACE_ID_A=$SERVED_ID; else AI_TRACE_ID_B=$SERVED_ID; fi
+done
+[ "$AI_TRACE_ID_A" != "$AI_TRACE_ID_B" ] || fail "two requests received the same server-generated x-request-id"
+# Each served id must key exactly one row whose merged hop timeline carries both the
+# listener-side hops (route_match/auth) and the upstream-side hops (upstream/usage) —
+# the full six-hop set, same shape as the AC 1 row (plan AC 14).
+for served in "$AI_TRACE_ID_A" "$AI_TRACE_ID_B"; do
+  AI_TRACE_DUP_ROW=""
+  for i in $(seq 1 20); do
+    AI_TRACE_DUP_ROW=$(psql "$PG_DB_URL" -Atc "SELECT row_to_json(t)::text FROM (SELECT * FROM ai_trace_events WHERE team_id = '$AI_TRACE_TEAM_ID' AND request_id = '$served') t" 2>/dev/null || true)
+    grep -q '"usage"' <<<"$AI_TRACE_DUP_ROW" && grep -q '"route_match"' <<<"$AI_TRACE_DUP_ROW" && break
+    sleep 1
+  done
+  [ -n "$AI_TRACE_DUP_ROW" ] || fail "no ai_trace_events row for duplicate-client-id request $served"
+  AI_TRACE_DUP_COUNT=$(psql "$PG_DB_URL" -Atc "SELECT count(*) FROM ai_trace_events WHERE team_id = '$AI_TRACE_TEAM_ID' AND request_id = '$served'")
+  [ "$AI_TRACE_DUP_COUNT" = "1" ] || fail "expected exactly one trace row for $served, got $AI_TRACE_DUP_COUNT"
+  printf '%s' "$AI_TRACE_DUP_ROW" > /tmp/fp-e2e-ai-trace-dup-row.json
+  python3 - /tmp/fp-e2e-ai-trace-dup-row.json <<'PY' || fail "duplicate-client-id row $served is missing listener-side or upstream-side hops"
+import json, sys
+row = json.load(open(sys.argv[1], encoding="utf-8"))
+names = sorted(h["hop"] for h in row["hops"])
+expected = sorted(["route_match", "auth", "budget", "credential_injection", "upstream", "usage"])
+assert names == expected, f"hops {names}"
+for h in row["hops"]:
+    assert h["started_at"] <= h["ended_at"], f"hop {h['hop']} window inverted"
+assert row["failure_hop"] is None
+assert row["listener_id"] is not None
+assert row["provider_id"] is not None
+PY
+done
+AI_TRACE_CLIENT_ROWS=$(psql "$PG_DB_URL" -Atc "SELECT count(*) FROM ai_trace_events WHERE team_id = '$AI_TRACE_TEAM_ID' AND request_id = '$AI_TRACE_CLIENT_ID'")
+[ "$AI_TRACE_CLIENT_ROWS" = "0" ] || fail "client-supplied x-request-id keyed a trace row ($AI_TRACE_CLIENT_ROWS rows)"
+
+# ---- AC 9 (negative): a request without traceparent leaves trace_id NULL.
+curl -sS -o /dev/null -D /tmp/fp-e2e-ai-trace-nt.hdrs \
+  -H "content-type: application/json" -H "x-flowplane-ai-model: gpt-5" --data "$AI_TRACE_REQUEST" \
+  http://127.0.0.1:$AI_TRACE_GATEWAY_PORT/v1/chat/completions
+AI_TRACE_NT_ID=$(grep -i '^x-request-id:' /tmp/fp-e2e-ai-trace-nt.hdrs | head -1 | awk '{print $2}' | tr -d '\r')
+AI_TRACE_NT_NULL=""
+for i in $(seq 1 20); do
+  AI_TRACE_NT_NULL=$(psql "$PG_DB_URL" -Atc "SELECT trace_id IS NULL FROM ai_trace_events WHERE team_id = '$AI_TRACE_TEAM_ID' AND request_id = '$AI_TRACE_NT_ID'")
+  [ -n "$AI_TRACE_NT_NULL" ] && break
+  sleep 1
+done
+[ "$AI_TRACE_NT_NULL" = "t" ] || fail "absent traceparent did not leave trace_id NULL (got '$AI_TRACE_NT_NULL')"
+
+# ---- Cleanup: this phase's Envoy, stub, and team resources.
+kill "$AI_TRACE_STUB_PID" >/dev/null 2>&1 || true
+if [ "$ENVOY_MODE" = docker ]; then
+  docker rm -f fp-e2e-envoy-trace >/dev/null 2>&1 || true
+else
+  kill "${AI_TRACE_ENVOY_PID:-}" >/dev/null 2>&1 || true
+fi
+AI_TRACE_ROUTE_REV=$(psql "$PG_DB_URL" -Atc "SELECT version FROM ai_routes WHERE id = '$AI_TRACE_ROUTE_ID'")
+curl -fsS "${auth[@]}" -X DELETE -H "If-Match: $AI_TRACE_ROUTE_REV" \
+  http://$API/api/v1/teams/$AI_TRACE_TEAM/ai/routes/$AI_TRACE_ROUTE_NAME >/dev/null
+AI_TRACE_PROVIDER_REV=$(psql "$PG_DB_URL" -Atc "SELECT version FROM ai_providers WHERE id = '$AI_TRACE_PROVIDER_ID'")
+curl -fsS "${auth[@]}" -X DELETE -H "If-Match: $AI_TRACE_PROVIDER_REV" \
+  http://$API/api/v1/teams/$AI_TRACE_TEAM/ai/providers/ai-e2e-trace-provider-$AI_TRACE_SFX >/dev/null
+echo "PHASE 1f OK: AI trace rows -> success hop timeline (AC1) -> server-owned request identity + per-row hop shape (AC14) -> traceparent propagation + trace_id (AC9) -> sensitive-string exclusion (AC6) -> 30-day default TTL"

--- a/scripts/e2e/19-p1g-ai-trace-failures.sh
+++ b/scripts/e2e/19-p1g-ai-trace-failures.sh
@@ -1,0 +1,411 @@
+# E2E phase P1g — sourced by scripts/e2e/run.sh (shares the runner shell: $TOKEN, auth[], helpers).
+REQUIRES=""
+
+# ---- Phase 1g: AI trace failure-path rows (feature ai-gateway-e2e-trace, slice s3).
+# One live smoke per failure class, each asserting its persisted ai_trace_events row:
+#   - no-eligible-backend direct 400  -> failure_hop='route_match', outcome no_eligible_backend (AC 11)
+#   - provider 500                    -> failure_hop='upstream', hop status 500 + provider ids (AC 4)
+#   - mid-SSE client disconnect       -> partial row, upstream hop outcome client_disconnect (Risk 6)
+#   - upstream connect failure (503)  -> failure_hop='upstream', outcome no_upstream_connection (Risk 6)
+#   - exhausted shadow budget         -> 2xx + budget hop shadow verdict would_reject (AC 3)
+#   - exhausted enforcing budget      -> 429 + failure_hop='budget', verdict rejected, no later hops (AC 2)
+#   - credential/secret failure       -> 500 credential-unavailable + failure_hop='credential_injection',
+#     outcome secret_missing, provoked fully in-band by rotating the shared provider secret to a
+#     near-future expires_at (the runtime credential read skips expired rows). Runs LAST: it kills
+#     credentials for both providers. The decrypt_failed outcome variant of the same class stays at
+#     the capture layer (fp-xds ai_credential_failure_stream_persists_secret_missing_and_decrypt_failed_rows):
+#     REST validates generic secrets are base64 at create/rotate, so undecodable credential material
+#     cannot be authored in-band — only out-of-band ciphertext corruption reaches that branch.
+#
+# Parallel-safety shape (constitution invariant 18): own uniquely named team with its own
+# dataplane and Envoy, uniquely suffixed resource names, no fixed ports — the stub binds
+# port 0; gateway/admin/dead-upstream ports come from a bind-0-then-release allocation.
+
+AI_FAIL_SFX=$(python3 -c 'import secrets; print(secrets.token_hex(4))')
+AI_FAIL_TEAM="e2e-trfail-$AI_FAIL_SFX"
+AI_FAIL_ROUTE_NAME="ai-e2e-trfail-$AI_FAIL_SFX"
+AI_FAIL_DEAD_ROUTE_NAME="ai-e2e-trfail-dead-$AI_FAIL_SFX"
+AI_FAIL_SECRET_B64=$(python3 -c 'import base64; print(base64.b64encode(b"Bearer fp-e2e-trfail-secret").decode())')
+
+# Gateway A (live stub), gateway B (dead upstream), Envoy admin, dead upstream port:
+# unique per-run kernel allocations, all four sockets held open together.
+AI_FAIL_PORTS=$(python3 - <<'PY'
+import socket
+socks = [socket.socket() for _ in range(4)]
+for s in socks:
+    s.bind(("127.0.0.1", 0))
+print(" ".join(str(s.getsockname()[1]) for s in socks))
+for s in socks:
+    s.close()
+PY
+)
+read -r AI_FAIL_GATEWAY_PORT AI_FAIL_DEAD_GATEWAY_PORT AI_FAIL_ADMIN_PORT AI_FAIL_DEAD_UPSTREAM_PORT <<<"$AI_FAIL_PORTS"
+
+# Stub provider: 200+usage by default, 500 when the prompt carries the fail marker, and a
+# never-ending SSE stream for stream:true requests (the client will disconnect mid-stream).
+cat >/tmp/fp-e2e-ai-trfail-provider.py <<'PY'
+import json
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+port_file = sys.argv[1]
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *_):
+        pass
+
+    def do_POST(self):
+        length = int(self.headers.get("content-length", "0") or 0)
+        raw = self.rfile.read(length) if length else b""
+        try:
+            body = json.loads(raw)
+        except Exception:
+            body = {}
+        prompt = json.dumps(body.get("messages", []))
+        if "fp-fail-500" in prompt:
+            data = json.dumps({"error": {"message": "mock provider failure"}}).encode()
+            self.send_response(500)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+            return
+        if body.get("stream"):
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.end_headers()
+            try:
+                for i in range(60):
+                    chunk = "data: " + json.dumps(
+                        {"id": "chatcmpl-trfail-sse", "choices": [{"index": 0, "delta": {"content": f"tok{i}"}}]}
+                    ) + "\n\n"
+                    self.wfile.write(chunk.encode())
+                    self.wfile.flush()
+                    time.sleep(1)
+            except OSError:
+                pass
+            return
+        data = json.dumps({
+            "id": "chatcmpl-trfail-ok",
+            "object": "chat.completion",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "mock-trfail-ok"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5},
+        }).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+with open(port_file, "w", encoding="utf-8") as f:
+    f.write(str(server.server_address[1]))
+server.serve_forever()
+PY
+rm -f /tmp/fp-e2e-ai-trfail-provider.port
+python3 /tmp/fp-e2e-ai-trfail-provider.py /tmp/fp-e2e-ai-trfail-provider.port \
+  >/tmp/fp-e2e-ai-trfail-provider.log 2>&1 &
+AI_FAIL_STUB_PID=$!
+AI_FAIL_PROVIDER_PORT=""
+for i in $(seq 1 20); do
+  AI_FAIL_PROVIDER_PORT=$(cat /tmp/fp-e2e-ai-trfail-provider.port 2>/dev/null || true)
+  [ -n "$AI_FAIL_PROVIDER_PORT" ] && break
+  sleep 0.5
+done
+[ -n "$AI_FAIL_PROVIDER_PORT" ] || fail "AI trace-failure stub provider did not report its bound port"
+
+# Unique team + its own dataplane and Envoy (xDS is team-scoped).
+AI_FAIL_TEAM_ID=$(curl -fsS "${auth[@]}" -X POST http://$API/api/v1/teams -d "{\"name\":\"$AI_FAIL_TEAM\"}" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['id'])")
+[ -n "$AI_FAIL_TEAM_ID" ] || fail "AI trace-failure team $AI_FAIL_TEAM was not created"
+
+AI_FAIL_SECRET_ID=$(curl -fsS "${auth[@]}" -X POST http://$API/api/v1/teams/$AI_FAIL_TEAM/secrets \
+  -d "{\"name\":\"ai-e2e-trfail-key-$AI_FAIL_SFX\",\"description\":\"AI trace-failure credential\",\"spec\":{\"type\":\"generic_secret\",\"secret\":\"$AI_FAIL_SECRET_B64\"}}" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['id'])")
+AI_FAIL_PROVIDER_ID=$(curl -fsS "${auth[@]}" -X POST http://$API/api/v1/teams/$AI_FAIL_TEAM/ai/providers \
+  -d "{\"name\":\"ai-e2e-trfail-live-$AI_FAIL_SFX\",\"spec\":{\"kind\":\"openai-compatible\",\"base_url\":\"http://127.0.0.1:$AI_FAIL_PROVIDER_PORT\",\"credential_secret_id\":\"$AI_FAIL_SECRET_ID\",\"auth_header\":\"authorization\",\"models\":[\"gpt-5\"]}}" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['id'])")
+AI_FAIL_DEAD_PROVIDER_ID=$(curl -fsS "${auth[@]}" -X POST http://$API/api/v1/teams/$AI_FAIL_TEAM/ai/providers \
+  -d "{\"name\":\"ai-e2e-trfail-dead-$AI_FAIL_SFX\",\"spec\":{\"kind\":\"openai-compatible\",\"base_url\":\"http://127.0.0.1:$AI_FAIL_DEAD_UPSTREAM_PORT\",\"credential_secret_id\":\"$AI_FAIL_SECRET_ID\",\"auth_header\":\"authorization\",\"models\":[\"gpt-5\"]}}" \
+  | python3 -c "import sys,json;print(json.load(sys.stdin)['id'])")
+# Route A: single backend constrained to gpt-5 so an unknown model has NO eligible backend.
+curl -fsS "${auth[@]}" -X POST http://$API/api/v1/teams/$AI_FAIL_TEAM/ai/routes \
+  -d "{\"name\":\"$AI_FAIL_ROUTE_NAME\",\"spec\":{\"listener_port\":$AI_FAIL_GATEWAY_PORT,\"backends\":[{\"provider_id\":\"$AI_FAIL_PROVIDER_ID\",\"models\":[\"gpt-5\"],\"weight\":1}]}}" \
+  >/dev/null
+# Route B: backend whose upstream port has no listener -> Envoy local 503 connect failure.
+curl -fsS "${auth[@]}" -X POST http://$API/api/v1/teams/$AI_FAIL_TEAM/ai/routes \
+  -d "{\"name\":\"$AI_FAIL_DEAD_ROUTE_NAME\",\"spec\":{\"listener_port\":$AI_FAIL_DEAD_GATEWAY_PORT,\"backends\":[{\"provider_id\":\"$AI_FAIL_DEAD_PROVIDER_ID\",\"models\":[],\"weight\":1}]}}" \
+  >/dev/null
+AI_FAIL_ROUTE_CONFIG_ID=$(psql "$PG_DB_URL" -Atc "SELECT id FROM route_configs WHERE team_id = '$AI_FAIL_TEAM_ID' AND name = 'ai-$AI_FAIL_ROUTE_NAME-routes' AND owner_kind = 'ai'")
+[ -n "$AI_FAIL_ROUTE_CONFIG_ID" ] || fail "AI trace-failure route materialized route config not found"
+
+FLOWPLANE_TEAM=$AI_FAIL_TEAM ./target/debug/flowplane dataplane create "dp-trfail-$AI_FAIL_SFX" \
+  --description "AI trace-failure e2e Envoy" >/dev/null
+FLOWPLANE_TEAM=$AI_FAIL_TEAM ./target/debug/flowplane --out /tmp/fp-e2e-ai-trfail-bootstrap.yaml \
+  dataplane bootstrap "dp-trfail-$AI_FAIL_SFX" --mode dev \
+  --xds-host 127.0.0.1 --xds-port "$XDS_PORT" --admin-port "$AI_FAIL_ADMIN_PORT"
+if [ "$ENVOY_MODE" = docker ]; then
+  docker run -d --name fp-e2e-envoy-trfail --network host \
+    -v /tmp/fp-e2e-ai-trfail-bootstrap.yaml:/etc/envoy/envoy.yaml:ro \
+    envoyproxy/envoy:v${ENVOY_VERSION} -c /etc/envoy/envoy.yaml --log-level info >/dev/null
+else
+  # --base-id 2: must not share the shared-memory region with the harness Envoy (0) or the
+  # phase-1f Envoy (1).
+  envoy -c /tmp/fp-e2e-ai-trfail-bootstrap.yaml --base-id 2 --log-level info \
+    > /tmp/fp-e2e-ai-trfail-envoy.log 2>&1 &
+  AI_FAIL_ENVOY_PID=$!
+fi
+for i in $(seq 1 50); do
+  curl -fsS http://127.0.0.1:$AI_FAIL_ADMIN_PORT/config_dump >/tmp/fp-e2e-ai-trfail-dump.json 2>/dev/null || true
+  grep -q "ai-$AI_FAIL_ROUTE_NAME-listener" /tmp/fp-e2e-ai-trfail-dump.json \
+    && grep -q "ai-$AI_FAIL_DEAD_ROUTE_NAME-listener" /tmp/fp-e2e-ai-trfail-dump.json && break
+  sleep 1
+done
+grep -q "ai-$AI_FAIL_ROUTE_NAME-listener" /tmp/fp-e2e-ai-trfail-dump.json \
+  && grep -q "ai-$AI_FAIL_DEAD_ROUTE_NAME-listener" /tmp/fp-e2e-ai-trfail-dump.json \
+  || fail "AI trace-failure listeners did not converge on the phase Envoy"
+
+# Poll helper: wait for the trace row of one request id and dump it as JSON to $2.
+ai_fail_row() { # $1 = request id, $2 = out file, $3 = grep marker that must appear in the row
+  local row="" i
+  for i in $(seq 1 30); do
+    row=$(psql "$PG_DB_URL" -Atc "SELECT row_to_json(t)::text FROM (SELECT * FROM ai_trace_events WHERE team_id = '$AI_FAIL_TEAM_ID' AND request_id = '$1') t" 2>/dev/null || true)
+    [ -n "$row" ] && grep -q "$3" <<<"$row" && break
+    sleep 1
+  done
+  [ -n "$row" ] || return 1
+  grep -q "$3" <<<"$row" || return 1
+  printf '%s' "$row" > "$2"
+}
+
+AI_FAIL_OK_REQUEST='{"model":"gpt-5","messages":[{"role":"user","content":"trace failure smoke"}]}'
+
+# Warm the route: first request may race listener/cluster warm-up on a fresh Envoy.
+AI_FAIL_WARM=""
+for i in $(seq 1 50); do
+  AI_FAIL_WARM=$(curl -sS -o /dev/null -w '%{http_code}' \
+    -H "content-type: application/json" -H "x-flowplane-ai-model: gpt-5" \
+    --data "$AI_FAIL_OK_REQUEST" \
+    http://127.0.0.1:$AI_FAIL_GATEWAY_PORT/v1/chat/completions 2>/dev/null || true)
+  [ "$AI_FAIL_WARM" = "200" ] && break
+  sleep 1
+done
+[ "$AI_FAIL_WARM" = "200" ] || fail "AI trace-failure route never served the live stub (last code $AI_FAIL_WARM)"
+
+# ---- AC 11: model matching no backend -> direct 400 no_eligible_ai_backend + row.
+AI_FAIL_400_CODE=$(curl -sS -o /tmp/fp-e2e-trfail-400.json -D /tmp/fp-e2e-trfail-400.hdrs -w '%{http_code}' \
+  -H "content-type: application/json" -H "x-flowplane-ai-model: no-such-model" \
+  --data '{"model":"no-such-model","messages":[{"role":"user","content":"nope"}]}' \
+  http://127.0.0.1:$AI_FAIL_GATEWAY_PORT/v1/chat/completions)
+[ "$AI_FAIL_400_CODE" = "400" ] || fail "no-eligible-backend request expected 400, got $AI_FAIL_400_CODE"
+grep -qi "no_eligible_ai_backend" /tmp/fp-e2e-trfail-400.json || fail "400 body did not carry no_eligible_ai_backend"
+AI_FAIL_400_REQ=$(grep -i '^x-request-id:' /tmp/fp-e2e-trfail-400.hdrs | head -1 | awk '{print $2}' | tr -d '\r')
+[ -n "$AI_FAIL_400_REQ" ] || fail "no-eligible-backend response carried no x-request-id"
+ai_fail_row "$AI_FAIL_400_REQ" /tmp/fp-e2e-trfail-400-row.json '"route_match"' \
+  || fail "no ai_trace_events row for the no-eligible-backend request $AI_FAIL_400_REQ"
+python3 - /tmp/fp-e2e-trfail-400-row.json <<'PY' || fail "no-eligible-backend row failed assertions"
+import json, sys
+row = json.load(open(sys.argv[1], encoding="utf-8"))
+assert row["failure_hop"] == "route_match", row["failure_hop"]
+by_name = {h["hop"]: h for h in row["hops"]}
+assert by_name["route_match"]["outcome"] in ("no_eligible_backend", "no_upstream_response"), by_name["route_match"]
+assert by_name["route_match"]["failed"] is True
+assert "upstream" not in by_name and "credential_injection" not in by_name, sorted(by_name)
+PY
+
+# ---- AC 4: stub upstream returns 500 -> failure_hop='upstream' with status + provider ids.
+AI_FAIL_500_CODE=$(curl -sS -o /dev/null -D /tmp/fp-e2e-trfail-500.hdrs -w '%{http_code}' \
+  -H "content-type: application/json" -H "x-flowplane-ai-model: gpt-5" \
+  --data '{"model":"gpt-5","messages":[{"role":"user","content":"fp-fail-500"}]}' \
+  http://127.0.0.1:$AI_FAIL_GATEWAY_PORT/v1/chat/completions)
+[ "$AI_FAIL_500_CODE" = "500" ] || fail "provider-failure request expected 500, got $AI_FAIL_500_CODE"
+AI_FAIL_500_REQ=$(grep -i '^x-request-id:' /tmp/fp-e2e-trfail-500.hdrs | head -1 | awk '{print $2}' | tr -d '\r')
+ai_fail_row "$AI_FAIL_500_REQ" /tmp/fp-e2e-trfail-500-row.json '"upstream"' \
+  || fail "no ai_trace_events row for the provider-500 request $AI_FAIL_500_REQ"
+python3 - "$AI_FAIL_PROVIDER_ID" /tmp/fp-e2e-trfail-500-row.json <<'PY' || fail "provider-500 row failed assertions"
+import json, sys
+row = json.load(open(sys.argv[2], encoding="utf-8"))
+assert row["failure_hop"] == "upstream", row["failure_hop"]
+assert row["provider_id"] == sys.argv[1], row["provider_id"]
+up = next(h for h in row["hops"] if h["hop"] == "upstream")
+assert up["detail"]["status"] == 500, up["detail"]
+assert up["detail"]["provider_id"] == sys.argv[1], up["detail"]
+assert up["detail"]["backend_position"] == 0, up["detail"]
+assert up["failed"] is True
+PY
+
+# ---- Risk 6 (disconnect half): client disconnect mid-SSE still persists a partial row.
+curl -sN --max-time 3 -D /tmp/fp-e2e-trfail-sse.hdrs -o /tmp/fp-e2e-trfail-sse.body \
+  -H "content-type: application/json" -H "x-flowplane-ai-model: gpt-5" \
+  --data '{"model":"gpt-5","stream":true,"messages":[{"role":"user","content":"keep streaming"}]}' \
+  http://127.0.0.1:$AI_FAIL_GATEWAY_PORT/v1/chat/completions || true
+grep -q "tok0" /tmp/fp-e2e-trfail-sse.body || fail "mid-SSE test never received a first stream chunk"
+AI_FAIL_SSE_REQ=$(grep -i '^x-request-id:' /tmp/fp-e2e-trfail-sse.hdrs | head -1 | awk '{print $2}' | tr -d '\r')
+[ -n "$AI_FAIL_SSE_REQ" ] || fail "mid-SSE response carried no x-request-id"
+ai_fail_row "$AI_FAIL_SSE_REQ" /tmp/fp-e2e-trfail-sse-row.json '"client_disconnect"' \
+  || fail "no partial ai_trace_events row with client_disconnect for mid-SSE request $AI_FAIL_SSE_REQ"
+python3 - /tmp/fp-e2e-trfail-sse-row.json <<'PY' || fail "mid-SSE disconnect row failed assertions"
+import json, sys
+row = json.load(open(sys.argv[1], encoding="utf-8"))
+up = next(h for h in row["hops"] if h["hop"] == "upstream")
+assert up["outcome"] == "client_disconnect", up
+names = {h["hop"] for h in row["hops"]}
+assert "usage" not in names, "a torn-down stream must not fabricate a usage hop"
+PY
+
+# ---- Risk 6 (connect half): dead upstream -> local 503 -> outcome no_upstream_connection.
+AI_FAIL_503_CODE=$(curl -sS -o /dev/null -D /tmp/fp-e2e-trfail-503.hdrs -w '%{http_code}' \
+  -H "content-type: application/json" -H "x-flowplane-ai-model: gpt-5" \
+  --data "$AI_FAIL_OK_REQUEST" \
+  http://127.0.0.1:$AI_FAIL_DEAD_GATEWAY_PORT/v1/chat/completions)
+[ "$AI_FAIL_503_CODE" = "503" ] || fail "dead-upstream request expected 503, got $AI_FAIL_503_CODE"
+AI_FAIL_503_REQ=$(grep -i '^x-request-id:' /tmp/fp-e2e-trfail-503.hdrs | head -1 | awk '{print $2}' | tr -d '\r')
+ai_fail_row "$AI_FAIL_503_REQ" /tmp/fp-e2e-trfail-503-row.json '"no_upstream_connection"' \
+  || fail "no ai_trace_events row with no_upstream_connection for request $AI_FAIL_503_REQ"
+python3 - /tmp/fp-e2e-trfail-503-row.json <<'PY' || fail "connect-failure row failed assertions"
+import json, sys
+row = json.load(open(sys.argv[1], encoding="utf-8"))
+assert row["failure_hop"] == "upstream", row["failure_hop"]
+up = next(h for h in row["hops"] if h["hop"] == "upstream")
+assert up["outcome"] == "no_upstream_connection", up
+assert up["failed"] is True
+assert "usage" not in {h["hop"] for h in row["hops"]}
+PY
+
+# ---- AC 3: exhausted SHADOW budget -> request still 2xx, budget hop records would_reject.
+curl -fsS "${auth[@]}" -X POST http://$API/api/v1/teams/$AI_FAIL_TEAM/ai/budgets \
+  -d "{\"name\":\"trfail-shadow-$AI_FAIL_SFX\",\"spec\":{\"mode\":\"shadow\",\"limit_units\":1,\"window_seconds\":3600,\"provider_id\":\"$AI_FAIL_PROVIDER_ID\",\"prompt_token_weight\":1,\"completion_token_weight\":1}}" \
+  >/dev/null
+# Settle usage into the shadow counter (5 units > limit 1), then trace the next request.
+curl -fsS -o /dev/null \
+  -H "content-type: application/json" -H "x-flowplane-ai-model: gpt-5" \
+  --data "$AI_FAIL_OK_REQUEST" http://127.0.0.1:$AI_FAIL_GATEWAY_PORT/v1/chat/completions
+for i in $(seq 1 20); do
+  AI_FAIL_SHADOW_USED=$(psql "$PG_DB_URL" -Atc "SELECT c.used_units FROM ai_budget_counters c JOIN ai_budgets b ON b.id = c.budget_id WHERE b.team_id = '$AI_FAIL_TEAM_ID' AND b.name = 'trfail-shadow-$AI_FAIL_SFX'")
+  [ -n "$AI_FAIL_SHADOW_USED" ] && [ "$AI_FAIL_SHADOW_USED" -ge 1 ] && break
+  sleep 1
+done
+[ -n "${AI_FAIL_SHADOW_USED:-}" ] && [ "$AI_FAIL_SHADOW_USED" -ge 1 ] || fail "shadow budget counter never settled"
+AI_FAIL_SHADOW_CODE=$(curl -sS -o /dev/null -D /tmp/fp-e2e-trfail-shadow.hdrs -w '%{http_code}' \
+  -H "content-type: application/json" -H "x-flowplane-ai-model: gpt-5" \
+  --data "$AI_FAIL_OK_REQUEST" http://127.0.0.1:$AI_FAIL_GATEWAY_PORT/v1/chat/completions)
+[ "$AI_FAIL_SHADOW_CODE" = "200" ] || fail "shadow-exhausted request must still succeed, got $AI_FAIL_SHADOW_CODE"
+AI_FAIL_SHADOW_REQ=$(grep -i '^x-request-id:' /tmp/fp-e2e-trfail-shadow.hdrs | head -1 | awk '{print $2}' | tr -d '\r')
+ai_fail_row "$AI_FAIL_SHADOW_REQ" /tmp/fp-e2e-trfail-shadow-row.json '"would_reject"' \
+  || fail "no ai_trace_events row with a would_reject shadow verdict for request $AI_FAIL_SHADOW_REQ"
+python3 - "trfail-shadow-$AI_FAIL_SFX" /tmp/fp-e2e-trfail-shadow-row.json <<'PY' || fail "shadow-verdict row failed assertions"
+import json, sys
+row = json.load(open(sys.argv[2], encoding="utf-8"))
+assert row["failure_hop"] is None, "shadow budgets never fail the request"
+assert row["status_code"] == 200, row["status_code"]
+budget = next(h for h in row["hops"] if h["hop"] == "budget")
+assert budget["outcome"] == "allowed", budget
+shadow = {entry["budget"]: entry for entry in budget["detail"]["shadow"]}
+assert shadow[sys.argv[1]]["verdict"] == "would_reject", shadow
+PY
+
+# ---- AC 2: exhausted ENFORCING budget -> 429 flowplane_ai_budget_exceeded + budget row.
+curl -fsS "${auth[@]}" -X POST http://$API/api/v1/teams/$AI_FAIL_TEAM/ai/budgets \
+  -d "{\"name\":\"trfail-hard-$AI_FAIL_SFX\",\"spec\":{\"mode\":\"enforcing\",\"limit_units\":1,\"window_seconds\":3600,\"provider_id\":\"$AI_FAIL_PROVIDER_ID\",\"prompt_token_weight\":1,\"completion_token_weight\":1}}" \
+  >/dev/null
+# Fresh counter starts at 0 < 1, so one more success settles it past the limit.
+curl -fsS -o /dev/null \
+  -H "content-type: application/json" -H "x-flowplane-ai-model: gpt-5" \
+  --data "$AI_FAIL_OK_REQUEST" http://127.0.0.1:$AI_FAIL_GATEWAY_PORT/v1/chat/completions
+for i in $(seq 1 20); do
+  AI_FAIL_HARD_USED=$(psql "$PG_DB_URL" -Atc "SELECT c.used_units FROM ai_budget_counters c JOIN ai_budgets b ON b.id = c.budget_id WHERE b.team_id = '$AI_FAIL_TEAM_ID' AND b.name = 'trfail-hard-$AI_FAIL_SFX'")
+  [ -n "$AI_FAIL_HARD_USED" ] && [ "$AI_FAIL_HARD_USED" -ge 1 ] && break
+  sleep 1
+done
+[ -n "${AI_FAIL_HARD_USED:-}" ] && [ "$AI_FAIL_HARD_USED" -ge 1 ] || fail "enforcing budget counter never settled"
+AI_FAIL_429_CODE=$(curl -sS -o /tmp/fp-e2e-trfail-429.body -D /tmp/fp-e2e-trfail-429.hdrs -w '%{http_code}' \
+  -H "content-type: application/json" -H "x-flowplane-ai-model: gpt-5" \
+  --data "$AI_FAIL_OK_REQUEST" http://127.0.0.1:$AI_FAIL_GATEWAY_PORT/v1/chat/completions)
+[ "$AI_FAIL_429_CODE" = "429" ] || fail "budget-exhausted request expected 429, got $AI_FAIL_429_CODE"
+grep -q "exceeded" /tmp/fp-e2e-trfail-429.body || fail "429 body did not carry the budget-exceeded message"
+AI_FAIL_429_REQ=$(grep -i '^x-request-id:' /tmp/fp-e2e-trfail-429.hdrs | head -1 | awk '{print $2}' | tr -d '\r')
+[ -n "$AI_FAIL_429_REQ" ] || fail "429 response carried no x-request-id"
+ai_fail_row "$AI_FAIL_429_REQ" /tmp/fp-e2e-trfail-429-row.json '"rejected"' \
+  || fail "no ai_trace_events row for the budget-rejected request $AI_FAIL_429_REQ"
+python3 - "trfail-hard-$AI_FAIL_SFX" /tmp/fp-e2e-trfail-429-row.json <<'PY' || fail "budget-reject row failed assertions"
+import json, sys
+row = json.load(open(sys.argv[2], encoding="utf-8"))
+assert row["failure_hop"] == "budget", row["failure_hop"]
+by_name = {h["hop"]: h for h in row["hops"]}
+budget = by_name["budget"]
+assert budget["outcome"] == "rejected"
+assert budget["detail"]["verdict"] == "rejected", budget["detail"]
+assert budget["detail"]["budget"] == sys.argv[1], budget["detail"]
+assert budget["failed"] is True
+assert "credential_injection" not in by_name and "upstream" not in by_name, sorted(by_name)
+PY
+
+# ---- Credential/secret failure: expire the shared secret, then hit route B (dead provider:
+# credential injection precedes upstream connect, and no budget guards that provider, so the
+# request dies at the credential hop). The runtime reads the secret row per request and treats
+# an expired row as absent -> outcome secret_missing + the credential-unavailable 500.
+AI_FAIL_SECRET_REV=$(psql "$PG_DB_URL" -Atc "SELECT version FROM secrets WHERE team_id = '$AI_FAIL_TEAM_ID' AND name = 'ai-e2e-trfail-key-$AI_FAIL_SFX'")
+[ -n "$AI_FAIL_SECRET_REV" ] || fail "AI trace-failure secret revision not found for rotation"
+AI_FAIL_EXPIRY=$(python3 -c 'from datetime import datetime, timezone, timedelta; print((datetime.now(timezone.utc) + timedelta(seconds=5)).isoformat())')
+curl -fsS "${auth[@]}" -X POST -H "If-Match: $AI_FAIL_SECRET_REV" \
+  "http://$API/api/v1/teams/$AI_FAIL_TEAM/secrets/ai-e2e-trfail-key-$AI_FAIL_SFX/rotate" \
+  -d "{\"spec\":{\"type\":\"generic_secret\",\"secret\":\"$AI_FAIL_SECRET_B64\"},\"expires_at\":\"$AI_FAIL_EXPIRY\"}" \
+  >/dev/null
+# Until expires_at passes the dead route still 503s at the upstream; poll for the flip to the
+# credential-unavailable 500 and keep that request's id for the row assertion.
+AI_FAIL_CRED_CODE=""
+for i in $(seq 1 30); do
+  AI_FAIL_CRED_CODE=$(curl -sS -o /tmp/fp-e2e-trfail-cred.body -D /tmp/fp-e2e-trfail-cred.hdrs -w '%{http_code}' \
+    -H "content-type: application/json" -H "x-flowplane-ai-model: gpt-5" \
+    --data "$AI_FAIL_OK_REQUEST" http://127.0.0.1:$AI_FAIL_DEAD_GATEWAY_PORT/v1/chat/completions)
+  [ "$AI_FAIL_CRED_CODE" = "500" ] && grep -qi "credential unavailable" /tmp/fp-e2e-trfail-cred.body && break
+  sleep 1
+done
+[ "$AI_FAIL_CRED_CODE" = "500" ] || fail "expired-secret request expected 500, got $AI_FAIL_CRED_CODE"
+grep -qi "AI provider credential unavailable" /tmp/fp-e2e-trfail-cred.body \
+  || fail "500 body did not carry the credential-unavailable message"
+AI_FAIL_CRED_REQ=$(grep -i '^x-request-id:' /tmp/fp-e2e-trfail-cred.hdrs | head -1 | awk '{print $2}' | tr -d '\r')
+[ -n "$AI_FAIL_CRED_REQ" ] || fail "credential-failure response carried no x-request-id"
+ai_fail_row "$AI_FAIL_CRED_REQ" /tmp/fp-e2e-trfail-cred-row.json '"secret_missing"' \
+  || fail "no ai_trace_events row with secret_missing for the credential-failure request $AI_FAIL_CRED_REQ"
+python3 - "$AI_FAIL_DEAD_PROVIDER_ID" "$AI_FAIL_SECRET_B64" /tmp/fp-e2e-trfail-cred-row.json <<'PY' || fail "credential-failure row failed assertions"
+import json, sys
+row = json.load(open(sys.argv[3], encoding="utf-8"))
+assert row["failure_hop"] == "credential_injection", row["failure_hop"]
+assert row["provider_id"] == sys.argv[1], row["provider_id"]
+by_name = {h["hop"]: h for h in row["hops"]}
+cred = by_name["credential_injection"]
+assert cred["outcome"] == "secret_missing", cred
+assert cred["failed"] is True
+assert cred["detail"]["auth_header"] == "authorization", cred["detail"]
+assert cred["detail"]["provider_id"] == sys.argv[1], cred["detail"]
+assert "upstream" not in by_name and "usage" not in by_name, sorted(by_name)
+row_text = json.dumps(row)
+assert "fp-e2e-trfail-secret" not in row_text, "credential material must never appear in the trace row"
+assert sys.argv[2] not in row_text, "encoded credential material must never appear in the trace row"
+PY
+
+# ---- Cleanup: this phase's Envoy, stub, and team resources.
+kill "$AI_FAIL_STUB_PID" >/dev/null 2>&1 || true
+if [ "$ENVOY_MODE" = docker ]; then
+  docker rm -f fp-e2e-envoy-trfail >/dev/null 2>&1 || true
+else
+  kill "${AI_FAIL_ENVOY_PID:-}" >/dev/null 2>&1 || true
+fi
+for budget in "trfail-shadow-$AI_FAIL_SFX" "trfail-hard-$AI_FAIL_SFX"; do
+  REV=$(psql "$PG_DB_URL" -Atc "SELECT version FROM ai_budgets WHERE team_id = '$AI_FAIL_TEAM_ID' AND name = '$budget'")
+  curl -fsS "${auth[@]}" -X DELETE -H "If-Match: $REV" \
+    "http://$API/api/v1/teams/$AI_FAIL_TEAM/ai/budgets/$budget" >/dev/null
+done
+for route in "$AI_FAIL_ROUTE_NAME" "$AI_FAIL_DEAD_ROUTE_NAME"; do
+  REV=$(psql "$PG_DB_URL" -Atc "SELECT version FROM ai_routes WHERE team_id = '$AI_FAIL_TEAM_ID' AND name = '$route'")
+  curl -fsS "${auth[@]}" -X DELETE -H "If-Match: $REV" \
+    "http://$API/api/v1/teams/$AI_FAIL_TEAM/ai/routes/$route" >/dev/null
+done
+for prov in "ai-e2e-trfail-live-$AI_FAIL_SFX" "ai-e2e-trfail-dead-$AI_FAIL_SFX"; do
+  REV=$(psql "$PG_DB_URL" -Atc "SELECT version FROM ai_providers WHERE team_id = '$AI_FAIL_TEAM_ID' AND name = '$prov'")
+  curl -fsS "${auth[@]}" -X DELETE -H "If-Match: $REV" \
+    "http://$API/api/v1/teams/$AI_FAIL_TEAM/ai/providers/$prov" >/dev/null
+done
+echo "PHASE 1g OK: AI trace failure rows -> no-eligible 400 (AC11) -> provider 500 (AC4) -> mid-SSE client_disconnect + connect-failure 503 (Risk 6) -> shadow would_reject (AC3) -> enforcing 429 budget row (AC2) -> expired-secret credential_injection secret_missing row"

--- a/scripts/e2e/lib.sh
+++ b/scripts/e2e/lib.sh
@@ -36,6 +36,7 @@ ENVOY_VERSION=${ENVOY_VERSION:-1.37-latest}
 cleanup() {
   docker rm -f fp-e2e-envoy >/dev/null 2>&1 || true
   docker rm -f fp-e2e-envoy-trace >/dev/null 2>&1 || true
+  docker rm -f fp-e2e-envoy-trfail >/dev/null 2>&1 || true
   [ -n "${CP_PID:-}" ] && kill "$CP_PID" >/dev/null 2>&1 || true
   [ -n "${UP_PID:-}" ] && kill "$UP_PID" >/dev/null 2>&1 || true
   [ -n "${UP2_PID:-}" ] && kill "$UP2_PID" >/dev/null 2>&1 || true
@@ -46,6 +47,8 @@ cleanup() {
   [ -n "${AI_MALFORMED_PID:-}" ] && kill "$AI_MALFORMED_PID" >/dev/null 2>&1 || true
   [ -n "${AI_TRACE_STUB_PID:-}" ] && kill "$AI_TRACE_STUB_PID" >/dev/null 2>&1 || true
   [ -n "${AI_TRACE_ENVOY_PID:-}" ] && kill "$AI_TRACE_ENVOY_PID" >/dev/null 2>&1 || true
+  [ -n "${AI_FAIL_STUB_PID:-}" ] && kill "$AI_FAIL_STUB_PID" >/dev/null 2>&1 || true
+  [ -n "${AI_FAIL_ENVOY_PID:-}" ] && kill "$AI_FAIL_ENVOY_PID" >/dev/null 2>&1 || true
   [ -n "${RLS_PID:-}" ] && kill "$RLS_PID" >/dev/null 2>&1 || true
   [ -n "${ENVOY_PID:-}" ] && kill "$ENVOY_PID" >/dev/null 2>&1 || true
 }

--- a/scripts/e2e/lib.sh
+++ b/scripts/e2e/lib.sh
@@ -35,6 +35,7 @@ ENVOY_VERSION=${ENVOY_VERSION:-1.37-latest}
 # here centrally so phases never re-install the trap.
 cleanup() {
   docker rm -f fp-e2e-envoy >/dev/null 2>&1 || true
+  docker rm -f fp-e2e-envoy-trace >/dev/null 2>&1 || true
   [ -n "${CP_PID:-}" ] && kill "$CP_PID" >/dev/null 2>&1 || true
   [ -n "${UP_PID:-}" ] && kill "$UP_PID" >/dev/null 2>&1 || true
   [ -n "${UP2_PID:-}" ] && kill "$UP2_PID" >/dev/null 2>&1 || true
@@ -43,6 +44,8 @@ cleanup() {
   [ -n "${AI_STREAM_DIE_PID:-}" ] && kill "$AI_STREAM_DIE_PID" >/dev/null 2>&1 || true
   [ -n "${AI_STREAM_FALLBACK_PID:-}" ] && kill "$AI_STREAM_FALLBACK_PID" >/dev/null 2>&1 || true
   [ -n "${AI_MALFORMED_PID:-}" ] && kill "$AI_MALFORMED_PID" >/dev/null 2>&1 || true
+  [ -n "${AI_TRACE_STUB_PID:-}" ] && kill "$AI_TRACE_STUB_PID" >/dev/null 2>&1 || true
+  [ -n "${AI_TRACE_ENVOY_PID:-}" ] && kill "$AI_TRACE_ENVOY_PID" >/dev/null 2>&1 || true
   [ -n "${RLS_PID:-}" ] && kill "$RLS_PID" >/dev/null 2>&1 || true
   [ -n "${ENVOY_PID:-}" ] && kill "$ENVOY_PID" >/dev/null 2>&1 || true
 }

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -24,10 +24,10 @@ source "$HERE/lib.sh"
 
 # Canonical phase order (index-aligned). File names carry the NN- ordering + phase ID; this table
 # is the single source of truth for ordering and ID->file resolution.
-PHASE_IDS=(P1 P1a P1d P1e P1f P1b P1c P2 P2a P3 P4 P5 P5a P6 P7 P8)
+PHASE_IDS=(P1 P1a P1d P1e P1f P1g P1b P1c P2 P2a P3 P4 P5 P5a P6 P7 P8)
 PHASE_FILES=(
   10-p1-basic.sh 15-p1a-ai.sh 16-p1d-ai-stream.sh 17-p1e-ai-malformed.sh
-  18-p1f-ai-trace.sh
+  18-p1f-ai-trace.sh 19-p1g-ai-trace-failures.sh
   20-p1b-learning.sh 25-p1c-discovery.sh 30-p2-cp-restart.sh 31-p2a-envoy-restart.sh
   40-p3-isolation.sh 50-p4-http-filters.sh 60-p5-auth-filters.sh 65-p5a-mcp.sh
   70-p6-sds-rotation.sh 80-p7-advanced-parity.sh 82-p8-rls-enforcement.sh

--- a/scripts/e2e/run.sh
+++ b/scripts/e2e/run.sh
@@ -24,9 +24,10 @@ source "$HERE/lib.sh"
 
 # Canonical phase order (index-aligned). File names carry the NN- ordering + phase ID; this table
 # is the single source of truth for ordering and ID->file resolution.
-PHASE_IDS=(P1 P1a P1d P1e P1b P1c P2 P2a P3 P4 P5 P5a P6 P7 P8)
+PHASE_IDS=(P1 P1a P1d P1e P1f P1b P1c P2 P2a P3 P4 P5 P5a P6 P7 P8)
 PHASE_FILES=(
   10-p1-basic.sh 15-p1a-ai.sh 16-p1d-ai-stream.sh 17-p1e-ai-malformed.sh
+  18-p1f-ai-trace.sh
   20-p1b-learning.sh 25-p1c-discovery.sh 30-p2-cp-restart.sh 31-p2a-envoy-restart.sh
   40-p3-isolation.sh 50-p4-http-filters.sh 60-p5-auth-filters.sh 65-p5a-mcp.sh
   70-p6-sds-rotation.sh 80-p7-advanced-parity.sh 82-p8-rls-enforcement.sh


### PR DESCRIPTION
## Summary

Merges the **AI request tracing** epic (`ai-gateway-e2e-trace`, slices s1–s6) plus six
follow-up fixes found and verified during a trace-docs verification + end-to-end pass.
Branches linearly off `main`; `main` is a direct ancestor.

## What ships

**AI request tracing (epic).** Per-hop trace rows for AI-gateway requests (route match →
auth → budget → credential injection → upstream → usage), retrievable via
`flowplane ai trace --request-id <id>`; `traceparent` propagation + stored `trace_id`;
per-team retention TTL (`flowplane ai retention`, default 30 days). Trace rows never carry
prompt/response bodies or credential values.

**Fixes (each Codex-reviewed):**

- **#227** — AI listeners now actually own `x-request-id`. The originally merged fix (empty
  `internal_address_config` + `preserve_external_request_id=false`) was a **false-green** —
  proven ineffective end-to-end on real Envoy. Root cause: `use_remote_address` was never set
  (request never an edge request) and empty `internal_address_config` falls back to Envoy's
  default (loopback/RFC1918 internal). Fixed with `use_remote_address: true` + a non-matching
  sentinel CIDR `240.0.0.0/4` (AI-scoped). Verified: `18-p1f-ai-trace.sh` **AC14 passes on
  Envoy 1.38.3** (server-owned id, distinct per request, client id keys zero trace rows).
- **#230** — budget-429 / credential-500 rejections now return the JSON error envelope
  `{"code","message"}` + `content-type: application/json` (were plain text).
- **#231** — listener-side rejections stamp the client-facing `status_code` in the trace row
  (was null).
- **#226** — `PUT .../ai/retention` enforces optimistic concurrency via `If-Match`
  (stale → 409, malformed → 400); previously silently last-writer-win.
- **#228 / #229** — trace-docs corrected to match runtime (budget-hop `detail.shadow[]`
  shape; hop timeline is a merged multi-stream view, not an execution-order waterfall;
  `latency_ms` scope).

## Verification

- Full workspace gate green: `cargo fmt --check` + `clippy -D warnings` + `nextest --workspace`
  → **622 tests, 0 failed**.
- End-to-end `scripts/e2e/18-p1f-ai-trace.sh` (AC1/AC6/AC9/**AC14**) passing on Envoy 1.38.3.
- Each fix independently reviewed by Codex (gpt-5.5) → APPROVE.

## Follow-ups (tracked, not in this PR)

- Wire AC14 (x-request-id ownership) into a running CI gate — its absence is why #227 went
  false-green (unit tests assert HCM field-presence, not behavior).
- `xff_num_trusted_hops` guidance when an AI dataplane sits behind an L7 LB (`use_remote_address`
  changes edge posture; request-id ownership holds regardless).

Closes #226
Closes #227
Closes #228
Closes #229
Closes #230
Closes #231
