### PR TITLE
ci(release): pass RLS insecure-loopback acks in hardened-smoke (unblocks v3.0.0 build)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,10 +135,16 @@ jobs:
           docker run --rm --entrypoint /usr/local/bin/flowplane-agent flowplane:hardened-smoke --help >/dev/null
           docker run --rm --entrypoint /usr/local/bin/fp-agent flowplane:hardened-smoke --help >/dev/null
           set +e
+          # Since 3.0.0 (fpv2-9sf) flowplane-rls fails closed on plaintext binds: a
+          # loopback-plaintext boot requires the explicit dev-only acknowledgements, else it
+          # exits 1 instead of running. This liveness smoke uses the documented loopback dev
+          # path, so it must pass both acks (production binds use the TLS triads instead).
           docker run --rm \
             --entrypoint /usr/bin/timeout \
             -e FLOWPLANE_RLS_GRPC_LISTEN=127.0.0.1:0 \
             -e FLOWPLANE_RLS_ADMIN_LISTEN=127.0.0.1:0 \
+            -e FLOWPLANE_RLS_ALLOW_INSECURE_GRPC=yes-this-is-local-only \
+            -e FLOWPLANE_RLS_ALLOW_INSECURE_ADMIN=yes-this-is-local-only \
             flowplane:hardened-smoke \
             3 /usr/local/bin/flowplane-rls
           rls_status=$?


### PR DESCRIPTION
## Problem

The v3.0.0 release build failed ([run 29553569119](https://github.com/rajeevramani/flowplane/actions/runs/29553569119)). The `build` job's `flowplane-rls` liveness smoke boots RLS on `127.0.0.1:0` and expects it to survive a 3s `timeout` (exit 124). But **3.0.0's own breaking change** (fpv2-9sf: fail-closed RLS transport) makes `flowplane-rls` **exit 1** on a plaintext loopback bind without the explicit dev-only acknowledgements:

```
Error: "plaintext gRPC on 127.0.0.1:0 requires the explicit acknowledgement
FLOWPLANE_RLS_ALLOW_INSECURE_GRPC=yes-this-is-local-only ... or configure the FLOWPLANE_RLS_GRPC_TLS_* triad"
```

The smoke step wasn't updated for the guard that shipped in the same release.

## Fix

Add `FLOWPLANE_RLS_ALLOW_INSECURE_GRPC` + `FLOWPLANE_RLS_ALLOW_INSECURE_ADMIN=yes-this-is-local-only` to the smoke (the documented loopback dev path). Production binds use the TLS triads instead — unchanged. CI-only; not in the image.

**Verified locally** against the real `flowplane-rls` binary: with both acks it boots `grpc_security="plaintext (loopback dev)"` and survives to `timeout` → **exit 124** (pass).

## Re-run

On merge, re-run the release build via `workflow_dispatch(version=3.0.0)` from `main` — it builds the immutable `v3.0.0` tag source with this fixed workflow. No re-tag needed (tag `v3.0.0` stays on 529d220).

Bead: fpv2-rnh.