### PR TITLE
chore(release): 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ upgrade of an earlier Flowplane line — there is no in-place migration path fro
 version. `1.0.0` is its first stable release and the point at which the public REST API,
 CLI surface, and configuration contract become subject to semantic versioning.
 
-## [Unreleased]
+## [2.2.0] - 2026-07-07
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,7 +762,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flowplane"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "flowplane-rls"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "axum",
  "envoy-types",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "fp-agent"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "fp-api"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "axum",
  "chrono",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "fp-core"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "fp-domain"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "base64",
  "chrono",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "fp-storage"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "chrono",
  "fp-domain",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "fp-xds"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.1.1"
+version = "2.2.0"
 edition = "2021"
 rust-version = "1.92"
 license = "Apache-2.0"


### PR DESCRIPTION
Version bump to **2.2.0** (MINOR per LIFECYCLE §1 — new additive surface: AI request tracing CLI + REST since 2.1.1).

- `Cargo.toml` workspace version 2.1.1 → 2.2.0 (+ `Cargo.lock`)
- `CHANGELOG.md`: rolled `[Unreleased]` → `[2.2.0] - 2026-07-07`

§1.1 API-surface review + bump justification recorded in the vault (`releases/2.2.0/_release.md`).

Merge → then tag `v2.2.0` (immutable build trigger) → RC validation behind the release HUMAN-GATE (§4.2) before any public image publish. Not done in this PR.