### PR TITLE
chore(release): prepare 3.1.2

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,6 +11,9 @@
 # the full suite was clean; 8 is a pragmatic guard that keeps most of the speedup
 # while leaving headroom for larger runners.
 
+[profile.default]
+test-threads = 8
+
 [profile.ci]
 # Run the whole suite for complete diagnostics rather than stopping at the first failure.
 fail-fast = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,33 @@ compatibility baseline.
 
 ## [Unreleased]
 
+## [3.1.2] - 2026-08-10
+
+Patch release restoring certificate-bound tenant authorization on the AI gateway credential path,
+aligning AI usage windows with PostgreSQL's clock, and correcting operator-facing release
+artifacts. REST, MCP, configuration, storage-schema, and response shapes are unchanged.
+
+### Security
+
+- AI gateway credential selection now uses the authenticated dataplane certificate identity,
+  restoring the tenant boundary already enforced by sibling xDS paths. (fpv2-26v)
+- Bootstrap and AWS deployment runbooks now create local token and trust files privately, fail
+  before partial mutation when required inputs are absent, and distinguish the xDS server-trust
+  CA from the dataplane client-chain CA. (#247, #248, fpv2-lrd.5, fpv2-lrd.6)
+
 ### Fixed
 
 - AI usage reads now resolve omitted time-window upper bounds from PostgreSQL, matching the clock that stamps usage events so freshly recorded usage is immediately visible even when control-plane and database host clocks differ. (fpv2-ejw)
 - `flowplane-rls` now reports `--help` and `--version` before evaluating server startup configuration, and rejects unknown arguments instead of silently ignoring them. (#243, fpv2-lrd.1)
+- The REST reference now records bootstrap and MCP endpoints as intentional live-route exceptions
+  to generated OpenAPI coverage. (#244, fpv2-lrd.2)
+- CLI and API documentation now distinguishes status-derived CLI retryability from
+  `ErrorCode`-derived API retryability, including the conservative aggregate `apply` exception.
+  (#245, fpv2-lrd.3)
+- JWT filter documentation and generated schema descriptions now match the translator's existing
+  empty-rule behavior without changing runtime enforcement. (#246, fpv2-lrd.4)
+- CLI examples, global-rate-limit topology wording, observability status, documentation vocabulary,
+  decision references, and published-release tense now match shipped behavior. (#249, fpv2-lrd.7)
 
 ## [3.1.1] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ compatibility baseline.
 ### Fixed
 
 - AI usage reads now resolve omitted time-window upper bounds from PostgreSQL, matching the clock that stamps usage events so freshly recorded usage is immediately visible even when control-plane and database host clocks differ. (fpv2-ejw)
+- `flowplane-rls` now reports `--help` and `--version` before evaluating server startup configuration, and rejects unknown arguments instead of silently ignoring them. (#243, fpv2-lrd.1)
 
 ## [3.1.1] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ compatibility baseline.
 
 ## [Unreleased]
 
+### Fixed
+
+- AI usage reads now resolve omitted time-window upper bounds from PostgreSQL, matching the clock that stamps usage events so freshly recorded usage is immediately visible even when control-plane and database host clocks differ. (fpv2-ejw)
+
 ## [3.1.1] - 2026-08-03
 
 Patch release restoring automatic dataplane-agent recovery after temporary control-plane loss and correcting release documentation, validation, and artifact metadata found during the `3.1.0` published-artifact gate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flowplane"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "anyhow",
  "askama",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "flowplane-rls"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "axum",
  "axum-server",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "fp-agent"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "fp-api"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "axum",
  "chrono",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "fp-core"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "fp-domain"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "base64",
  "chrono",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "fp-storage"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "chrono",
  "fp-domain",
@@ -1040,7 +1040,7 @@ dependencies = [
 
 [[package]]
 name = "fp-xds"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,6 +855,7 @@ version = "3.1.1"
 dependencies = [
  "axum",
  "axum-server",
+ "clap",
  "envoy-types",
  "fp-domain",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.1.1"
+version = "3.1.2"
 edition = "2021"
 rust-version = "1.92"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ published **evaluation** image and stands up the whole stack — Postgres, the d
 demo upstream, and Envoy — then routes a real request through the gateway. No repo checkout, no
 `cargo build`.
 
-> Set `VER` to a published release. The example below targets `3.1.1`; use it after `v3.1.1`
-> appears on the GitHub Releases page. Its evaluator bundle and `:${VER}-eval` image support
+> Set `VER` to a published release. The example below targets the published `v3.1.1` release.
+> Its evaluator bundle and `:${VER}-eval` image support
 > `linux/amd64` and `linux/arm64` (the dashboard step
 > needs `3.1.0` or newer). For newer releases, use the version shown on the GitHub Releases
 > page. The image is **multi-arch**: a plain `docker pull` resolves the native variant — no

--- a/crates/flowplane-rls/Cargo.toml
+++ b/crates/flowplane-rls/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 fp-domain = { workspace = true }
+clap = { workspace = true }
 envoy-types = { workspace = true }
 prost = { workspace = true }
 tonic = { workspace = true }

--- a/crates/flowplane-rls/src/main.rs
+++ b/crates/flowplane-rls/src/main.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use clap::Parser;
 use envoy_types::pb::envoy::service::ratelimit::v3::rate_limit_service_server::RateLimitServiceServer;
 use flowplane_rls::admin::{self, AdminState};
 use flowplane_rls::config::RlsConfig;
@@ -11,8 +12,18 @@ use flowplane_rls::grpc::RlsService;
 use flowplane_rls::policy::PolicyCache;
 use tracing_subscriber::EnvFilter;
 
+#[derive(Debug, Parser)]
+#[command(
+    name = "flowplane-rls",
+    version,
+    about = "Flowplane global rate-limit service"
+)]
+struct Args {}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _args = Args::parse();
+
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
@@ -69,4 +80,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     admin_handle.abort();
     result?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::{error::ErrorKind, Parser};
+
+    use super::Args;
+
+    #[test]
+    fn empty_arguments_parse_for_normal_startup() {
+        Args::try_parse_from(["flowplane-rls"]).expect("empty arguments must parse");
+    }
+
+    #[test]
+    fn unknown_arguments_are_rejected() {
+        let error = Args::try_parse_from(["flowplane-rls", "--definitely-unknown"])
+            .expect_err("unknown arguments must fail parsing");
+
+        assert_eq!(error.kind(), ErrorKind::UnknownArgument);
+    }
 }

--- a/crates/flowplane-rls/tests/cli.rs
+++ b/crates/flowplane-rls/tests/cli.rs
@@ -1,0 +1,97 @@
+//! Black-box CLI contract tests for `flowplane-rls` (fpv2-lrd.1).
+//!
+//! These tests execute the real Cargo-built binary, remove ambient RLS TLS and
+//! plaintext acknowledgement settings, and never bind or open a port.
+#![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
+
+use std::process::{Command, Output};
+
+const STARTUP_GUARD_ENV_VARS: &[&str] = &[
+    "FLOWPLANE_RLS_GRPC_TLS_CERT",
+    "FLOWPLANE_RLS_GRPC_TLS_KEY",
+    "FLOWPLANE_RLS_GRPC_TLS_CLIENT_CA",
+    "FLOWPLANE_RLS_ADMIN_TLS_CERT",
+    "FLOWPLANE_RLS_ADMIN_TLS_KEY",
+    "FLOWPLANE_RLS_ALLOW_INSECURE_GRPC",
+    "FLOWPLANE_RLS_ALLOW_INSECURE_ADMIN",
+];
+
+fn run_rls(args: &[&str]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_flowplane-rls"));
+    command.args(args);
+    for variable in STARTUP_GUARD_ENV_VARS {
+        command.env_remove(variable);
+    }
+    command
+        .output()
+        .expect("run the Cargo-built flowplane-rls binary")
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn version_succeeds_without_startup_configuration() {
+    let output = run_rls(&["--version"]);
+
+    assert!(
+        output.status.success(),
+        "--version must exit successfully without startup configuration; status={:?}, stderr={}",
+        output.status,
+        stderr(&output)
+    );
+    assert_eq!(
+        stdout(&output).trim(),
+        format!("flowplane-rls {}", env!("CARGO_PKG_VERSION"))
+    );
+}
+
+#[test]
+fn help_succeeds_and_describes_the_product_without_startup_configuration() {
+    let output = run_rls(&["--help"]);
+    let stdout = stdout(&output);
+
+    assert!(
+        output.status.success(),
+        "--help must exit successfully without startup configuration; status={:?}, stderr={}",
+        output.status,
+        stderr(&output)
+    );
+    assert!(
+        stdout.contains("Usage:"),
+        "help must contain usage: {stdout}"
+    );
+    assert!(
+        stdout
+            .to_ascii_lowercase()
+            .contains("global rate-limit service"),
+        "help must describe the product purpose: {stdout}"
+    );
+}
+
+#[test]
+fn unknown_argument_is_rejected_before_startup_validation() {
+    let output = run_rls(&["--definitely-unknown"]);
+    let stderr = stderr(&output);
+
+    assert!(
+        !output.status.success(),
+        "an unknown argument must exit non-zero; stdout={}",
+        stdout(&output)
+    );
+    assert!(
+        stderr.to_ascii_lowercase().contains("unexpected argument"),
+        "stderr must identify the unexpected argument: {stderr}"
+    );
+    for startup_guard in STARTUP_GUARD_ENV_VARS {
+        assert!(
+            !stderr.contains(startup_guard),
+            "CLI parsing must precede the RLS TLS/plaintext startup guard; stderr={stderr}"
+        );
+    }
+}

--- a/crates/fp-core/src/services/ai.rs
+++ b/crates/fp-core/src/services/ai.rs
@@ -630,10 +630,10 @@ pub async fn delete_budget(
 pub const MAX_USAGE_WINDOW_DAYS: i64 = 92;
 
 /// Windowed, team-scoped usage summary. Window semantics (design ui-f5): half-open
-/// `[since, until)`; an omitted `until` resolves server-side to `now` BEFORE validation;
-/// `since >= until` (after resolution) and spans over [`MAX_USAGE_WINDOW_DAYS`] fail
-/// validation. Returns the summary rows plus the total grouped-row count for the same
-/// filters (the `Page.total`).
+/// `[since, until)`; an omitted `until` resolves from PostgreSQL's clock BEFORE validation,
+/// matching the authority that stamps usage rows. `since >= until` (after resolution) and
+/// spans over [`MAX_USAGE_WINDOW_DAYS`] fail validation. Returns the summary rows plus the
+/// total grouped-row count for the same filters (the `Page.total`).
 pub async fn usage_summary(
     pool: &PgPool,
     ctx: &PrincipalCtx,
@@ -642,11 +642,14 @@ pub async fn usage_summary(
     request_id: RequestId,
 ) -> DomainResult<(Vec<AiUsageSummary>, i64)> {
     authorize(pool, ctx, Resource::AiUsage, Action::Read, team, request_id).await?;
-    query.until = Some(resolve_usage_window(
-        query.since,
-        query.until,
-        chrono::Utc::now(),
-    )?);
+    let effective_until = match query.until {
+        Some(until) => resolve_usage_window(query.since, Some(until), until)?,
+        None => {
+            let database_now = ai::usage_clock_now(pool).await?;
+            resolve_usage_window(query.since, None, database_now)?
+        }
+    };
+    query.until = Some(effective_until);
     ai::usage_summary(pool, team.id, query).await
 }
 
@@ -1820,6 +1823,17 @@ mod tests {
             let now = ts("2026-07-19T12:00:00Z");
             let until = resolve_usage_window(None, None, now).unwrap();
             assert_eq!(until, now);
+        }
+
+        #[test]
+        fn omitted_until_uses_supplied_authority_when_another_clock_is_behind() {
+            let host_now = ts("2026-07-19T12:00:00Z");
+            let database_now = host_now + Duration::milliseconds(254);
+
+            let until = resolve_usage_window(None, None, database_now).unwrap();
+
+            assert_eq!(until, database_now);
+            assert!(until > host_now);
         }
 
         #[test]

--- a/crates/fp-core/tests/ai_usage_clock.rs
+++ b/crates/fp-core/tests/ai_usage_clock.rs
@@ -1,0 +1,179 @@
+//! Slice fpv2-ejw.1 acceptance: a freshly PostgreSQL-stamped AI usage event must be
+//! visible through an immediate `fp_core::services::ai::usage_summary` read with an
+//! omitted `until`.
+//!
+//! Honesty note (fixed-behavior property guard, not a deterministic regression): the
+//! insert path stamps `created_at` with PostgreSQL `now()` while the pre-fix service
+//! resolves the omitted `until` from the host clock (`chrono::Utc::now()`), and the
+//! window is half-open (`created_at < until`). This test is therefore only RED before
+//! the fix when the database clock runs ahead of the host clock (the live diagnostic
+//! measured `db_minus_host_ms=253.949`); after the fix (PostgreSQL as the single clock
+//! authority) it is deterministically green. The clock skew observed at run time is
+//! printed as a diagnostic so the environment seam is visible in test output.
+//!
+//! Unique org/team/provider/route identities per run keep this parallel-safe against
+//! sibling tests sharing the database. Authorization is real: the read goes through a
+//! principal holding an (AiUsage, Read) grant on the team. All fixture bytes are inert;
+//! no credentials are created or printed.
+
+#![allow(clippy::panic, clippy::unwrap_used, clippy::expect_used)]
+
+use fp_core::{GrantSet, PrincipalCtx};
+use fp_domain::authz::{Action, Resource};
+use fp_domain::{AiProviderId, OpenAiTokenUsage, OrgRole, RequestId, RouteConfigId};
+use fp_storage::repos::{ai, identity};
+use sqlx::PgPool;
+
+fn unique(prefix: &str) -> String {
+    format!(
+        "{prefix}-{}",
+        &uuid::Uuid::now_v7().simple().to_string()[20..]
+    )
+}
+
+async fn test_pool() -> Option<PgPool> {
+    let Ok(url) = std::env::var("FLOWPLANE_TEST_DATABASE_URL") else {
+        eprintln!("skipping: FLOWPLANE_TEST_DATABASE_URL not set");
+        return None;
+    };
+    let pool = fp_storage::connect(&url, 4).await.expect("connect");
+    fp_storage::migrate(&pool).await.expect("migrate");
+    Some(pool)
+}
+
+/// Mirror the auth middleware's D-014 resolution for single-org test users.
+async fn principal_ctx(pool: &PgPool, subject: &str) -> PrincipalCtx {
+    let loaded = identity::load_principal(pool, subject)
+        .await
+        .expect("load principal")
+        .expect("principal exists");
+    let candidates: Vec<_> = loaded
+        .memberships
+        .iter()
+        .copied()
+        .filter(|(org_id, _)| Some(*org_id) != loaded.platform_org_id)
+        .collect();
+    let (org, org_selector_required) = match candidates.as_slice() {
+        [one] => (Some(*one), false),
+        [] => (None, false),
+        _ => (None, true),
+    };
+    PrincipalCtx::User {
+        user_id: loaded.user_id,
+        platform_admin: loaded.platform_admin,
+        org_selector_required,
+        org,
+        grants: GrantSet::new(loaded.grants),
+    }
+}
+
+/// Measured DB-vs-host clock offset in milliseconds, printed as the environment RED seam
+/// diagnostic. Positive means the database clock is ahead of the host clock.
+async fn db_minus_host_ms(pool: &PgPool) -> f64 {
+    let db_now: chrono::DateTime<chrono::Utc> = sqlx::query_scalar("SELECT now()")
+        .fetch_one(pool)
+        .await
+        .expect("db now");
+    let host_now = chrono::Utc::now();
+    (db_now - host_now).num_microseconds().unwrap_or(0) as f64 / 1000.0
+}
+
+#[tokio::test]
+async fn fresh_db_stamped_usage_event_is_visible_through_omitted_until_summary_read() {
+    let Some(pool) = test_pool().await else {
+        return;
+    };
+
+    let org = identity::create_org(&pool, &unique("org-usage-clock"), "")
+        .await
+        .expect("org");
+    let team = identity::create_team(&pool, org.id, &unique("team-usage-clock"), "")
+        .await
+        .expect("team");
+    let team_ref = identity::resolve_team_ref(&pool, team.id)
+        .await
+        .expect("q")
+        .expect("team ref");
+
+    // Real principal holding (AiUsage, Read) on the team — the read must pass authz.
+    let reader_sub = unique("sub-usage-clock-reader");
+    let reader = identity::upsert_user_by_subject(&pool, &reader_sub, "r@a.test", "Reader")
+        .await
+        .expect("reader");
+    identity::add_org_membership(&pool, reader, org.id, OrgRole::Member)
+        .await
+        .expect("member");
+    identity::add_grant(
+        &pool,
+        reader,
+        org.id,
+        team.id,
+        Resource::AiUsage,
+        Action::Read,
+        None,
+    )
+    .await
+    .expect("grant ai usage read");
+    let reader_ctx = principal_ctx(&pool, &reader_sub).await;
+
+    // ai_usage_events carries no FK on route_config_id/provider_id, so fresh UUIDs give
+    // unique per-run identities without materializing gateway resources.
+    let route_config_id = RouteConfigId::from(uuid::Uuid::now_v7());
+    let provider_id = AiProviderId::from(uuid::Uuid::now_v7());
+    let usage = OpenAiTokenUsage {
+        prompt_tokens: 1_234,
+        completion_tokens: 5_678,
+        total_tokens: 6_912,
+    };
+
+    eprintln!(
+        "diagnostic: db_minus_host_ms={:.3} (positive = DB ahead of host = pre-fix RED seam)",
+        db_minus_host_ms(&pool).await
+    );
+
+    // The insert path stamps created_at with PostgreSQL now().
+    ai::record_usage_event(
+        &pool,
+        ai::AiUsageEventInsert {
+            team_id: team.id,
+            route_config_id,
+            provider_id,
+            backend_position: Some(0),
+            usage,
+        },
+    )
+    .await
+    .expect("record usage event");
+
+    // Immediately read through the service with an omitted `until`: the fresh event must
+    // fall inside the resolved half-open window.
+    let (items, total) = fp_core::services::ai::usage_summary(
+        &pool,
+        &reader_ctx,
+        team_ref,
+        ai::AiUsageQuery {
+            route_config_id: Some(route_config_id),
+            provider_id: Some(provider_id),
+            since: None,
+            until: None,
+            limit: 50,
+            offset: 0,
+        },
+        RequestId::generate(),
+    )
+    .await
+    .expect("authorized usage summary read");
+
+    assert_eq!(
+        total, 1,
+        "the just-stamped event must produce exactly one grouped row in the total"
+    );
+    assert_eq!(items.len(), 1, "expected exactly one grouped summary row");
+    let row = &items[0];
+    assert_eq!(row.route_config_id, Some(route_config_id));
+    assert_eq!(row.provider_id, Some(provider_id));
+    assert_eq!(row.prompt_tokens, 1_234);
+    assert_eq!(row.completion_tokens, 5_678);
+    assert_eq!(row.total_tokens, 6_912);
+    assert_eq!(row.event_count, 1);
+}

--- a/crates/fp-domain/src/gateway/filters.rs
+++ b/crates/fp-domain/src/gateway/filters.rs
@@ -725,7 +725,8 @@ pub struct JwtAuthConfig {
     /// Named requirements, referenced by rules and per-route overrides.
     #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
     pub requirement_map: std::collections::BTreeMap<String, JwtRequirement>,
-    /// Path rules, first match wins. Empty → every path requires any provider (v1 rule).
+    /// Path rules, first match wins. Empty rules configure providers but synthesize no per-route JWT
+    /// requirement; enforcement requires explicit rules or a per-route `jwt_auth` requirement override.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub rules: Vec<JwtRule>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]

--- a/crates/fp-storage/src/repos/ai.rs
+++ b/crates/fp-storage/src/repos/ai.rs
@@ -49,6 +49,15 @@ pub struct AiUsageQuery {
     pub offset: i64,
 }
 
+/// PostgreSQL's current clock value for resolving usage-window boundaries against
+/// `ai_usage_events.created_at`, which PostgreSQL also stamps.
+pub async fn usage_clock_now(pool: &PgPool) -> DomainResult<chrono::DateTime<chrono::Utc>> {
+    sqlx::query_scalar("SELECT clock_timestamp()")
+        .fetch_one(pool)
+        .await
+        .map_err(|e| DomainError::internal(format!("read AI usage clock: {e}")))
+}
+
 fn provider_from_row(row: &PgRow) -> DomainResult<AiProvider> {
     Ok(AiProvider {
         id: AiProviderId::from(row.get::<Uuid, _>("id")),

--- a/crates/fp-xds/src/capture.rs
+++ b/crates/fp-xds/src/capture.rs
@@ -383,6 +383,20 @@ impl ExternalProcessor for LearningCaptureService {
     ) -> Result<Response<Self::ProcessStream>, Status> {
         if is_ai_processor(request.metadata()) {
             let context = ai_context(request.metadata())?;
+            let context = match context {
+                Some(mut ctx) => {
+                    let team_id = authenticated_team(
+                        &request,
+                        &self.resolver,
+                        ctx.team_id,
+                        "AI processor team_id does not match the client certificate",
+                    )
+                    .await?;
+                    ctx.team_id = team_id;
+                    Some(ctx)
+                }
+                None => None,
+            };
             return Ok(Response::new(ReceiverStream::new(ai_process_stream(
                 self.pool.clone(),
                 request.into_inner(),
@@ -609,12 +623,22 @@ fn parse_ai_failover_chain(
     Ok(providers.into_iter().zip(positions).collect())
 }
 
-async fn capture_context<T>(
+/// Resolve the peer's certificate-bound team identity and verify it matches a claimed team.
+///
+/// Extracts the verified peer SPIFFE URI from `Request::peer_certs()` (with the `PeerSpiffe`
+/// test-extension fallback), invokes `resolver.resolve("team=<claimed>", peer_spiffe)`, and
+/// rejects when the resolved team differs from the claimed team. Returns the resolver-derived
+/// team — the authoritative tenant identity for all downstream scoping.
+///
+/// The `mismatch_message` parameter lets each call site use a context-specific denial message
+/// that leaks no team identity (no oracle), matching `CertRegistryResolver`'s indistinct-failure
+/// discipline.
+async fn authenticated_team<T>(
     request: &Request<T>,
     resolver: &Arc<dyn TeamResolver>,
-) -> Result<CaptureContext, Status> {
-    let metadata = request.metadata();
-    let claimed_team_id = TeamId::from(metadata_uuid(metadata, "x-flowplane-team-id")?);
+    claimed_team_id: TeamId,
+    mismatch_message: &'static str,
+) -> Result<TeamId, Status> {
     let peer_spiffe = request
         .peer_certs()
         .and_then(|certs| {
@@ -632,14 +656,28 @@ async fn capture_context<T>(
         .resolve(&format!("team={claimed_team_id}"), peer_spiffe.as_deref())
         .await?;
     if identity.team_id != claimed_team_id {
-        return Err(Status::permission_denied(
-            "capture team_id does not match the client certificate",
-        ));
+        return Err(Status::permission_denied(mismatch_message));
     }
+    Ok(identity.team_id)
+}
+
+async fn capture_context<T>(
+    request: &Request<T>,
+    resolver: &Arc<dyn TeamResolver>,
+) -> Result<CaptureContext, Status> {
+    let metadata = request.metadata();
+    let claimed_team_id = TeamId::from(metadata_uuid(metadata, "x-flowplane-team-id")?);
+    let team_id = authenticated_team(
+        request,
+        resolver,
+        claimed_team_id,
+        "capture team_id does not match the client certificate",
+    )
+    .await?;
     if let Some(session_id) = optional_metadata_uuid(metadata, "x-flowplane-discovery-session-id")?
     {
         return Ok(CaptureContext::Discovery(DiscoveryCaptureContext {
-            team_id: identity.team_id,
+            team_id,
             session_id: DiscoverySessionId::from(session_id),
             listener_id: ListenerId::from(metadata_uuid(
                 metadata,
@@ -655,7 +693,7 @@ async fn capture_context<T>(
         }));
     }
     Ok(CaptureContext::Config(ConfigCaptureContext {
-        team_id: identity.team_id,
+        team_id,
         session_id: CaptureSessionId::from(metadata_uuid(
             metadata,
             "x-flowplane-capture-session-id",
@@ -2224,6 +2262,7 @@ mod tests {
     };
     use envoy_types::pb::google::protobuf::UInt32Value;
     use std::collections::HashMap;
+    use tonic::codec::Codec;
     use tonic::Code;
 
     /// Assert an ext_proc `ImmediateResponse` carries the AI JSON error envelope
@@ -2287,6 +2326,58 @@ mod tests {
         }
     }
 
+    /// Build an AI ExtProc upstream-context streaming request: `x-flowplane-ai-processor: true`
+    /// plus team/route-config/provider/backend-position metadata for `claimed_team_id`, over an
+    /// empty (no-message) request stream. `PeerSpiffe` in the request extensions represents the
+    /// certificate-bound identity the resolver sees.
+    fn ai_process_request(
+        claimed_team_id: TeamId,
+        bound_team_id: TeamId,
+    ) -> Request<Streaming<ProcessingRequest>> {
+        let mut request = Request::new(Streaming::new_request(
+            tonic_prost::ProstCodec::<ProcessingRequest, ProcessingRequest>::default().decoder(),
+            tonic::body::Body::empty(),
+            None,
+            None,
+        ));
+        let metadata = request.metadata_mut();
+        metadata.insert(
+            "x-flowplane-ai-processor",
+            "true".parse().expect("metadata value"),
+        );
+        metadata.insert(
+            "x-flowplane-team-id",
+            claimed_team_id.to_string().parse().expect("metadata value"),
+        );
+        metadata.insert(
+            "x-flowplane-route-config-id",
+            Uuid::now_v7().to_string().parse().expect("metadata value"),
+        );
+        metadata.insert(
+            "x-flowplane-ai-provider-id",
+            Uuid::now_v7().to_string().parse().expect("metadata value"),
+        );
+        metadata.insert(
+            "x-flowplane-ai-backend-position",
+            "0".parse().expect("metadata value"),
+        );
+        request
+            .extensions_mut()
+            .insert(crate::server::PeerSpiffe(format!(
+                "spiffe://flowplane.test/team/{bound_team_id}/proxy/dp-test"
+            )));
+        request
+    }
+
+    fn ai_capture_service(bound_team_id: TeamId) -> LearningCaptureService {
+        let pool =
+            sqlx::PgPool::connect_lazy("postgres://localhost/flowplane_test").expect("lazy pool");
+        let resolver = Arc::new(FixedTeamResolver {
+            team_id: bound_team_id,
+        }) as Arc<dyn TeamResolver>;
+        LearningCaptureService::new(pool, resolver)
+    }
+
     fn capture_request(team_id: TeamId) -> Request<()> {
         let mut request = Request::new(());
         let metadata = request.metadata_mut();
@@ -2337,6 +2428,33 @@ mod tests {
             err.message(),
             "capture team_id does not match the client certificate"
         );
+    }
+
+    #[tokio::test]
+    async fn ai_process_rejects_cert_bound_team_mismatch_before_stream() {
+        let claimed_team_id = TeamId::from(Uuid::now_v7());
+        let bound_team_id = TeamId::from(Uuid::now_v7());
+        let service = ai_capture_service(bound_team_id);
+        let request = ai_process_request(claimed_team_id, bound_team_id);
+
+        let err = ExternalProcessor::process(&service, request)
+            .await
+            .expect_err("mismatch should be rejected");
+
+        assert_eq!(err.code(), Code::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn ai_process_accepts_cert_bound_team_match() {
+        let team_id = TeamId::from(Uuid::now_v7());
+        let service = ai_capture_service(team_id);
+        let request = ai_process_request(team_id, team_id);
+
+        let response = ExternalProcessor::process(&service, request)
+            .await
+            .expect("match should be accepted");
+
+        drop(response);
     }
 
     #[test]

--- a/crates/fp-xds/src/translate.rs
+++ b/crates/fp-xds/src/translate.rs
@@ -1731,9 +1731,9 @@ fn global_rate_limit_to_proto(
     }
 }
 
-/// JwtAuthentication proto (spec/04 §4.1). One filter per chain (v2 invariant), so v1's
-/// provider-merge machinery is unnecessary. With no rules, every path requires any
-/// provider (v1 default rule).
+/// JwtAuthentication proto. One filter per chain, so provider-merge machinery is unnecessary.
+/// Empty rules configure providers but synthesize no per-route JWT requirement; enforcement
+/// requires explicit rules or a per-route `jwt_auth` requirement override.
 fn jwt_auth_to_proto(
     c: &fp_domain::gateway::filters::JwtAuthConfig,
 ) -> envoy_types::pb::envoy::extensions::filters::http::jwt_authn::v3::JwtAuthentication {

--- a/crates/fp-xds/tests/ads_mtls.rs
+++ b/crates/fp-xds/tests/ads_mtls.rs
@@ -7,6 +7,8 @@
 use envoy_types::pb::envoy::config::core::v3::Node;
 use envoy_types::pb::envoy::service::discovery::v3::aggregated_discovery_service_client::AggregatedDiscoveryServiceClient;
 use envoy_types::pb::envoy::service::discovery::v3::DiscoveryRequest;
+use envoy_types::pb::envoy::service::ext_proc::v3::external_processor_client::ExternalProcessorClient;
+use envoy_types::pb::envoy::service::ext_proc::v3::ProcessingRequest;
 use fp_core::{GrantSet, PrincipalCtx};
 use fp_domain::authz::TeamRef;
 use fp_domain::gateway::cluster::{ClusterSpec, Endpoint, LbPolicy};
@@ -324,6 +326,89 @@ fn cds_subscribe(node_id: &str) -> DiscoveryRequest {
         type_url: CLUSTER_TYPE_URL.to_string(),
         ..Default::default()
     }
+}
+
+fn ai_ext_proc_request(
+    claimed_team: impl std::fmt::Display,
+) -> (
+    tonic::Request<tokio_stream::wrappers::ReceiverStream<ProcessingRequest>>,
+    tokio::sync::mpsc::Sender<ProcessingRequest>,
+) {
+    let (request_tx, request_rx) = tokio::sync::mpsc::channel(1);
+    let mut request = tonic::Request::new(tokio_stream::wrappers::ReceiverStream::new(request_rx));
+    let metadata = request.metadata_mut();
+    metadata.insert("x-flowplane-ai-processor", "true".parse().unwrap());
+    metadata.insert(
+        "x-flowplane-team-id",
+        claimed_team.to_string().parse().unwrap(),
+    );
+    metadata.insert(
+        "x-flowplane-route-config-id",
+        uuid::Uuid::now_v7().to_string().parse().unwrap(),
+    );
+    metadata.insert(
+        "x-flowplane-ai-provider-id",
+        uuid::Uuid::now_v7().to_string().parse().unwrap(),
+    );
+    metadata.insert("x-flowplane-ai-backend-position", "0".parse().unwrap());
+    (request, request_tx)
+}
+
+#[tokio::test]
+async fn ai_ext_proc_mtls_binds_team_before_opening_stream() {
+    let Some(w) = world().await else { return };
+    let pki = TestPki::new();
+
+    let dataplane = unique("ai-dp");
+    fp_core::services::dataplanes::create_dataplane(
+        &w.pool,
+        &w.ctx,
+        w.team,
+        &dataplane,
+        "",
+        RequestId::generate(),
+    )
+    .await
+    .expect("dataplane");
+    let spiffe = format!("spiffe://flowplane.test/team/ai/proxy/{dataplane}");
+    fp_core::services::dataplanes::register_certificate(
+        &w.pool,
+        &w.ctx,
+        w.team,
+        fp_core::services::dataplanes::CertificateRegistration {
+            dataplane: &dataplane,
+            spiffe_uri: &spiffe,
+            serial_number: &unique("ai-serial"),
+            expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+        },
+        RequestId::generate(),
+    )
+    .await
+    .expect("register");
+
+    let cache = SnapshotCache::new();
+    let (addr, _revocations) = start_server(&pki, cache, w.pool.clone()).await;
+    let identity = pki.client_identity("ai-ext-proc", &spiffe);
+    let channel = tls_channel(&pki, addr, Some(identity))
+        .await
+        .expect("mTLS connect");
+
+    let mut client = ExternalProcessorClient::new(channel.clone());
+    let other_team = uuid::Uuid::now_v7();
+    assert_ne!(other_team.to_string(), w.team.id.to_string());
+    let (mismatched_request, _mismatched_request_tx) = ai_ext_proc_request(other_team);
+    let mismatch = tokio::time::timeout(Duration::from_secs(5), client.process(mismatched_request))
+        .await
+        .expect("mismatched team must be rejected before reading a request message")
+        .expect_err("mismatched team must not yield a response stream");
+    assert_eq!(mismatch.code(), tonic::Code::PermissionDenied);
+
+    let mut client = ExternalProcessorClient::new(channel);
+    let (matching_request, _matching_request_tx) = ai_ext_proc_request(w.team.id);
+    tokio::time::timeout(Duration::from_secs(5), client.process(matching_request))
+        .await
+        .expect("matching team must open a response stream before any request message is sent")
+        .expect("certificate-bound team claim must be accepted");
 }
 
 #[tokio::test]

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -16,7 +16,7 @@ The module intentionally does not manage Cloudflare DNS. Use the outputs to crea
 ## Prerequisites
 
 - OpenTofu.
-- AWS credentials for the target account.
+- AWS CLI credentials and a configured default region for the target account.
 - A Flowplane release image pushed to ECR in the selected region.
 - An ACM certificate for the API hostname.
 - Secrets Manager secrets containing:
@@ -28,6 +28,28 @@ The module intentionally does not manage Cloudflare DNS. Use the outputs to crea
   - dataplane client CA certificate PEM
   - dataplane certificate issuer CA certificate PEM
   - dataplane certificate issuer CA private key PEM
+  - xDS server-trust CA certificate PEM for the local workstation smoke test
+
+Create the workstation-only xDS server-trust CA secret once, or export the name/ARN of an existing
+secret with the same raw-PEM content:
+
+```bash
+export XDS_SERVER_CA_SECRET_ID="/flowplane/prod/xds-server-ca"
+(
+  set -eu
+  openssl x509 -noout -in path/to/xds-server-ca.crt
+  aws secretsmanager create-secret \
+    --name "$XDS_SERVER_CA_SECRET_ID" \
+    --secret-string file://path/to/xds-server-ca.crt
+)
+```
+
+`XDS_SERVER_CA_SECRET_ID` is a local-operator input, not an OpenTofu module variable or output. The
+module consumes the xDS leaf certificate through `xds_tls_cert_secret_arn`; it does not return that
+certificate's issuing CA to the workstation.
+
+If this workstation secret uses a customer-managed KMS key, the AWS CLI operator identity also
+needs `kms:Decrypt` for that key. This is separate from module-side `secret_kms_key_arns` access.
 
 The control-plane container receives PEM values as ECS secrets, writes them to `/tmp/flowplane/tls`,
 and starts `flowplane serve` with file-path environment variables.
@@ -130,6 +152,7 @@ flowplane auth login --device-code \
   --client-id "$FLOWPLANE_OIDC_CLIENT_ID" \
   --scope "openid email profile"
 
+install -d -m 0700 .local
 flowplane dataplane create edge-local --team <team>
 flowplane --out .local/aws-dp-cert.json dataplane cert issue edge-local --team <team>
 
@@ -138,9 +161,20 @@ jq -r '.data.private_key_pem' .local/aws-dp-cert.json > .local/aws-dp.key
 jq -r '.data.ca_certificate_pem' .local/aws-dp-cert.json > .local/aws-dp-client-chain-ca.crt
 chmod 600 .local/aws-dp.key
 
-# `data.ca_certificate_pem` is the dataplane client-chain CA. Use a separate xDS
-# server-trust CA bundle for `--ca-path`: the CA that validates xds.getflowplane.io.
-printf '%s' "$CP_XDS_SERVER_CA_PEM" > .local/aws-xds-server-ca.crt
+# XDS_SERVER_CA_SECRET_ID names a workstation-only xDS server-trust CA secret.
+# It is separate from data.ca_certificate_pem, the dataplane client-chain CA.
+(
+  set -eu
+  : "${XDS_SERVER_CA_SECRET_ID:?set this to the xDS server-trust CA secret name or ARN}"
+  install -m 0600 /dev/null .local/aws-xds-server-ca.crt
+  aws secretsmanager get-secret-value \
+    --secret-id "$XDS_SERVER_CA_SECRET_ID" \
+    --query SecretString \
+    --output text \
+    > .local/aws-xds-server-ca.crt
+  test -s .local/aws-xds-server-ca.crt
+  openssl x509 -noout -in .local/aws-xds-server-ca.crt
+)
 
 flowplane --out .local/aws-envoy.yaml dataplane bootstrap edge-local \
   --team <team> \

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,7 +49,9 @@ Every page starts with one metadata line:
 > Audience: operators · Status: stable
 ```
 
-Use `Audience:` (operators / platform-engineers / api-teams / newcomers) and `Status:` (stable / draft).
+`Audience` and `Status` values are open-ended conventions, not closed vocabularies. Common examples
+are `Audience: operators` / `platform-engineers` / `api-teams` / `newcomers` and
+`Status: stable` / `draft`; use other clear values when they describe the page better.
 
 ## Source-of-truth policy
 

--- a/docs/concepts/cli-contract.md
+++ b/docs/concepts/cli-contract.md
@@ -84,7 +84,7 @@ keeps two operators (or two agents) from clobbering each other.
 default — with no network call. This exists so agents do not have to scrape `--help` text. It is
 also the **derivation seam** between the human CLI and the agent/MCP layer: the machine-readable
 catalog is the single source the MCP tool definitions are derived from, so the two surfaces cannot
-drift apart. (See decision FP-DEC-0003.)
+drift apart.
 
 ## Safety is explicit, never a hang
 

--- a/docs/concepts/cli-contract.md
+++ b/docs/concepts/cli-contract.md
@@ -46,9 +46,19 @@ reads stdout therefore never confuses an error for a result. The error object is
 wrapped in the success envelope — it is a distinct shape with `code`, `message`, `retryable`, and
 (when present) `status`, `request_id`, and `hint`.
 
-`retryable` is the key affordance: it is `true` for transient failures (`429`, any `5xx`, transport
-and timeout errors) and `false` for terminal `4xx`. A client can implement backoff by reading one
-boolean instead of hard-coding a status list.
+`retryable` is the key CLI affordance. For a single-request failure, the CLI derives both its emitted
+`retryable` field and process exit class from the HTTP response status: `429`, any `5xx`, and
+transport or timeout failures are retryable; terminal `4xx` responses are not. Because both outputs
+are status-derived, the CLI exit class and its emitted `retryable` field agree, so a script can
+implement backoff by reading one boolean instead of hard-coding a status list. An aggregate `apply`
+failure is the conservative exception: it emits `retryable: false` because some resources may
+already have applied.
+
+The API error envelope has a distinct contract and does not carry a `retryable` field. Direct API
+clients derive retryability from its `ErrorCode` using the error-code table; only `rate_limited` and
+`unavailable` are retryable. Not every API `5xx` response is therefore retryable. Direct API clients
+must follow that code-derived classification, while CLI scripts must follow the CLI-emitted
+status-derived value. See [Error codes](../reference/errors.md#codes).
 
 ## Exit codes carry the failure class
 
@@ -56,8 +66,9 @@ The process exits `0` on success and a **specific code by failure class** otherw
 auth `3`, not-found/conflict `4`, validation `5`, rate-limited `6`, server/transport `7` — rather
 than a generic non-zero. Usage `2` covers invalid flags/arguments and local preflight usage checks.
 A script can branch on `$?` alone, before parsing any JSON, and a CI job can distinguish "your input
-was wrong" (`2`/`5`) from "the server is down" (`7`). The codes mirror the error classes, so the
-exit code and the `code`/`retryable` fields always agree.
+was wrong" (`2`/`5`) from "the server is down" (`7`). Within the CLI, the status-derived exit class
+and `retryable` field agree; direct API clients separately classify the server-supplied `code` as
+described above.
 
 ## Optimistic concurrency instead of last-write-wins
 

--- a/docs/concepts/global-rate-limiting.md
+++ b/docs/concepts/global-rate-limiting.md
@@ -100,7 +100,7 @@ is slow or unreachable, each filter's `failure_mode_deny` decides: `false` fails
 request proceeds), `true` fails **closed** (the request is rejected, default `500`). Pick per
 listener based on whether availability or the limit matters more for that traffic.
 
-## Deliberate limits (1.1.0 topology)
+## Deliberate limits (current topology)
 
 The counter store is in-memory fixed-window. That keeps the deployment dependency-free — **no Redis
 required** — but has stated semantics:
@@ -109,9 +109,9 @@ required** — but has stated semantics:
 - **Horizontal scaling over-admits.** Each RLS instance keeps its own counters, so N instances admit
   up to ~N× the limit.
 
-The committed 1.1.0 topology is therefore a **single** RLS instance per control plane. A
-Redis-backed counter store for multi-instance correctness and durable counters is a named follow-on,
-not part of 1.1.0. The algorithm is fixed-window (not sliding).
+The supported topology is therefore a **single** RLS instance per control plane. A Redis-backed
+counter store for multi-instance correctness and durable counters is a named follow-on, not part of
+the current implementation. The algorithm is fixed-window (not sliding).
 
 ## Further reading
 

--- a/docs/how-to/aws-secure-deployment.md
+++ b/docs/how-to/aws-secure-deployment.md
@@ -18,12 +18,15 @@ Use `deploy/aws/local.auto.tfvars` for local operator values. This file is ignor
 
 Required high-level values:
 
+- An AWS CLI authenticated to the target account and configured for the same region as `aws_region`.
 - `aws_region` and matching `availability_zones`.
 - `control_plane_image`: Flowplane release image in ECR.
 - `api_certificate_arn`: ACM certificate for the public API hostname.
 - `oidc_issuer` and `oidc_audience`.
 - `xds_ingress_cidrs`: your local dataplane/operator public IP CIDR, for example `["1.2.3.4/32"]`.
 - Secrets Manager ARNs for Flowplane KEK and PEM material.
+- `XDS_SERVER_CA_SECRET_ID`: the Secrets Manager name or ARN containing, as its raw
+  `SecretString`, the CA certificate that issued the xDS server certificate.
 
 Set the OIDC values from your identity provider:
 
@@ -48,6 +51,28 @@ Create Secrets Manager secrets for:
 - dataplane client CA certificate PEM
 - dataplane certificate issuer CA certificate PEM
 - dataplane certificate issuer CA private key PEM
+- xDS server-trust CA certificate PEM for the local workstation smoke test
+
+Create the workstation-only xDS server-trust CA secret once, or export the name/ARN of an existing
+secret with the same raw-PEM content:
+
+```bash
+export XDS_SERVER_CA_SECRET_ID="/flowplane/prod/xds-server-ca"
+(
+  set -eu
+  openssl x509 -noout -in path/to/xds-server-ca.crt
+  aws secretsmanager create-secret \
+    --name "$XDS_SERVER_CA_SECRET_ID" \
+    --secret-string file://path/to/xds-server-ca.crt
+)
+```
+
+`XDS_SERVER_CA_SECRET_ID` is a local-operator input, not an OpenTofu module variable or output. The
+module consumes the xDS leaf certificate through `xds_tls_cert_secret_arn`; it does not return that
+certificate's issuing CA to the workstation.
+
+If this workstation secret uses a customer-managed KMS key, the AWS CLI operator identity also
+needs `kms:Decrypt` for that key. This is separate from module-side `secret_kms_key_arns` access.
 
 The OpenTofu module passes secret ARNs into ECS. The container writes PEM values to files under `/tmp/flowplane/tls` before running `flowplane serve`.
 
@@ -131,6 +156,7 @@ org+team below.
 Create the dataplane and issue a one-time cert response:
 
 ```bash
+install -d -m 0700 .local
 flowplane dataplane create edge-local --team <team>
 flowplane --out .local/aws-dp-cert.json dataplane cert issue edge-local --team <team>
 ```
@@ -144,12 +170,23 @@ jq -r '.data.ca_certificate_pem' .local/aws-dp-cert.json > .local/aws-dp-client-
 chmod 600 .local/aws-dp.key
 ```
 
-`ca_certificate_pem` is the dataplane **client-chain CA** from the issue response. It is the CA the control plane trusts for the dataplane client certificate; it is not the CA Envoy uses to verify the control plane's xDS server certificate.
+`data.ca_certificate_pem` is the dataplane **client-chain CA** from the issue response. It is the CA the control plane trusts for the dataplane client certificate; it is not the CA Envoy uses to verify the control plane's xDS server certificate.
 
-Write the xDS **server-trust CA** to a separate file. This is the CA bundle that validates the certificate served by `xds.getflowplane.io`, from the same PKI material that produced your xDS server certificate secret:
+`XDS_SERVER_CA_SECRET_ID` names a workstation-only xDS **server-trust CA** secret that is separate from `data.ca_certificate_pem`; its `SecretString` contains the issuing CA that validates the certificate served by `xds.getflowplane.io`.
 
 ```bash
-printf '%s' "$CP_XDS_SERVER_CA_PEM" > .local/aws-xds-server-ca.crt
+(
+  set -eu
+  : "${XDS_SERVER_CA_SECRET_ID:?set this to the xDS server-trust CA secret name or ARN}"
+  install -m 0600 /dev/null .local/aws-xds-server-ca.crt
+  aws secretsmanager get-secret-value \
+    --secret-id "$XDS_SERVER_CA_SECRET_ID" \
+    --query SecretString \
+    --output text \
+    > .local/aws-xds-server-ca.crt
+  test -s .local/aws-xds-server-ca.crt
+  openssl x509 -noout -in .local/aws-xds-server-ca.crt
+)
 ```
 
 Generate the local Envoy bootstrap:

--- a/docs/how-to/bootstrap-platform.md
+++ b/docs/how-to/bootstrap-platform.md
@@ -22,8 +22,25 @@ Provide it by **either** of these, before `flowplane serve` starts. The control 
 
 - A file (preferred — safer than env, which is visible via process inspection):
 
+  On Linux, `/run` is normally volatile, but it is not necessarily mounted as `tmpfs`. Set
+  `FLOWPLANE_OS_USER` and `FLOWPLANE_OS_GROUP` for the configured control-plane service account
+  before running this block. Creating the directory and assigning its ownership normally requires
+  root; use `sudo` as shown, or have `systemd-tmpfiles` or equivalent deployment setup pre-create
+  the same paths with these owners and modes. The Flowplane service reads the token file as its
+  configured OS user.
+
   ```bash
-  printf '%s' "$BOOTSTRAP_TOKEN" > /run/flowplane/bootstrap-token   # tmpfs, mode 0600
+  (
+    set -eu
+    : "${FLOWPLANE_OS_USER:?set this to the service OS user}"
+    : "${FLOWPLANE_OS_GROUP:?set this to the service OS group}"
+    : "${BOOTSTRAP_TOKEN:?set this to the chosen bootstrap token}"
+    sudo install -d -m 0700 -o "$FLOWPLANE_OS_USER" -g "$FLOWPLANE_OS_GROUP" /run/flowplane
+    sudo install -m 0600 -o "$FLOWPLANE_OS_USER" -g "$FLOWPLANE_OS_GROUP" \
+      /dev/null /run/flowplane/bootstrap-token
+    printf '%s' "$BOOTSTRAP_TOKEN" \
+      | sudo -u "$FLOWPLANE_OS_USER" tee /run/flowplane/bootstrap-token >/dev/null
+  )
   export FLOWPLANE_BOOTSTRAP_TOKEN_FILE=/run/flowplane/bootstrap-token
   ```
 

--- a/docs/how-to/global-rate-limit.md
+++ b/docs/how-to/global-rate-limit.md
@@ -58,7 +58,7 @@ curl -fsS http://127.0.0.1:8081/healthz && echo OK
 ```
 
 The counter store is in-memory — no Redis, no database. (Counters reset on restart, and the
-committed 1.1.0 topology is a **single** RLS instance; see
+current topology uses a **single** RLS instance; see
 [Global rate limiting](../concepts/global-rate-limiting.md) for why.)
 
 ## 2. Point the control plane at it

--- a/docs/how-to/script-the-cli.md
+++ b/docs/how-to/script-the-cli.md
@@ -93,8 +93,10 @@ The full map (see [`../reference/cli.md#exit-codes`](../reference/cli.md#exit-co
 | `6` | Rate limited | HTTP `429` |
 | `7` | Server / transport | HTTP `5xx`, connection refused, timeout |
 
-The error envelope carries a `retryable` boolean — `true` for `429`/`5xx`/transport, `false` for
-terminal `4xx`. A retry loop can key off it:
+For a single-request command, the CLI error envelope carries a `retryable` boolean derived from the
+HTTP response status: `true` for `429`, any `5xx`, and transport or timeout failures; `false` for
+terminal `4xx`. The CLI process exit class is also status-derived, so its exit class and emitted
+`retryable` field agree. A retry loop can key off that field:
 
 ```bash
 for attempt in 1 2 3; do
@@ -105,6 +107,15 @@ for attempt in 1 2 3; do
   sleep $((attempt * 2))
 done
 ```
+
+An aggregate `flowplane apply` failure is the conservative exception: it emits `retryable: false`
+because some resources may already have applied.
+
+This is a CLI transport contract, not the API error-envelope contract. The API envelope does not
+carry a `retryable` field; direct API clients derive retryability from `ErrorCode` using the
+[error-code table](../reference/errors.md#codes), where only `rate_limited` and `unavailable` are
+retryable. Not every API `5xx` is retryable. CLI scripts should use the CLI-emitted field above;
+direct API clients should use the code-derived table.
 
 ## 3. Project only the fields you need
 

--- a/docs/how-to/script-the-cli.md
+++ b/docs/how-to/script-the-cli.md
@@ -152,6 +152,7 @@ and default. `schema` makes **no network call**, so an agent can introspect offl
 flowplane schema -o json | jq -r '.data.command.subcommands[].name'
 # serve
 # db
+# openapi
 # auth
 # ...
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -114,13 +114,22 @@ separate from the success envelope above (it is **not** wrapped in `{schemaVersi
 }
 ```
 
-- `retryable` — `true` for transient failures (HTTP `429`, any `5xx`, and transport/timeout
-  failures), `false` for terminal `4xx`.
+- `retryable` — the CLI's status-derived classification: `true` for HTTP `429`, any `5xx`, and
+  transport/timeout failures; `false` for terminal `4xx`.
 - `hint` — on a `401` with no server-supplied hint the client synthesizes
   `run \`flowplane auth login\` to authenticate`; a `403` carries the server's hint naming
   the `(resource, action)`.
 - `status` — the HTTP status (absent for transport failures, whose `code` is
   `connection_failed`/`timeout`/`transport_error`).
+
+For a single-request failure, the CLI derives both the process exit class and its emitted
+`retryable` field from HTTP status, so those two CLI outputs agree. Aggregate `apply` failures are the
+conservative exception: they emit `retryable: false` because some resources may already have
+applied. The API error envelope uses a separate contract and does not carry a `retryable` field:
+direct API clients derive retryability from `ErrorCode` using the
+[error-code table](./errors.md#codes), where only `rate_limited` and `unavailable` are retryable. Not
+every API `5xx` is therefore retryable. CLI scripts must follow the CLI-emitted field; direct API
+clients must follow the code-derived table.
 
 ### Exit codes
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -458,7 +458,7 @@ Print the binary version (from `CARGO_PKG_VERSION`). No subcommands or args.
 ### `schema`
 Print the machine-readable CLI catalog — the whole command tree (commands, subcommands,
 flags, types, enums, required/defaults, help) as JSON. Makes no network call. This is the
-**canonical CLI contract source and the MCP-derivation seam** (ADR FP-DEC-0003): generated
+**canonical CLI contract source and the MCP-derivation seam**: generated
 consumers (shell completion, the future MCP tool catalog, docs) derive from `flowplane schema`
 rather than scraping `--help`. Under `-o json` the payload is the standard envelope with
 `kind: "cliSchema"`; `data` carries its own integer `catalogVersion` (distinct from the

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -48,6 +48,15 @@ One row per code. **Retryable** = the identical request may succeed if retried w
 | `unavailable` | 503 Service Unavailable | **yes** | A dependency (database, IdP, provider) is unavailable. |
 | `internal` | 500 Internal Server Error | no | Unexpected internal failure. Message and details are redacted (see below). |
 
+Retryability is surface-specific. The API error envelope does not carry a `retryable` field; direct
+API clients derive retryability from its `ErrorCode` using this table. Only `rate_limited` and
+`unavailable` are retryable, so not every API `5xx` response is retryable. For a single-request
+failure, the CLI instead derives its emitted `retryable` field and process exit class from the HTTP
+status: `429`, any `5xx`, and transport or timeout failures are retryable. Because both CLI outputs
+are status-derived, the CLI exit class and emitted `retryable` field agree. Aggregate `apply` failures
+conservatively emit `retryable: false` because some resources may already have applied. CLI scripts
+should follow the CLI-emitted value.
+
 ## Redaction of internal errors
 
 For `internal` and `invalid_config`, the server does **not** return the underlying message or `details`. The response body is:

--- a/docs/reference/filters.md
+++ b/docs/reference/filters.md
@@ -120,7 +120,7 @@ Validation:
 |---|---|---|---|
 | `providers` | `BTreeMap<String, JwtProvider>` | required | Provider name → provider (deterministic encoding). |
 | `requirement_map` | `BTreeMap<String, JwtRequirement>` | optional (default empty) | Named requirements referenced by rules and per-route overrides. |
-| `rules` | `Vec<JwtRule>` | optional (default empty) | Path rules, first match wins. Empty → every path requires any provider. |
+| `rules` | `Vec<JwtRule>` | optional (default empty) | Path rules, first match wins. Empty rules configure providers but synthesize no per-route JWT requirement; enforcement requires explicit rules or a per-route `jwt_auth` requirement override. |
 | `bypass_cors_preflight` | `bool` | optional (default `false`) | Bypass JWT for CORS preflight requests. |
 
 `JwtProvider`:

--- a/docs/reference/observability-alerts.md
+++ b/docs/reference/observability-alerts.md
@@ -4,7 +4,7 @@
 
 This reference is the operator baseline for production alerting. It uses the metrics that exist in the current control-plane and data-plane-adjacent services. Dashboards and alerts should keep labels bounded: do not add team, org, dataplane, route, budget, tool, or agent labels unless a later issue explicitly accepts the cardinality cost.
 
-Native OpenTelemetry `gen_ai.*` semantic-convention meters are deferred for v1.0. Flowplane emits pragmatic counters for shipped AI budget behavior instead.
+Flowplane currently emits pragmatic counters for shipped AI budget behavior rather than native OpenTelemetry `gen_ai.*` semantic-convention meters.
 
 ## Metric Inventory
 

--- a/docs/reference/rest-api.md
+++ b/docs/reference/rest-api.md
@@ -400,8 +400,6 @@ The spec-content endpoint supports conditional reads: it returns `ETag`, accepts
 | PATCH | `/api/v1/teams/{team}/mcp/tools/{name}` |
 | POST  | `/api/v1/mcp` |
 
-> `POST /api/v1/mcp` is the MCP JSON-RPC endpoint. It is mounted on the secured router but registered outside the `routes!` set, so it does not appear in the generated OpenAPI document.
-
 ### Learning sessions
 
 | Method | Path |
@@ -515,9 +513,7 @@ The spec-content endpoint supports conditional reads: it returns `ETag`, accepts
 
 The **generated OpenAPI document is the source of truth** for per-field request and response schemas. Registered OpenAPI routes and their schemas are built from the same `routes!` declarations; the prose endpoint catalogue above is maintained separately and must be updated when routes are added. Per-field detail is intentionally **not** hand-copied into this reference (it would drift).
 
-Known exception: the public bootstrap endpoints are documented in the endpoint catalogue above and
-in [Bootstrap the first platform admin](../how-to/bootstrap-platform.md), but they are not included
-in the generated OpenAPI document.
+Three intentional live-route exceptions are absent from the generated OpenAPI document because all three are outside the `secured_api()` route registrations: `GET /api/v1/bootstrap/status`, `POST /api/v1/bootstrap/initialize`, and `POST /api/v1/mcp`. The two bootstrap routes are public, outer-router, pre-auth routes (although initialize validates the one-shot bootstrap token); `POST /api/v1/mcp` is mounted directly on the secured router, where normal authentication and write throttling apply.
 
 Obtain the document:
 

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -190,7 +190,7 @@ Envoy connects to the control plane as a registered dataplane. The bootstrap gen
 
 ## 6. Generate the Envoy bootstrap and start Envoy
 
-Generate the dev (plaintext) Envoy bootstrap config. Note that `--out` is a **global** flag and must come *before* the `dataplane bootstrap` subcommand:
+Generate the dev (plaintext) Envoy bootstrap config. `--out` is a **global** flag and is accepted anywhere in the command:
 
 ```bash
 ./target/debug/flowplane --out /tmp/flowplane-envoy.yaml \


### PR DESCRIPTION
## Summary

Prepare Flowplane 3.1.2 as a patch release containing:

- certificate-bound tenant identity for AI traffic capture and credential selection;
- PostgreSQL-authoritative AI usage windows when `until` is omitted;
- `flowplane-rls` help, version, and strict argument parsing;
- corrected REST, retryability, JWT, bootstrap-token, AWS deployment, CLI, and operator documentation;
- workspace version and lockfile updates for 3.1.2.

## Compatibility

Manual comparison against `v3.1.1` found no incompatible REST, MCP, configuration, storage-schema, or deprecation change.

- OpenAPI shape is unchanged except `info.version` and the corrected JWT-rules description.
- Main CLI schema is unchanged.
- `flowplane-rls` now rejects unknown arguments that were previously ignored; this is an intentional bug fix.

## Verification

- Default nextest: 1328/1328 passed, 0 skipped
- CI-profile nextest: 1328/1328 passed, 0 skipped
- Formatting, all-target/all-feature Clippy, no-default-feature Clippy, doctests, and `cargo deny`: passed
- Documentation contracts, issue acceptance verifiers, OpenTofu format/validate, and diff checks: passed
- Fresh PostgreSQL plaintext and X.509 v3 TLS boot smokes: passed
- Exact candidate tree: `7c40808329d3f75450a0bd88aeba0e43a156d098`
- Independent exact-artifact release review: APPROVE, zero blockers

## Release boundary

This PR stages the reviewed source on `main`. Merging, creating `v3.1.2`, validating immutable release candidates, approving publication, and publishing GitHub/GHCR artifacts remain separate gates. This PR does not authorize tagging or publication.

Closes #243
Closes #244
Closes #245
Closes #246
Closes #247
Closes #248
Closes #249
