### PR TITLE
fix(release): match dashboard total card in smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,7 +276,9 @@ jobs:
           partial=$(curl -fsS "${url}partials/overview")
           echo "$partial" | grep -q "dp-eval" \
             || { echo "::error::overview partial does not list the dp-eval dataplane"; exit 1; }
-          echo "$partial" | grep -Eq "[1-9][0-9]* total" \
+          partial_flat=$(printf '%s' "$partial" | tr '\n' ' ')
+          printf '%s' "$partial_flat" \
+            | grep -Eq '<span class="label">Dataplanes</span>[[:space:]]*<span class="value">[1-9][0-9]*</span>' \
             || { echo "::error::overview partial does not show a nonzero dataplane total"; exit 1; }
 
           no_nonce=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:8081/")


### PR DESCRIPTION
## Root cause
The exact-candidate smoke expected the obsolete literal phrase `N total`. The current Overview template renders the Dataplanes label and positive value in adjacent spans. Both AMD64 and ARM64 run 30428143247 imported the exact OCI candidates, routed eval traffic, rendered `dp-eval`, and then failed only at this stale text assertion. Publication was skipped.

## Fix
Flatten the returned partial and require the actual semantic Dataplanes card to contain a positive numeric value. Zero, missing stats, and malformed markup fail closed.

## Recovery
Do not move `v3.1.0`. After merge, manually dispatch Release with `version=3.1.0`; the workflow resolves and checks out the immutable tag commit.

## Validation
- positive current card markup accepted
- zero total rejected
- `actionlint .github/workflows/release.yml`
- YAML parse and `git diff --check`
- independent Claude review: `VERDICT: APPROVE`